### PR TITLE
build(lto): enable link time optimization for F051

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ FIRMWARE_VERSION := $(VERSION_MAJOR).$(VERSION_MINOR)
 CFLAGS_BASE := -fsingle-precision-constant -fomit-frame-pointer -ffast-math
 CFLAGS_BASE += -I$(MAIN_INC_DIR) -g3 -O3 -ffunction-sections --specs=nosys.specs
 CFLAGS_BASE += -Wall -Wundef -Wextra -Werror -Wno-unused-parameter -Wno-stringop-truncation
+# link time optimization, inlines across translation units which matters a lot
+# on cortex-m0 where call overhead is high. Enabled for F051 only for now: it is
+# the flash-tight, CPU-bound target that benefits most, and keeping it off the
+# other MCUs avoids widening the test surface while this is evaluated. The whole
+# firmware is compiled and linked in one compiler invocation so this needs no
+# other build changes. Opt another target in with LTO_FLAGS_<MCU> := -flto in
+# its mcu makefile.
+LTO_FLAGS_F051 ?= -flto
 
 CFLAGS_COMMON := $(CFLAGS_BASE)
 
@@ -105,8 +113,11 @@ $$($(2)_BASENAME).bin: $$($(2)_BASENAME).elf
 $(eval xLDSCRIPT := $$(if $$(call has_can_suffix,$$(2)),$(LDSCRIPT_CAN_$(1)),$(LDSCRIPT_$(1))))
 $(eval xCFLAGS := $$(if $$(call has_can_suffix,$$(2)),$(CFLAGS_CAN_$(1))))
 $(eval xSRC := $$(if $$(call has_can_suffix,$$(2)),$(SRC_CAN_$(1))))
+# no LTO for DroneCAN builds, gcc 10 LTO trips -Werror=maybe-uninitialized
+# false positives in the canard/dsdl code (defensive: no F051 CAN target today)
+$(eval xLTO := $$(if $$(call has_can_suffix,$$(2)),,$(LTO_FLAGS_$(1))))
 
-CFLAGS_$(2) = -DAM32_MCU=\"$(MCU)\" $(MCU_$(1)) -D$(2) $(CFLAGS_$(1)) $(CFLAGS_COMMON) $(xCFLAGS)
+CFLAGS_$(2) = -DAM32_MCU=\"$(MCU)\" $(MCU_$(1)) -D$(2) $(CFLAGS_$(1)) $(CFLAGS_COMMON) $(xLTO) $(xCFLAGS)
 LDFLAGS_$(2) = $(LDFLAGS_COMMON) $(LDFLAGS_$(1)) -T$(xLDSCRIPT)
 
 -include $$($(2)_BASENAME).d

--- a/Src/main.c
+++ b/Src/main.c
@@ -344,7 +344,7 @@ uint16_t low_cell_volt_cutoff = 330; // 3.3volts per cell
 
 //=========================== END EEPROM Defaults ===========================
 
-const char filename[30] __attribute__((section(".file_name"))) = FILE_NAME;
+const char filename[30] __attribute__((used, section(".file_name"))) = FILE_NAME; // used: keep under LTO
 _Static_assert(sizeof(FIRMWARE_NAME) <=13,"Firmware name too long");   // max 12 character firmware name plus NULL 
 
 // move these to targets folder or peripherals for each mcu


### PR DESCRIPTION
## Summary
Compile and link the **F051** firmware with `-flto`. Scoped to F051 only via `LTO_FLAGS_F051`; all other MCUs are unchanged (verified: G431 flash is unaffected apart from +4 B for the `used` attribute below). Should merge after the `volatile` PR so cross-TU inlining is safe.

## Problem
F051 is the most CPU-constrained target. Without LTO the compiler cannot inline across translation units, leaving call overhead in the hot commutation and PWM paths on the Cortex-M0.

## Solution
Enable `-flto` for F051 only — the whole firmware is built in a single compiler invocation, so this needs no other build changes. The `filename` string gets `__attribute__((used))` so LTO does not drop it from its section. A defensive CAN guard keeps LTO off any future DroneCAN F051 build (none exists today).

⚠️ **Flash impact — read before merging.** At `-O3`, LTO inlining grows F051 flash from 22200 B (81%) to **26680 B (97.3%, 744 B free)** on its own, while cutting RAM (3688 → 2824 B via dead-code elimination). It fits, but standalone headroom is thin. It does not overflow when combined with the other F051 PRs — measured: LTO + the RAM-functions PR is 26024 B (94.9%), and the full F051 stack including the flash-reclaim PRs (gate custom tune, drop the SysTick handler) lands at 24980 B (91%). The thin standalone margin is the thing to watch; keep the reclaim PRs in the stack. Given 97.3% on its own, consider treating this as risk:4.
