### PR TITLE
perf(f051): keep SysTick counting but drop its empty interrupt

### DIFF
--- a/Mcu/f051/Src/peripherals.c
+++ b/Mcu/f051/Src/peripherals.c
@@ -62,11 +62,11 @@ void initAfterJump(void)
         ((SYSCFG_TypeDef*)(((uint32_t)0x40000000U) + 0x00010000))->CFGR1 |= ((0x1U << (0U)) | (0x2U << (0U)));
     } while (0);
 
-    if (SysTick_Config(SystemCoreClock / 1000)) {
-        /* Capture error */
-        while (1) {
-        }
-    }
+    // keep the SysTick counter running for anything that polls it but do not
+    // enable its interrupt, the handler is empty and just burns cycles at 1khz
+    SysTick->LOAD = (SystemCoreClock / 1000) - 1;
+    SysTick->VAL = 0;
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_ENABLE_Msk;
     __enable_irq();
 }
 


### PR DESCRIPTION
## Summary
Keep the F051 SysTick counter running but disable its interrupt, since the SysTick handler is empty.

## Problem
`initAfterJump()` configured SysTick with `SysTick_Config()`, which enables the SysTick interrupt. `SysTick_Handler` is empty, so the firmware took a 1 kHz interrupt that did nothing but burn entry/exit overhead.

## Solution
Program the SysTick LOAD/VAL/CTRL registers directly to enable the counter (CLKSOURCE + ENABLE) without TICKINT. The free-running counter stays available for anything that polls it; the useless 1 kHz interrupt is gone. Verified nothing in the F051 tree relies on the SysTick interrupt — timekeeping (`delayMicros`/`delayMillis`) runs off the utility timer, not SysTick.
