### PR TITLE
fix(mcu): correct mismatched extern declarations

### DIFF
--- a/Mcu/a153/Src/DMA.c
+++ b/Mcu/a153/Src/DMA.c
@@ -12,8 +12,7 @@ extern uint16_t ADCDataDMA[];
 extern uint8_t buffersize;
 extern uint32_t dma_buffer[64];
 
-//extern int8_t aTxBuffer[10];
-extern int8_t aTxBuffer[18];
+extern uint8_t aTxBuffer[49];
 extern uint8_t nbDataToTransmit;
 
 /*

--- a/Mcu/g431/Src/stm32g4xx_it.c
+++ b/Mcu/g431/Src/stm32g4xx_it.c
@@ -19,7 +19,7 @@ extern volatile char dshot_telemetry;
 extern volatile char armed;
 extern volatile char out_put;
 extern volatile uint8_t compute_dshot_flag;
-extern volatile uint16_t commutation_interval;
+extern volatile uint32_t commutation_interval;
 
 int interrupt = 0;
 

--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -48,7 +48,6 @@ char EDT_ARM_ENABLE = 0;
 char EDT_ARMED = 0;
 int shift_amount = 0;
 volatile uint32_t gcrnumber;
-extern int zero_crosses;
 extern volatile char send_telemetry;
 extern uint8_t max_duty_cycle_change;
 int dshot_full_number;


### PR DESCRIPTION
## Summary
Correct three `extern` declarations that disagreed with their definitions. Surfaced while preparing the later LTO work (LTO merges types across translation units and flags the mismatches), but these are standing bugs with or without LTO.

## Problem
- **g431 (real bug):** `commutation_interval` is a `volatile uint32_t`, but `stm32g4xx_it.c` declared it `extern volatile uint16_t`. The early-zero-cross guard in the interrupt therefore read only the low 16 bits of the variable.
- **a153:** `aTxBuffer` was declared `extern int8_t[18]` while the definition is `uint8_t[49]`. Harmless today (only the address is taken for the telemetry DMA) but incorrect in sign and size.
- **dshot.c:** an unused `extern int zero_crosses;` whose type also disagreed with the definition (`volatile uint32_t`).

## Solution
Make each extern match its definition and drop the unused one. The only runtime change is on G431, where the interrupt now reads the full 32-bit `commutation_interval`.
