### PR TITLE
perf(f051): gate unused BlueJay custom tune to reclaim flash

### DIFF
--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -2194,6 +2194,7 @@
 #ifdef ARK_4IN1_F051
 #define FILE_NAME "ARK_4IN1_F051"
 #define FIRMWARE_NAME "ARK 4IN1"
+#define DISABLE_CUSTOM_TUNE // flash-tight F051; ARK does not use custom startup melodies
 #define DEAD_TIME 25
 #define HARDWARE_GROUP_F0_B
 #define MILLIVOLT_PER_AMP 10
@@ -2216,6 +2217,7 @@
 #ifdef ARK_4IN1_RAMP_F051
 #define FILE_NAME "ARK_4IN1_RAMP_F051"
 #define FIRMWARE_NAME "ARK 4IN1 SLO"
+#define DISABLE_CUSTOM_TUNE // flash-tight F051; ARK does not use custom startup melodies
 #define DEAD_TIME 25
 #define HARDWARE_GROUP_F0_B
 #define MILLIVOLT_PER_AMP 10

--- a/Src/sounds.c
+++ b/Src/sounds.c
@@ -41,6 +41,11 @@ void setCaptureCompare()
     SET_DUTY_CYCLE_ALL(beep_volume); // volume of the beep, (duty cycle) 
 }
 
+// The BlueJay custom startup melody is a user-programmable tune stored in the
+// eeprom tune[] blob. Boards that never load a custom tune can compile it out
+// with DISABLE_CUSTOM_TUNE to save flash; playStartupTune() falls back to the
+// fixed three-beep startup below.
+#ifndef DISABLE_CUSTOM_TUNE
 /*
  * @Brief 	Freq in hz, bduration in ms
  */
@@ -113,15 +118,19 @@ void playBlueJayTune(void)
     signaltimeout = 0;
     RELOAD_WATCHDOG_COUNTER();
 }
+#endif // DISABLE_CUSTOM_TUNE
 
 
 void playStartupTune()
 {
     __disable_irq();
 comStep(3);
+#ifndef DISABLE_CUSTOM_TUNE
   if (eepromBuffer.tune[0] != ERASED_FLASH_BYTE) {
     playBlueJayTune();
-    } else {
+    } else
+#endif
+    {
         SET_AUTO_RELOAD_PWM(TIM1_AUTORELOAD);
         setCaptureCompare();
         comStep(3); // activate a pwm channel


### PR DESCRIPTION
## Summary
Compile out the BlueJay custom startup tune on the flash-tight ARK F051 targets via a new `DISABLE_CUSTOM_TUNE` define; they fall back to the fixed three-beep startup.

## Problem
`playBlueJayTune()` plays a user-programmable melody stored in the eeprom `tune[]` blob. The ARK F051 boards never load a custom tune, so the code is dead weight on a 32 KB part where flash is the binding constraint once LTO and RAM-execution are in.

## Solution
Guard `playBlueJayTune()` and its call site with `#ifndef DISABLE_CUSTOM_TUNE`, and set `DISABLE_CUSTOM_TUNE` for the `ARK_4IN1_F051` and `ARK_4IN1_RAMP_F051` targets. Those boards keep the existing fixed startup beep. Saves ~364 B of flash; other targets are unaffected (the define is target-scoped).
