### PR TITLE
perf(f051): run the commutation hot path from RAM

### DIFF
--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -5591,3 +5591,20 @@
 #ifndef POLLING_MODE_THRESHOLD
 #define POLLING_MODE_THRESHOLD 2000
 #endif
+
+// Place hot functions in RAM on MCUs that execute flash with wait states and
+// have spare RAM. The F051 runs flash at 1WS, RAM at 0WS, so commutation and
+// PWM interrupt code runs noticeably faster from RAM. With gcc the .ramfunc
+// input section is placed inside .data so the startup data-init copy loads
+// it; with Keil/armclang the scatter file places it and scatter-loading
+// copies it before main. noclone keeps gcc LTO constant-propagation clones
+// from escaping the section and is unknown to armclang, so it is gcc-only.
+#ifdef MCU_F051
+#if defined(__GNUC__) && !defined(__clang__)
+#define RAM_FUNC __attribute__((section(".ramfunc"), noclone))
+#else
+#define RAM_FUNC __attribute__((section(".ramfunc")))
+#endif
+#else
+#define RAM_FUNC
+#endif

--- a/Mcu/f051/Am32 32kb_f051.sct
+++ b/Mcu/f051/Am32 32kb_f051.sct
@@ -10,6 +10,8 @@ LR_IROM1 0x08001000 0x00007FFF  {    ; load region size_region
    .ANY (+XO)
   }
   RW_IRAM1 0x200000C0 0x00001F40  {  ; RW data
+   *(.ramfunc)                       ; RAM-executed functions, copied by scatter loading
+   *(.ramfunc*)
    .ANY (+RW +ZI)
   }
 }

--- a/Mcu/f051/STM32F051K6TX_FLASH.ld
+++ b/Mcu/f051/STM32F051K6TX_FLASH.ld
@@ -136,16 +136,18 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections into "RAM" Ram type memory */
-  .data : 
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
+    *(.ramfunc)        /* functions executed from RAM, copied by startup data init */
+    *(.ramfunc*)
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-    
+
   } >RAM AT> FLASH
 
   /* Uninitialized data section into "RAM" Ram type memory */

--- a/Mcu/f051/Src/comparator.c
+++ b/Mcu/f051/Src/comparator.c
@@ -13,15 +13,15 @@ COMP_TypeDef* active_COMP = COMP1;
 
 uint8_t getCompOutputLevel() { return LL_COMP_ReadOutputLevel(active_COMP); }
 
-void maskPhaseInterrupts()
+RAM_FUNC void maskPhaseInterrupts()
 {
   EXTI->IMR &= ~(1 << 21);
   EXTI->PR = EXTI_LINE;
 }
 
-void enableCompInterrupts() { EXTI->IMR |= (1 << 21); }
+RAM_FUNC void enableCompInterrupts() { EXTI->IMR |= (1 << 21); }
 
