### PR TITLE
perf(main): write dshot NVIC priorities only on actual change

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -2038,8 +2038,13 @@ if(zero_crosses < 5){
         }
 
 #if !defined(MCU_G031) && !defined(NEED_INPUT_READY)
+        // only touch the NVIC when the priority scheme actually changes
+        static uint8_t input_priority_is_high = 0xFF; // unknown at boot, first pass sets it
+        uint8_t want_input_priority = dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD);
+        if (want_input_priority != input_priority_is_high) {
+            input_priority_is_high = want_input_priority;
 #ifdef NXP
-	if (dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD)) {
+	if (want_input_priority) {
 		NVIC_SetPriority(IC_DMA_IRQ_NAME, 0);
 		NVIC_SetPriority(COM_TIMER_IRQ, 1);
 		NVIC_SetPriority(COMP0_IRQ, 1);
@@ -2051,7 +2056,7 @@ if(zero_crosses < 5){
 		NVIC_SetPriority(COMP1_IRQ, 0);
 	}
 #else
-        if (dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD)) {
+        if (want_input_priority) {
              NVIC_SetPriority(IC_DMA_IRQ_NAME, 0);
              NVIC_SetPriority(COM_TIMER_IRQ, 1);
              NVIC_SetPriority(COMPARATOR_IRQ, 1);
@@ -2061,6 +2066,7 @@ if(zero_crosses < 5){
              NVIC_SetPriority(COMPARATOR_IRQ, 0);
          }
 #endif
+        }
 #endif
         if (send_telemetry) {
 #ifdef USE_SERIAL_TELEMETRY


### PR DESCRIPTION
## Summary
Write the DShot input / commutation NVIC priorities only when the desired priority scheme actually changes, instead of re-applying it on every main-loop pass.

## Problem
Every main-loop iteration unconditionally called `NVIC_SetPriority()` for several interrupts based on `dshot_telemetry && commutation_interval > threshold`. That condition rarely changes, so the loop kept rewriting the same priority values.

## Solution
Track the current scheme in `input_priority_is_high` (initialised to 0xFF so the first pass always applies it) and call `NVIC_SetPriority()` only on a transition. Identical resulting priorities, fewer register writes per loop. The flag is a `static` local scoped to the priority block rather than a file-scope global, so it also drops off the `MCU_G031` / `NEED_INPUT_READY` targets that compile the block out.
