### PR TITLE
fix(f051): glitch-tolerant zero-cross confirm to cut commutation jitter

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -959,12 +959,35 @@ RAM_FUNC void interruptRoutine()
 //            return;
 //        }
 //    }
-        // Zero-cross confirm: return unless filter_level consecutive reads hold
-        // the post-crossing level. Loop speed sets the sampling window: inlining
+        // Zero-cross confirm: reject unless the window's reads hold the
+        // post-crossing level. Loop speed sets the sampling window: inlining
         // getCompOutputLevel removes the per-sample call overhead, and with the
-        // companion RAM-execution change the loop is faster still, shrinking the
-        // window from ~5us to ~1.2us at filter_level 12. Less wall-clock noise
-        // immunity per count; may need bench retuning.
+        // companion RAM-execution change the loop is faster still; filter_level
+        // is scaled (42/10/7 on F051) to keep the same wall-clock window as the
+        // stock ~56-cycle sampling cadence.
+#ifdef MCU_F051
+        // Glitch-tolerant variant: the ~16-cycle cadence lands on a brief
+        // comparator glitch ~3x more often than stock sampling, and a strict
+        // all-samples-must-agree confirm defers detection to the NEXT
+        // comparator edge - up to a PWM period late. Bench-measured on the
+        // ARK 4IN1: 2-3x higher commutation jitter at 15-20 kHz commutation
+        // rates vs stock cadence (upstream 2.1% vs 5.4% at full throttle).
+        // Tolerating up to filter_level/4 bad samples per window accepts
+        // through isolated glitches while a genuinely un-crossed level still
+        // rejects via the early-out; the full window length (and so the
+        // sustained-noise immunity of the filter_level retune) is unchanged.
+        {
+            int bad = 0;
+            const int tolerance = filter_level >> 2;
+            for (int i = 0; i < filter_level; i++) {
+                if (getCompOutputLevel() == rising) {
+                    if (++bad > tolerance) {
+                        return;
+                    }
+                }
+            }
+        }
+#else
         for (int i = 0; i < filter_level; i++) {
 #if defined(MCU_F031) || defined(MCU_G031)
             if (((current_GPIO_PORT->IDR & current_GPIO_PIN) == !(rising))) {
@@ -974,6 +997,7 @@ RAM_FUNC void interruptRoutine()
                 return;
             }
         }
+#endif
     __disable_irq();
     maskPhaseInterrupts();
     lastzctime = thiszctime;

--- a/hwci/hwci/profiles/jitter_probe.yaml
+++ b/hwci/hwci/profiles/jitter_probe.yaml
@@ -1,0 +1,26 @@
+name: jitter_probe
+description: >
+  Short zero-cross jitter probe: holds only the operating points where the
+  jitter metric separates firmwares on this bench (the 21-24k RPM
+  PWM/commutation beat hump plus the high-RPM tail, and t30 as a guard for
+  the region where ark-release measured BETTER than upstream). Roughly a
+  third of an efficiency_sweep's motor/battery time; use it to iterate on
+  zero-cross filter changes, then confirm the final candidate with a full
+  efficiency_sweep against the baseline.
+sample_rate_hz: 100
+arm_settle_s: 2.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 40.0
+  max_thrust_n: 16.0
+  max_rpm: 32000
+
+segments:
+  - {label: idle,   throttle: 0.00, duration_s: 2.0}
+  - {label: t30,    throttle: 0.30, duration_s: 6.0, ramp: true,  steady: true}
+  - {label: t60,    throttle: 0.60, duration_s: 6.0, steady: true}
+  - {label: t70,    throttle: 0.70, duration_s: 6.0, steady: true}
+  - {label: t90,    throttle: 0.90, duration_s: 6.0, steady: true}
+  - {label: t100,   throttle: 1.00, duration_s: 6.0, steady: true}
+  - {label: rampdn, throttle: 0.00, duration_s: 4.0, ramp: true}