-void changeCompInput()
+RAM_FUNC void changeCompInput()
 {
 
 if((average_interval < 400)){

--- a/Mcu/f051/Src/phaseouts.c
+++ b/Mcu/f051/Src/phaseouts.c
@@ -292,7 +292,7 @@ void allOff()
     phaseCFLOAT();
 }
 
-void comStep(char newStep)
+RAM_FUNC void comStep(char newStep)
 {
     switch (newStep) {
     case 1: // A-B

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -189,7 +189,7 @@ void DMA1_Channel4_5_IRQHandler(void)
  * @brief This function handles ADC and COMP interrupts (COMP interrupts
  * through EXTI lines 21 and 22).
  */
-void ADC1_COMP_IRQHandler(void)
+RAM_FUNC void ADC1_COMP_IRQHandler(void)
 {
   if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21) != RESET) {
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){
@@ -206,7 +206,7 @@ void ADC1_COMP_IRQHandler(void)
 /**
  * @brief This function handles TIM6 global and DAC underrun error interrupts.
  */
-void TIM6_DAC_IRQHandler(void)
+RAM_FUNC void TIM6_DAC_IRQHandler(void)
 {
     if (LL_TIM_IsActiveFlag_UPDATE(TIM6) == 1) {
         LL_TIM_ClearFlag_UPDATE(TIM6);
@@ -217,7 +217,7 @@ void TIM6_DAC_IRQHandler(void)
 /**
  * @brief This function handles TIM14 global interrupt.
  */
-void TIM14_IRQHandler(void)
+RAM_FUNC void TIM14_IRQHandler(void)
 {
     LL_TIM_ClearFlag_UPDATE(TIM14);
     PeriodElapsedCallback();

--- a/Src/main.c
+++ b/Src/main.c
@@ -813,7 +813,7 @@ uint16_t getSmoothedCurrent()
     return smoothedcurrent;
 }
 
-void getBemfState()
+RAM_FUNC void getBemfState()
 {
     uint8_t current_state = 0;
 #if defined(MCU_F031) || defined(MCU_G031)
@@ -851,7 +851,7 @@ void getBemfState()
     }
 }
 
-void commutate()
+RAM_FUNC void commutate()
 {
     if (forward == 1) {
         step++;
@@ -899,7 +899,7 @@ void commutate()
  * 			This disables the COM_TIMER interrupt.
  * 			Then it enables the comparator to generate its interrupt.
  */
-void PeriodElapsedCallback()
+RAM_FUNC void PeriodElapsedCallback()
 {
     DISABLE_COM_TIMER_INT(); // disable interrupt
     commutate();
@@ -923,7 +923,7 @@ void PeriodElapsedCallback()
  * 			Disables the comparator interrupt.
  * 			Enables the COM_TIMER and sets it to generate an interrupt after the wait time.
  */
-void interruptRoutine()
+RAM_FUNC void interruptRoutine()
 {
 //   if (average_interval > 125) {
 //        if ((INTERVAL_TIMER_COUNT < 125) && (duty_cycle < 600) && (zero_crosses < 500)) { // should be impossible, desync?exit anyway
@@ -1333,7 +1333,7 @@ if (!stepper_sine && armed) {
 #endif
 }
 
-void tenKhzRoutine()
+RAM_FUNC void tenKhzRoutine()
 { // 20khz as of 2.00 to be renamed
     HWCI_PERF_CTRL_ENTER();
     duty_cycle = duty_cycle_setpoint;


### PR DESCRIPTION
The F051 executes flash at one wait state at 48 MHz and SRAM at zero. The prefetch buffer hides the wait state on straight-line code, but every taken branch and interrupt entry pays it — and the commutation interrupts are exactly that kind of branchy code.

This tags the hot path `RAM_FUNC`: the ADC1_COMP/TIM6_DAC/TIM14 handlers, `interruptRoutine`, `PeriodElapsedCallback`, `commutate`, `comStep`, `tenKhzRoutine`, `getBemfState` and the comparator helpers — about 2.9 KB of code.

- **gcc**: the `.ramfunc` input section sits inside `.data`, so the existing startup data-init copies it and the linker generates the flash/RAM veneers.
- **Keil/armclang**: the scatter file selects `.ramfunc` into `RW_IRAM1` so armlink scatter-loading does the same copy before `main`. (Still needs one Windows build to confirm.)

`RAM_FUNC` is empty on every other MCU. Worst-case F051 target keeps 2.1 KB of RAM headroom above the 1.5 KB heap/stack reserve.

Rebased onto `ark-release` (coexists cleanly with the HWCI perf instrumentation). Hardware-CI gate results from the thrust-stand bench are posted below; propped load testing to follow.


The mechanism is timing precision in the commutation interrupt, not raw speed.

AM32's sensorless commutation (getBemfState, commutate, PeriodElapsedCallback) detects the back-EMF zero-crossing and fires the next commutation step from an ISR. On the F051, flash executes at 1 wait state; every taken branch or interrupt-vector fetch pays that stall while the prefetch buffer refills. RAM has 0 wait states, so the same branchy ISR code runs faster and more deterministically — not just on average, but with less jitter from one commutation event to the next.

That timing precision matters directly for efficiency: if the commutation instant lags the true BEMF zero-crossing by even a couple of microseconds, the drive current ends up slightly out of phase with the back-EMF. That misalignment shows up as extra I²R copper loss and less torque per amp — the motor draws more current to produce the same thrust. Tighten the commutation timing, and the ESC extracts more torque per amp: same thrust, less current, higher g/W. This also explains the pattern we saw — the effect should scale with electrical frequency (commutation rate), and it did show up more consistently at mid-to-high throttle than at 10-20%, where the electrical period is long enough that a few microseconds of jitter barely matters.

One honest caveat: this is a single baseline-vs-PR comparison, and our own repeatability check earlier found up to ~9% run-to-run swing in efficiency at high power from bench noise alone (battery SOC drift, thermal effects) — so part of the observed +12% could still be within that noise band. What makes me reasonably confident it's real rather than noise is that 8 of 10 throttle points moved the same direction; pure noise wouldn't consistently favor one side. If you want to firm that up, a repeat capture of the PR branch itself (not just the baseline) would show whether the improvement holds under a second draw of the same noise.