### PR TITLE
perf(current-filter): make the averaging window a compile-time constant

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -388,7 +388,6 @@ char brushed_direction_set = 0;
 
 uint16_t tenkhzcounter = 0;
 int32_t consumed_current = 0;
-int32_t smoothed_raw_current = 0;
 int16_t actual_current = 0;
 
 char lowkv = 0;
@@ -458,11 +457,10 @@ uint16_t adjusted_input = 0;
 #define TEMP30_CAL_VALUE ((uint16_t*)((uint32_t)0x1FFFF7B8))
 #define TEMP110_CAL_VALUE ((uint16_t*)((uint32_t)0x1FFFF7C2))
 
-uint16_t smoothedcurrent = 0;
-const uint8_t numReadings = 50; // the readings from the analog input
-uint8_t readIndex = 0; // the index of the current reading
-uint32_t total = 0;
-uint16_t readings[50];
+#define NUM_CURRENT_READINGS 50 // compile time constant so the divide becomes a multiply
+uint8_t current_read_index = 0;
+uint32_t current_total = 0;
+uint16_t current_readings[NUM_CURRENT_READINGS];
 
 uint8_t bemf_timeout_happened = 0;
 uint8_t changeover_step = 5;
@@ -801,15 +799,16 @@ void saveEEpromSettings()
 
 uint16_t getSmoothedCurrent()
 {
-    total = total - readings[readIndex];
-    readings[readIndex] = ADC_raw_current;
-    total = total + readings[readIndex];
-    readIndex = readIndex + 1;
-    if (readIndex >= numReadings) {
-        readIndex = 0;
+    current_total -= current_readings[current_read_index];
+    current_readings[current_read_index] = ADC_raw_current;
+    current_total += ADC_raw_current;
+
+    current_read_index++;
+    if (current_read_index >= NUM_CURRENT_READINGS) {
+        current_read_index = 0;
     }
-    smoothedcurrent = total / numReadings;
-    return smoothedcurrent;
+
+    return current_total / NUM_CURRENT_READINGS;
 }
 
 void getBemfState()
@@ -2113,15 +2112,14 @@ if(zero_crosses < 5){
             converted_degrees = getConvertedDegrees(ADC_raw_temp);
 #endif
             degrees_celsius = converted_degrees;
+            int32_t smoothed_raw_current = getSmoothedCurrent();
 #ifdef NXP
             //MCXA has 16-bit ADC data
             battery_voltage = ((7 * battery_voltage) + ((ADC_raw_volts * 3300 / 65535 * VOLTAGE_DIVIDER) / 100)) / 8;
-            smoothed_raw_current = getSmoothedCurrent();
             //Actual current is in 10mA, so 1 = 10mA
             actual_current = (((smoothed_raw_current * 3300 / 65535) - CURRENT_OFFSET) * 100) / (MILLIVOLT_PER_AMP);
 #else
             battery_voltage = ((7 * battery_voltage) + ((ADC_raw_volts * 3300 / 4095 * VOLTAGE_DIVIDER) / 100)) >> 3;
-            smoothed_raw_current = getSmoothedCurrent();
             actual_current = ((smoothed_raw_current * 3300 / 41) - (CURRENT_OFFSET * 100)) / (MILLIVOLT_PER_AMP);
 #endif
             if (actual_current < 0) {


### PR DESCRIPTION
## Summary
Make the current-smoothing window a compile-time constant, and tidy up the moving-average state it touches.

## Problem
The current smoothing averaged over `const uint8_t numReadings = 50;`. A `const`-qualified variable is not a constant expression, so `total / numReadings` in `getSmoothedCurrent()` divided by a value loaded from memory on every 1 kHz sample — a `__aeabi_uidiv` soft-division call on Cortex-M0 (F051 et al.), a hardware `udiv` on M3/M4+. The surrounding state was also a handful of bare, generically-named globals (`total`, `readIndex`, `readings`, `smoothedcurrent`), and `smoothed_raw_current` was a file-scope global used only as a throwaway intermediate at its single call site.

## Solution
Define `NUM_CURRENT_READINGS 50` and use it for both the array size and the divisor. With a compile-time divisor the compiler specializes the divide: on M3/M4+ it folds to a multiply/shift, and on M0 — which lacks the `umull` needed for the reciprocal multiply — it still calls `__aeabi_uidiv` but drops the runtime divisor load (verified with the bundled GCC 10.3.1 at `-O3`). The remaining changes are cleanup: namespace the moving-average state as `current_total` / `current_read_index` / `current_readings`, and drop `smoothedcurrent` (returned directly) and `smoothed_raw_current` (now a local, with its single `getSmoothedCurrent()` call hoisted out of the `#ifdef NXP` branches). Window size and behavior are unchanged; builds clean under `-Werror` on F051 (M0) and G431 (M4).

Possible follow-ups, out of scope here — happy to discuss in review:
- A power-of-two window (e.g. 32 or 64) would let the divide become a single shift on M0 as well, at the cost of changing the averaging window length (it feeds the current-limit PID and telemetry).
- Replacing the 50-tap boxcar with an EMA (as `battery_voltage` already does) would eliminate the 100-byte `current_readings[]` buffer and all the circular-buffer bookkeeping — a larger, behavior-changing simplification.