--- a/hwci/hwci/profiles/jitter_probe_mid.yaml
+++ b/hwci/hwci/profiles/jitter_probe_mid.yaml
@@ -1,0 +1,21 @@
+name: jitter_probe_mid
+description: >
+  Minimal mid-band jitter probe (t40/t50/t80 only) for interleaved A/B
+  flashing on a partially drained pack: excludes t100 (cutoff headroom) and
+  the already-settled hump points. Compare only against runs taken minutes
+  apart - these mid points shift with pack voltage.
+sample_rate_hz: 100
+arm_settle_s: 2.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 40.0
+  max_thrust_n: 16.0
+  max_rpm: 32000
+
+segments:
+  - {label: idle,   throttle: 0.00, duration_s: 2.0}
+  - {label: t40,    throttle: 0.40, duration_s: 6.0, ramp: true,  steady: true}
+  - {label: t50,    throttle: 0.50, duration_s: 6.0, steady: true}
+  - {label: t80,    throttle: 0.80, duration_s: 6.0, steady: true}
+  - {label: rampdn, throttle: 0.00, duration_s: 4.0, ramp: true}


### PR DESCRIPTION
## Problem

The new zero-cross jitter metric (hwci_perf v2, `ffa0414`) ran its first upstream-vs-ark A/B today (2 sweeps each, same pack/day) and found ark-release with **2-3x higher commutation jitter at high commutation rates**:

| point (RPM) | upstream main | ark-release HEAD |
|---|---|---|
| t60 (~21.4k) | 17.2 / 19.2 % | 23.8 / 25.6 % |
| t70 (~23.5k) | 11.5 / 13.2 % | 16.1 / 17.4 % |
| t90 (~27.2k) | 7.3 / 7.4 % | 9.4 / 9.5 % |
| t100 (~28.8k) | 2.12 / 2.12 % | 5.37 / 5.45 % |

Attribution was confirmed on the bench: pre-#14 firmware (`aa53524` + jitter instrumentation) reads at/below upstream levels (t60 17.1, t70 9.5, t100 3.8), so PR #14's fine sampling is the cause. Mechanism: at the inlined ~16-cycle cadence a brief comparator glitch lands on ~3x more samples than the stock ~56-cycle cadence, and the strict all-samples-must-agree confirm **defers detection to the next comparator edge — up to a PWM period late**.

## Fix

Tolerate up to `filter_level/4` bad samples per confirm window (F051 only; other MCUs keep the stock strict loop). The window length and the 42/10/7 retune are unchanged, so sustained-noise immunity is preserved — isolated glitches simply no longer defer detection. A genuinely un-crossed level still rejects via the early-out.

## Results (ARK 4IN1 F051 + JS 2306 1800KV + HQ5136)

3 independent runs (2 probes + full sweep), plus an interleaved HEAD↔fix pair at matched pack state:

| point | HEAD | this PR | upstream |
|---|---|---|---|
| hump band 21-23.5k RPM | 16.1-25.6 % | **0.7-13.4 %** | 11.5-19.2 % |
| t90 | 9.4 % | **7.8-7.9 %** | 7.3 % |
| t100 | 5.4 % | **3.1-3.4 %** | 2.1 % |
| t30 | 7.0-7.1 % | **2.5-4.8 %** | 9.1-9.9 % |
| interleaved t40/t50/t80 | 7.05 / 8.43 / 16.93 % | **6.58 / 7.64 / 14.33 %** | - |

Better than or equal to HEAD at every matched comparison (12/12); better than upstream nearly everywhere. 0 demag / 0 bemf-timeouts across all runs, `efficiency_sweep` gate **PASS** vs the ark baseline, ctrl exec / CPU load unchanged (Q16 + inline perf wins intact).

Also adds the `jitter_probe` / `jitter_probe_mid` profiles used for the iteration. Runs: `runs/zc-tolerance-{probe,probe-2,sweep}`, `runs/mid-ab-{head,tolerant}`, attribution `runs/pre14-jitter-probe`.

Suggested follow-up after merge: recapture the propped baseline (jitter columns now gate-ready data) on a fresh pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)