### PR TITLE
perf(main): replace 20khz duty cycle divisions with Q16 multiplies

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -420,6 +420,9 @@ char desync_check = 0;
 char low_kv_filter_level = 20;
 
 volatile uint16_t tim1_arr = TIM1_AUTORELOAD; // current auto reset value
+// Q16 fixed point scale factor equal to tim1_arr / 2000, recomputed in the main
+// loop when tim1_arr changes so the 20khz routine multiplies instead of divides
+volatile uint32_t pwm_to_arr_scale_q16 = ((uint32_t)TIM1_AUTORELOAD << 16) / 2000;
 uint16_t TIMER1_MAX_ARR = TIM1_AUTORELOAD; // maximum auto reset register value
 volatile uint16_t duty_cycle_maximum = 2000; // restricted by temperature or low rpm throttle protect
 uint16_t low_rpm_level = 20; // thousand erpm used to set range for throttle resrictions
@@ -1497,18 +1500,18 @@ RAM_FUNC void tenKhzRoutine()
         if ((armed && running) && input > 47) {
             if (eepromBuffer.variable_pwm) {
             }
-            adjusted_duty_cycle = ((duty_cycle * tim1_arr) / 2000) + 1;
+            adjusted_duty_cycle = (((uint32_t)duty_cycle * pwm_to_arr_scale_q16) >> 16) + 1;
 
         } else {
 
             if (prop_brake_active) {
-              adjusted_duty_cycle =  tim1_arr - ((prop_brake_duty_cycle * tim1_arr) / 2000);
+              adjusted_duty_cycle =  tim1_arr - (((uint32_t)prop_brake_duty_cycle * pwm_to_arr_scale_q16) >> 16);
             } else {
               if((eepromBuffer.brake_on_stop == 2) && armed){  // require arming for active brake
                 comStep(2);
-                adjusted_duty_cycle = DEAD_TIME + ((eepromBuffer.active_brake_power * tim1_arr) / 2000)* 10;
+                adjusted_duty_cycle = DEAD_TIME + (((uint32_t)eepromBuffer.active_brake_power * pwm_to_arr_scale_q16) >> 16)* 10;
             }else{
-                adjusted_duty_cycle = ((duty_cycle * tim1_arr) / 2000);
+                adjusted_duty_cycle = (((uint32_t)duty_cycle * pwm_to_arr_scale_q16) >> 16);
             }
             }
         }
@@ -1896,6 +1899,8 @@ int main(void)
   startup_max_duty_cycle = startup_max_duty_cycle + 400;
 #endif
 
+    uint16_t last_tim1_arr = 0; // force scale factor computation on first pass
+
     while (1) {
         HWCI_PERF_MAIN_LOOP();
 e_com_time = ((commutation_intervals[0] + commutation_intervals[1] + commutation_intervals[2] + commutation_intervals[3] + commutation_intervals[4] + commutation_intervals[5]) + 4) >> 1; // COMMUTATION INTERVAL IS 0.5US INCREMENTS 
@@ -1932,20 +1937,32 @@ if(zero_crosses < 5){
 
        RELOAD_WATCHDOG_COUNTER();
 
+        uint16_t next_tim1_arr = tim1_arr; // unchanged unless variable_pwm recomputes it below
         if (eepromBuffer.variable_pwm == 1) {      // uses range defined by pwm frequency setting
-            tim1_arr = map(commutation_interval, 96, 200, TIMER1_MAX_ARR / 2,
+            next_tim1_arr = map(commutation_interval, 96, 200, TIMER1_MAX_ARR / 2,
                 TIMER1_MAX_ARR);
         }
-        if (eepromBuffer.variable_pwm == 2) {      // uses automatic range   
+        if (eepromBuffer.variable_pwm == 2) {      // uses automatic range
           if(average_interval < 250 && average_interval > 100){
-            tim1_arr = average_interval * (CPU_FREQUENCY_MHZ/9);
+            next_tim1_arr = average_interval * (CPU_FREQUENCY_MHZ/9);
           }
           if(average_interval < 100 && average_interval > 0){
-            tim1_arr = 100 * (CPU_FREQUENCY_MHZ/9);
+            next_tim1_arr = 100 * (CPU_FREQUENCY_MHZ/9);
          }
           if((average_interval >= 250) || (average_interval == 0)){
-              tim1_arr = 250 * (CPU_FREQUENCY_MHZ/9);
-          } 
+              next_tim1_arr = 250 * (CPU_FREQUENCY_MHZ/9);
+          }
+        }
+        if (next_tim1_arr != last_tim1_arr) {
+            last_tim1_arr = next_tim1_arr;
+            // recompute the scale at idle priority, outside the mask so no interrupt is
+            // held off across the divide; then publish tim1_arr and the scale together so
+            // the 20khz routine never pairs a new arr with a stale scale
+            const uint32_t next_scale = ((uint32_t)next_tim1_arr << 16) / 2000;
+            __disable_irq();
+            tim1_arr = next_tim1_arr;
+            pwm_to_arr_scale_q16 = next_scale;
+            __enable_irq();
         }
         if (signaltimeout > (LOOP_FREQUENCY_HZ >> 1)) { // half second timeout when armed;
             if (armed) {


### PR DESCRIPTION
## Summary
Replace the per-cycle `(duty_cycle * tim1_arr) / 2000` integer divisions in the 20 kHz PWM routine with a Q16 fixed-point multiply, recomputing the scale factor in the main loop only when `tim1_arr` changes.

## Problem
The 20 kHz routine ran several 32-bit integer divisions per cycle to turn the duty cycle into a timer compare value. The Cortex-M0 has no hardware divide, so these are expensive in the hottest periodic routine on the firmware.

## Solution
Precompute `pwm_to_arr_scale_q16 = (tim1_arr << 16) / 2000` in the main loop whenever `tim1_arr` changes; the 20 kHz routine then does a multiply + shift. Result is equivalent within Q16 rounding (≤ 1 timer count, verified exhaustively host-side up to the max ARR).

`tim1_arr` and the scale factor have to stay consistent — the routine derives the compare from the scale but programs the auto-reload from `tim1_arr`, so a mismatched pair could briefly produce a compare above the reload. They are published together under a short interrupt mask: the new ARR is computed into a local, the divide runs at idle priority outside the mask (no interrupt is held off across it), and only the two stores are masked. So the 20 kHz routine always reads a consistent `(arr, scale)` pair, and behavior is otherwise identical to before this PR.
