### PR TITLE
feat(f051): PWM-synchronized comparator blanking to attack the beat-band jitter hump

### DIFF
--- a/Inc/common.h
+++ b/Inc/common.h
@@ -30,6 +30,9 @@ extern uint16_t battery_voltage;
 extern int16_t actual_current;
 extern uint16_t e_rpm;
 extern volatile uint32_t average_interval;
+#ifdef COMP_PWM_BLANKING
+extern volatile uint16_t comp_blank_off_lo;
+#endif
 extern volatile int16_t degrees_celsius;
 
 #ifdef STMICRO

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -40,8 +40,10 @@
 /* ASCII "HWC1" in little-endian memory order - lets the host locate/validate
  * the struct either by ELF symbol or by scanning RAM for the magic. */
 #define HWCI_PERF_MAGIC   0x31435748u
-/* v2: appended the zero-cross jitter block (zc_*) after host_cmd. */
-#define HWCI_PERF_VERSION 2u
+/* v2: appended the zero-cross jitter block (zc_*) after host_cmd.
+ * v3: appended the PWM-blanking / confirm-reject counters after the v2
+ *     jitter block (host_cmd stays frozen at offset 60). */
+#define HWCI_PERF_VERSION 3u
 
 /* Commands the host may write to hwci_perf.host_cmd (cleared by firmware). */
 #define HWCI_CMD_NONE          0u
@@ -104,7 +106,14 @@ typedef struct hwci_perf_s {
     uint32_t zc_interval_sum;          /* off 72 : sum raw interval, ticks  */
     uint16_t zc_jitter_max;            /* off 76 : worst single deviation   */
     uint16_t _pad2;                    /* off 78 : keep sizeof 4-aligned    */
-} hwci_perf_t;                         /* total size: 80 bytes              */
+
+    /* --- v3: comparator-ISR gate counters (monotonic; host differences
+     * consecutive snapshots like zc_count). zc_blank_engaged counts accepted
+     * comparator edges that landed inside a PWM-blanking dirty window (see
+     * COMP_PWM_BLANKING); zc_confirm_reject counts confirm-loop early-outs. */
+    uint32_t zc_blank_engaged;         /* off 80 : blanking spin-waits      */
+    uint32_t zc_confirm_reject;        /* off 84 : confirm-loop rejections  */
+} hwci_perf_t;                         /* total size: 88 bytes              */
 
 extern volatile hwci_perf_t hwci_perf;
 
@@ -192,6 +201,16 @@ void hwci_perf_reset_stats(void);
     } while (0)
 
 /*
+ * Comparator-ISR gate counters. BLANK_ENGAGED fires when an accepted edge
+ * lands inside a PWM-blanking dirty window (the rare path of the
+ * COMP_PWM_BLANKING gate); CONFIRM_REJECT fires on the zero-cross confirm
+ * loop's early-out reject. Both run in the comparator ISR: a single volatile
+ * u32 increment each, on paths that are already off the hot quiet path.
+ */
+#define HWCI_PERF_BLANK_ENGAGED()  do { hwci_perf.zc_blank_engaged++; } while (0)
+#define HWCI_PERF_CONFIRM_REJECT() do { hwci_perf.zc_confirm_reject++; } while (0)
+
+/*
  * Background-loop instrumentation. Call once at the top of the main while(1).
  *
  * Every iteration: measures iteration time and counts iterations (the host
@@ -252,10 +271,12 @@ void hwci_perf_reset_stats(void);
 
 #else /* !HWCI_PERF - all hooks vanish, no struct, no code */
 
-#define HWCI_PERF_CTRL_ENTER() do {} while (0)
-#define HWCI_PERF_CTRL_EXIT()  do {} while (0)
-#define HWCI_PERF_ZC()         do {} while (0)
-#define HWCI_PERF_MAIN_LOOP()  do {} while (0)
+#define HWCI_PERF_CTRL_ENTER()     do {} while (0)
+#define HWCI_PERF_CTRL_EXIT()      do {} while (0)
+#define HWCI_PERF_ZC()             do {} while (0)
+#define HWCI_PERF_MAIN_LOOP()      do {} while (0)
+#define HWCI_PERF_BLANK_ENGAGED()  do {} while (0)
+#define HWCI_PERF_CONFIRM_REJECT() do {} while (0)
 
 #endif /* HWCI_PERF */
 

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -5263,6 +5263,16 @@
 #define COMP_PA0 0b1100001
 #define COMP_PA4 0b1000001
 #define COMP_PA5 0b1010001
+// PWM-synchronized comparator blanking (software; F051 COMP has no HW
+// blanking). TIM1 runs PWM1 mode up-counting, so the turn-off edge lands at
+// CNT=CCR and the turn-on edge at rollover CNT=0, each smeared by
+// DEAD_TIME(25) ticks of driver dead-time plus a fixed-duration switching
+// ring - hence fixed windows in TIM1 ticks (= CPU cycles at 48 MHz).
+#define COMP_PWM_BLANKING
+#define COMP_BLANK_ON_TICKS  64u  // TIM1 ticks (=CPU cycles, 48 MHz): DT(25)+ring+margin
+#define COMP_BLANK_OFF_LEAD  8u   // lead before CCR: CCR-preload/ramp staleness
+#define COMP_BLANK_OFF_LEN   72u  // LEAD + DT(25) + ring + margin
+#define COMP_BLANK_MAX_SPIN  24u  // hard iteration cap: progress guarantee
 #endif
 
 #ifdef  MCU_F031

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -27,6 +27,7 @@
 #include "ADC.h"
 #include "targets.h"
 #include "common.h"
+#include "hwci_perf.h" // no-op macros unless built with HWCI_PERF
 
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
@@ -214,6 +215,7 @@ RAM_FUNC void ADC1_COMP_IRQHandler(void)
         uint16_t lo = comp_blank_off_lo;       // one ldrh, atomic
         uint16_t cnt = TIM1->CNT;
         if (compBlankDirty(cnt, lo)) {         // rare path
+            HWCI_PERF_BLANK_ENGAGED();
             for (uint32_t i = 0; i < COMP_BLANK_MAX_SPIN; i++) {
                 cnt = TIM1->CNT;
                 if (!compBlankDirty(cnt, lo))

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -185,6 +185,16 @@ void DMA1_Channel4_5_IRQHandler(void)
 #endif
 }
 
+#ifdef COMP_PWM_BLANKING
+// Dirty when near the PWM turn-on edge (rollover) or turn-off edge (CCR).
+// The unsigned-subtract idiom makes the CCR window one compare.
+static inline uint32_t compBlankDirty(uint16_t cnt, uint16_t lo)
+{
+    return (cnt < COMP_BLANK_ON_TICKS) ||
+           ((uint16_t)(cnt - lo) < COMP_BLANK_OFF_LEN);
+}
+#endif
+
 /**
  * @brief This function handles ADC and COMP interrupts (COMP interrupts
  * through EXTI lines 21 and 22).
@@ -194,8 +204,26 @@ RAM_FUNC void ADC1_COMP_IRQHandler(void)
   if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21) != RESET) {
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){
        EXTI->PR = EXTI_LINE;
+#ifdef COMP_PWM_BLANKING
+    // PWM-synchronized blanking: if this edge fired inside a dirty window
+    // around a PWM switching edge, spin (bounded) until TIM1 leaves the
+    // window, then let the confirm loop judge a clean signal. The edge is
+    // only ever DELAYED (<= COMP_BLANK_MAX_SPIN iterations, ~4.2 us), never
+    // discarded - a discarded true crossing may never re-trigger.
+    {
+        uint16_t lo = comp_blank_off_lo;       // one ldrh, atomic
+        uint16_t cnt = TIM1->CNT;
+        if (compBlankDirty(cnt, lo)) {         // rare path
+            for (uint32_t i = 0; i < COMP_BLANK_MAX_SPIN; i++) {
+                cnt = TIM1->CNT;
+                if (!compBlankDirty(cnt, lo))
+                    break;
+            }
+        }
+    }
+#endif
       interruptRoutine();
-  }else{ 
+  }else{
       if (getCompOutputLevel() == rising){
       EXTI->PR = EXTI_LINE;
   }

--- a/Src/hwci_perf.c
+++ b/Src/hwci_perf.c
@@ -42,6 +42,10 @@ void hwci_perf_reset_stats(void)
     hwci_perf.main_loop_us_max = 0;
     hwci_perf.commutation_interval_max = 0;
     hwci_perf.zc_jitter_max = 0;
+    /* zc_count/zc_*_sum and the v3 zc_blank_engaged/zc_confirm_reject
+     * counters are monotonic by contract (the host differences snapshots),
+     * so they are deliberately NOT reset here; they start at 0 from the
+     * static initializer like every other unlisted field. */
 }
 
 /*

--- a/Src/main.c
+++ b/Src/main.c
@@ -420,6 +420,12 @@ char desync_check = 0;
 char low_kv_filter_level = 20;
 
 volatile uint16_t tim1_arr = TIM1_AUTORELOAD; // current auto reset value
+#ifdef COMP_PWM_BLANKING
+// Lower bound of the off-edge dirty window, TIM1 ticks. Published by the
+// 20 kHz routine; read by the comparator ISR. Single uint16_t: 16-bit
+// load/store is atomic on M0, so no pairing/masking is needed.
+volatile uint16_t comp_blank_off_lo = 0;
+#endif
 // Q16 fixed point scale factor equal to tim1_arr / 2000, recomputed in the main
 // loop when tim1_arr changes so the 20khz routine multiplies instead of divides
 volatile uint32_t pwm_to_arr_scale_q16 = ((uint32_t)TIM1_AUTORELOAD << 16) / 2000;
@@ -1572,6 +1578,15 @@ RAM_FUNC void tenKhzRoutine()
         last_duty_cycle = duty_cycle;
         SET_AUTO_RELOAD_PWM(tim1_arr);
         SET_DUTY_CYCLE_ALL(adjusted_duty_cycle);
+#ifdef COMP_PWM_BLANKING
+        // Publish the off-edge window lower bound for the comparator ISR.
+        // This is the single SET_DUTY_CYCLE_ALL that runs while the
+        // comparator can be active (all running/brake paths funnel through
+        // it); the other call sites run with phase interrupts masked
+        // (brushed mode, sine startup, disarm/stop paths).
+        comp_blank_off_lo = (adjusted_duty_cycle > COMP_BLANK_OFF_LEAD)
+            ? (uint16_t)(adjusted_duty_cycle - COMP_BLANK_OFF_LEAD) : 0u;
+#endif
     }
 #endif // ndef brushed_mode
 #if defined(FIXED_DUTY_MODE) || defined(FIXED_SPEED_MODE)

--- a/Src/main.c
+++ b/Src/main.c
@@ -988,6 +988,7 @@ RAM_FUNC void interruptRoutine()
             for (int i = 0; i < filter_level; i++) {
                 if (getCompOutputLevel() == rising) {
                     if (++bad > tolerance) {
+                        HWCI_PERF_CONFIRM_REJECT();
                         return;
                     }
                 }

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -157,6 +157,31 @@ def zc_jitter_window(count: np.ndarray, jsum: np.ndarray, isum: np.ndarray,
     return out
 
 
+def blank_engaged_window(blank: np.ndarray, count: np.ndarray,
+                         idx: np.ndarray) -> float | None:
+    """PWM-blanking engagement ratio over the sample window ``idx``.
+
+    ``delta(zc_blank_engaged) / delta(zc_count)`` between the first and last
+    valid snapshot (both monotonic u32 counters, differenced wrap-safe like
+    :func:`zc_jitter_window`): the fraction of accepted comparator edges that
+    landed inside a PWM switching dirty window and spun. Report-only sanity
+    signal for COMP_PWM_BLANKING - healthy runs sit around 0.05-0.3; 0 means
+    the gate never engages (windows missing the noise), ~1.0 means the
+    windows are miscomputed and everything reads dirty. ``None`` when the
+    firmware predates struct v3 or nothing accumulated in the window.
+    """
+    if idx.size == 0:
+        return None
+    valid = idx[~np.isnan(blank[idx]) & ~np.isnan(count[idx])]
+    if valid.size < 2:
+        return None
+    a, b = valid[0], valid[-1]
+    n = _wrap32(count[a], count[b])
+    if n <= 0:
+        return None
+    return round(_wrap32(blank[a], blank[b]) / n, 4)
+
+
 def compute(run: RunResult, profile: Profile) -> dict:
     rows = run.rows
     seg = np.array([r.get("segment") for r in rows], dtype=object)
@@ -180,6 +205,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
     zc_jsum = _col(rows, "perf_zc_jitter_sum")
     zc_isum = _col(rows, "perf_zc_interval_sum")
     zc_jmax = _col(rows, "perf_zc_jitter_max")
+    zc_blank = _col(rows, "perf_zc_blank_engaged")
 
     steady_points = []
     for s in profile.segments:
@@ -208,6 +234,8 @@ def compute(run: RunResult, profile: Profile) -> dict:
             # bench has repeat captures establishing its run-to-run spread)
             "zc_jitter_pct": jitter["mean_pct"],
             "zc_jitter_max_pct": jitter["max_pct"],
+            # PWM-blanking engagement ratio (report-only, struct v3+)
+            "blank_engaged_per_zc": blank_engaged_window(zc_blank, zc_count, tail),
         })
 
     demag = detect_demag(run, profile)

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -34,6 +34,8 @@ COLUMNS = [
     # firmware predates them - metrics treat blank as "metric unavailable")
     "perf_zc_count", "perf_zc_jitter_sum", "perf_zc_interval_sum",
     "perf_zc_jitter_max",
+    # comparator-ISR gate counters (struct v3+; blank on older firmware)
+    "perf_zc_blank_engaged", "perf_zc_confirm_reject",
     "perf_bemf_timeout", "perf_e_rpm",
     # ESC input/arming state (proves the ESC decoded the throttle protocol)
     "perf_input", "perf_armed", "perf_running",
@@ -96,6 +98,11 @@ def make_row(t: float, segment: str, throttle_cmd: float,
                 perf_zc_jitter_sum=r["zc_jitter_sum"],
                 perf_zc_interval_sum=r["zc_interval_sum"],
                 perf_zc_jitter_max=r["zc_jitter_max"],
+            )
+        if "zc_blank_engaged" in r:  # struct v3+
+            row.update(
+                perf_zc_blank_engaged=r["zc_blank_engaged"],
+                perf_zc_confirm_reject=r["zc_confirm_reject"],
             )
     return row
 

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 2
+VERSION = 3
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -57,7 +57,7 @@ FIELDS_V1: list[tuple[str, str]] = [
 ]
 
 # v2 appends the zero-cross jitter block (see HWCI_PERF_ZC in Inc/hwci_perf.h).
-FIELDS: list[tuple[str, str]] = FIELDS_V1 + [
+FIELDS_V2: list[tuple[str, str]] = FIELDS_V1 + [
     ("zc_count", "I"),
     ("zc_jitter_sum", "I"),
     ("zc_interval_sum", "I"),
@@ -65,7 +65,17 @@ FIELDS: list[tuple[str, str]] = FIELDS_V1 + [
     ("_pad2", "H"),
 ]
 
-FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {1: FIELDS_V1, 2: FIELDS}
+# v3 appends the comparator-ISR gate counters (PWM blanking engagement and
+# confirm-loop rejections; see COMP_PWM_BLANKING and Inc/hwci_perf.h).
+FIELDS_V3: list[tuple[str, str]] = FIELDS_V2 + [
+    ("zc_blank_engaged", "I"),
+    ("zc_confirm_reject", "I"),
+]
+
+FIELDS = FIELDS_V3
+
+FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
+    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3}
 
 
 def _format(fields: list[tuple[str, str]]) -> str:
@@ -76,7 +86,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 80 bytes (v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 88 bytes (v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -51,8 +51,13 @@ class PerfReader:
                           "relying on the canonical layout in hwci/hwci/perf.py")
             return
         # Pick the canonical layout matching the firmware's vintage by probing
-        # for a v2-only member, then verify every field of THAT layout.
-        fields = perf.FIELDS if "zc_count" in members else perf.FIELDS_V1
+        # for version-marker members, then verify every field of THAT layout.
+        if "zc_blank_engaged" in members:
+            fields = perf.FIELDS_V3
+        elif "zc_count" in members:
+            fields = perf.FIELDS_V2
+        else:
+            fields = perf.FIELDS_V1
         off = 0
         import struct as _struct
         for name, code in fields:

--- a/hwci/hwci/report.py
+++ b/hwci/hwci/report.py
@@ -43,7 +43,7 @@ def render_markdown(metrics: dict, comparison: dict | None = None,
         cols = ["segment", "throttle", "rpm", "thrust_gf", "current_a",
                 "voltage_v", "elec_power_w", "eff_gf_per_w",
                 "ctrl_exec_us_max", "cpu_load_pct",
-                "zc_jitter_pct", "zc_jitter_max_pct"]
+                "zc_jitter_pct", "zc_jitter_max_pct", "blank_engaged_per_zc"]
         out.append("| " + " | ".join(cols) + " |")
         out.append("|" + "---|" * len(cols))
         for p in pts:

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -67,6 +67,9 @@ class RigSimulator:
         self.zc_jitter_sum = 0
         self.zc_interval_sum = 0
         self.zc_jitter_max = 0
+        # comparator-ISR gate counters (perf struct v3)
+        self.zc_blank_engaged = 0
+        self.zc_confirm_reject = 0
 
     # --- model -------------------------------------------------------
     def _rpm_max(self) -> float:
@@ -115,6 +118,15 @@ class RigSimulator:
             self.zc_jitter_sum = (self.zc_jitter_sum + dev * n_comm) & 0xFFFFFFFF
             self.zc_interval_sum = (self.zc_interval_sum + interval * n_comm) & 0xFFFFFFFF
             self.zc_jitter_max = min(max(self.zc_jitter_max, dev), 0xFFFF)
+            # v3 gate counters: a healthy ~10-20% of accepted edges land in a
+            # PWM switching dirty window and spin; confirm-loop rejects stay
+            # rare in clean running and balloon during a desync
+            blank_frac = self._rng.uniform(0.10, 0.20)
+            self.zc_blank_engaged = (self.zc_blank_engaged
+                                     + int(n_comm * blank_frac)) & 0xFFFFFFFF
+            reject_frac = 0.2 if self.desync_remaining > 0 else 0.01
+            self.zc_confirm_reject = (self.zc_confirm_reject
+                                      + int(n_comm * reject_frac)) & 0xFFFFFFFF
         # idle loop iterations: ~120 kHz when idle, dropping with motor load
         idle_hz = 120000.0 * (1.0 - 0.25 * throttle)
         self.loop_iters += int(idle_hz * dt)
@@ -228,4 +240,6 @@ class RigSimulator:
             "zc_jitter_sum": self.zc_jitter_sum,
             "zc_interval_sum": self.zc_interval_sum,
             "zc_jitter_max": self.zc_jitter_max,
+            "zc_blank_engaged": self.zc_blank_engaged,
+            "zc_confirm_reject": self.zc_confirm_reject,
         })

--- a/hwci/tests/conftest.py
+++ b/hwci/tests/conftest.py
@@ -51,6 +51,33 @@ int main(void){ return (int)hwci_perf.size; }
 """
 
 
+# Frozen copy of the v2 struct (zero-cross jitter block, pre v3 gate
+# counters), so the host keeps decoding v2 firmware: an A/B bench session
+# flashes vintages with exactly this layout.
+_PROBE_V2_C = """\
+#include <stdint.h>
+typedef struct hwci_perf_s {
+    uint32_t magic; uint16_t version; uint16_t size;
+    uint16_t ctrl_exec_us_last; uint16_t ctrl_exec_us_max;
+    uint16_t ctrl_period_us_last; uint16_t ctrl_period_us_max;
+    uint16_t ctrl_period_us_min;
+    uint16_t main_loop_us_last; uint16_t main_loop_us_max;
+    uint16_t input; uint16_t duty_cycle; uint16_t e_rpm;
+    uint16_t voltage_cv; int16_t current_ca; int16_t temperature_c;
+    uint8_t bemf_timeout_state; uint8_t armed; uint8_t running;
+    uint8_t _pad0; uint16_t _pad1;
+    uint32_t loop_iters; uint32_t zero_cross_count;
+    uint32_t commutation_interval; uint32_t commutation_interval_max;
+    uint32_t update_count; volatile uint32_t host_cmd;
+    uint32_t zc_count; uint32_t zc_jitter_sum; uint32_t zc_interval_sum;
+    uint16_t zc_jitter_max; uint16_t _pad2;
+} hwci_perf_t;
+volatile hwci_perf_t hwci_perf = {
+  .magic = 0x31435748u, .version = 2, .size = (uint16_t)sizeof(hwci_perf_t) };
+int main(void){ return (int)hwci_perf.size; }
+"""
+
+
 def _compile_probe(tmp_path_factory, name: str, source: str,
                    include_dir=None) -> str:
     pytest.importorskip("elftools")
@@ -78,3 +105,8 @@ def host_perf_elf(tmp_path_factory):
 @pytest.fixture(scope="session")
 def host_perf_elf_v1(tmp_path_factory):
     return _compile_probe(tmp_path_factory, "perf_elf_v1", _PROBE_V1_C)
+
+
+@pytest.fixture(scope="session")
+def host_perf_elf_v2(tmp_path_factory):
+    return _compile_probe(tmp_path_factory, "perf_elf_v2", _PROBE_V2_C)

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 80
+    assert sym.size == perf.SIZE == 88
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -187,6 +187,66 @@ def test_zc_jitter_none_for_v1_runs():
     assert m["summary"]["worst_zc_jitter_pct"] is None
 
 
+def test_blank_engaged_per_zc_from_accumulator_deltas():
+    # 100 commutations per tick, 15 of them blanking-engaged -> ratio 0.15
+    # from first/last snapshot deltas over the steady tail.
+    n = 100
+    rows = _rows(
+        n,
+        perf_zc_count=lambda i: 100 * i,
+        perf_zc_jitter_sum=lambda i: 2 * 100 * i,
+        perf_zc_interval_sum=lambda i: 200 * 100 * i,
+        perf_zc_jitter_max=lambda i: 9,
+        perf_zc_blank_engaged=lambda i: 15 * i,
+    )
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["steady_points"][0]["blank_engaged_per_zc"] == 0.15
+
+
+def test_blank_engaged_per_zc_survives_u32_wrap():
+    # blank_engaged wraps u32 mid-window; modular differencing must keep the
+    # ratio exact (same wrap-safety contract as zc_jitter_window).
+    n = 100
+    start = (1 << 32) - 15 * 50  # wraps halfway through the run
+    rows = _rows(
+        n,
+        perf_zc_count=lambda i: 100 * i,
+        perf_zc_blank_engaged=lambda i: (start + 15 * i) % (1 << 32),
+    )
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["steady_points"][0]["blank_engaged_per_zc"] == 0.15
+
+
+def test_blank_engaged_none_for_pre_v3_runs():
+    # Runs captured on pre-v3 firmware have no blank_engaged column: the
+    # metric must report None (unavailable), never 0 (which would read as
+    # "gate never engages" - a real, alarming condition).
+    n = 50
+    rows = _rows(
+        n,
+        perf_zc_count=lambda i: 100 * i,
+        perf_zc_jitter_sum=lambda i: 2 * 100 * i,
+        perf_zc_interval_sum=lambda i: 200 * 100 * i,
+        perf_zc_jitter_max=lambda i: 9,
+    )
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    pt = m["steady_points"][0]
+    assert pt["zc_jitter_pct"] == 1.0       # v2 metrics still computed
+    assert pt["blank_engaged_per_zc"] is None
+
+
+def test_blank_engaged_none_when_no_commutations_accumulate():
+    # Counters present but frozen (motor stopped): no window delta, so the
+    # ratio is unavailable rather than 0/0 noise.
+    rows = _rows(
+        50,
+        perf_zc_count=lambda i: 5000,
+        perf_zc_blank_engaged=lambda i: 750,
+    )
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["steady_points"][0]["blank_engaged_per_zc"] is None
+
+
 def test_zc_jitter_none_when_no_commutations_accumulate():
     # Counters present but frozen (motor stopped / startup-gated): no window
     # delta, so the metric is unavailable rather than 0/0 noise.

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -8,7 +8,8 @@ from hwci import perf
 
 def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[1] == 64
-    assert perf.SIZE == perf.SIZE_BY_VERSION[2] == 80
+    assert perf.SIZE_BY_VERSION[2] == 80
+    assert perf.SIZE == perf.SIZE_BY_VERSION[3] == 88
 
 
 def test_host_cmd_offset_matches_layout():
@@ -58,6 +59,30 @@ def test_roundtrip_zc_jitter_fields():
     assert r["zc_jitter_max"] == 41
 
 
+def test_roundtrip_v3_gate_counters():
+    blob = perf.encode({
+        "zc_blank_engaged": 123456,
+        "zc_confirm_reject": 4200000000,   # near the u32 limit
+    })
+    assert len(blob) == 88
+    r = perf.decode(blob).raw
+    assert r["zc_blank_engaged"] == 123456
+    assert r["zc_confirm_reject"] == 4200000000
+
+
+def test_v2_roundtrip_has_no_v3_keys():
+    # v2-vintage firmware (B side of an A/B session) reports an 80-byte
+    # struct: it must decode cleanly, keep the zc jitter block, and simply
+    # not carry the v3 gate counters.
+    blob = perf.encode({"zc_count": 99, "zc_jitter_max": 7}, version=2)
+    assert len(blob) == perf.SIZE_BY_VERSION[2]
+    s = perf.decode(blob)
+    assert s.raw["zc_count"] == 99
+    assert s.raw["zc_jitter_max"] == 7
+    assert "zc_blank_engaged" not in s.raw
+    assert "zc_confirm_reject" not in s.raw
+
+
 def test_v1_roundtrip_has_no_zc_keys():
     # Old firmware (A side of an A/B session) reports a 64-byte v1 struct;
     # it must decode cleanly and simply not carry the jitter fields.
@@ -70,7 +95,7 @@ def test_v1_roundtrip_has_no_zc_keys():
 
 
 def test_v1_decodes_from_oversized_read():
-    # PerfReader sizes its read from the ELF symbol, but a v2-sized buffer
+    # PerfReader sizes its read from the ELF symbol, but a v3-sized buffer
     # holding a v1 struct (plus trailing junk) must still decode as v1.
     blob = perf.encode({"loop_iters": 7}, version=1) + b"\xa5" * 16
     s = perf.decode(blob)

--- a/hwci/tests/test_perf_reader.py
+++ b/hwci/tests/test_perf_reader.py
@@ -87,6 +87,24 @@ def test_v1_firmware_reads_and_resets(host_perf_elf_v1):
     assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS
 
 
+def test_v2_firmware_reads_and_resets(host_perf_elf_v2):
+    # v2-vintage firmware (80-byte struct, zc jitter block but no v3 gate
+    # counters): the reader must size its SWD read from the ELF, pass the
+    # DWARF cross-check against the v2 canonical table, decode without the
+    # v3 keys, and land RESET_STATS at the version-stable offset 60.
+    reader, dbg = _reader_with_mock(host_perf_elf_v2)
+    assert reader._read_size == perf.SIZE_BY_VERSION[2]
+    dbg.poke(reader.address, perf.encode(
+        {"zc_count": 777, "loop_iters": 31337}, version=2))
+    sample = reader.read()
+    assert sample.raw["zc_count"] == 777
+    assert sample.loop_iters == 31337
+    assert "zc_blank_engaged" not in sample.raw
+    reader.reset_stats(verify=False)
+    word = dbg.read_memory(reader.address + perf.HOST_CMD_OFFSET, 4)
+    assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS
+
+
 def test_missing_struct_die_fails_hard(host_perf_elf, monkeypatch):
     # DWARF present but the struct tag gone (rename/LTO): decoding on faith is
     # exactly the drift the cross-check exists to catch -> must raise.

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -80,3 +80,18 @@ def test_perf_channel_carries_zc_jitter_accumulators():
         b["zc_interval_sum"] - a["zc_interval_sum"])
     assert 0.1 < mean_pct < 2.0
     assert b["zc_jitter_max"] >= 1
+
+
+def test_perf_channel_carries_v3_gate_counters():
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.7)
+    a = perf.decode(rig.perf_bytes()).raw
+    _settle(rig, 0.7)
+    b = perf.decode(rig.perf_bytes()).raw
+    # monotonic counters, growing while running
+    assert b["zc_blank_engaged"] > a["zc_blank_engaged"] > 0
+    assert b["zc_confirm_reject"] >= a["zc_confirm_reject"]
+    # blanking engagement fraction lands in the modeled healthy band
+    ratio = (b["zc_blank_engaged"] - a["zc_blank_engaged"]) / (
+        b["zc_count"] - a["zc_count"])
+    assert 0.05 < ratio < 0.3


### PR DESCRIPTION
## Problem

The zc-jitter beat band (21–24k RPM: **t60 25.6% / t70 17.4%** on the current baseline, 11–20% on every firmware variant including upstream) is PWM switching noise aliasing into zero-cross detection. As the ZC instant slowly sweeps through the PWM period, some commutations land their comparator edge right on a switching transient. PR #22 flagged "PWM-synchronized comparator blanking" as the fix to attack this at the source.

## Design

The key constraint: **an accepted edge must never be discarded.** After a true crossing the comparator level stays crossed, so a rejected edge may never re-trigger and the ZC would be lost until the 22.5 ms bemf timeout. Hardware blanking doesn't exist on the F051 COMP, and gating samples inside the confirm loop would silently change the 42/10/7 wall-clock windows that #14/#21 just retuned.

So the gate lives at ISR entry, and it **delays instead of rejecting**: after the existing half-interval check accepts the edge, read `TIM1->CNT` once; if it sits in a dirty window around a PWM switching edge — `[0, 64)` at the turn-on rollover, `[CCR−8, CCR+64)` at turn-off (dead time 25 + fixed-duration ring + margin) — spin (hard-capped at 24 iterations ≈ 4.2 µs) until the window exits, then run the unchanged confirm loop on a clean signal. A spike-induced false edge gets rejected by the glitch-tolerant confirm within ~3 samples; a true crossing is time-stamped at the window exit instead of somewhere random inside the transient.

The only published state is a single `uint16_t` off-window bound, written in `tenKhzRoutine` right after `SET_DUTY_CYCLE_ALL` (16-bit stores are atomic on M0 — no masking dance). The gate uses only CNT + that bound + constants, so variable PWM needs nothing extra. All other `SET_DUTY_CYCLE_ALL` call sites run with phase interrupts masked (verified: brushed, sine startup, disarm/stop paths). F051-only via `COMP_PWM_BLANKING`, same scoping pattern as the #21 glitch-tolerant loop.

Edge cases: at 100% duty there are no switching edges and the residual blanked span is a harmless ≤1.5 µs delay; near-100% the unsigned compare truncates the off window at ARR and the rollover window covers the wrap; at low duty the windows merge and the long off-time stays fully quiet.

## Instrumentation (hwci_perf v3)

- `zc_blank_engaged` (offset 80) — accepts that hit a dirty window. Healthy ≈ 0.05–0.3 per ZC (reported as `blank_engaged_per_zc` per steady point); 0 = gate not engaging, ~1.0 = windows miscomputed.
- `zc_confirm_reject` (offset 84) — F051 confirm-loop early-outs, for watching the spike-reject mechanism.
- Host decode (`perf.py` v3, DWARF cross-check, metrics/report/sim/tests updated).

⚠️ **Merge-order note:** the demag-compensation PR also claims perf v3 with different fields at offset 80. Whichever merges second rebases its fields after the first's and bumps to v4.

## Measured cost

- Quiet path (the ~93% common case): **12 added instructions ≈ 20 cycles (~0.42 µs)**, verified by disassembly; handler stays RAM-resident (0x20000b9c).
- ARK_4IN1_F051: FLASH +80 B (85.0%), RAM +80 B (84.7%).
- Builds clean under `-Werror`: ARK_4IN1_F051 (plain + `HWCI_PERF=1`) and AIRBOT_PHOENIX_12S_G071 (non-F051 unaffected). hwci offline tests: **123 passed** (8 new).

## Bench validation (before undrafting)

1. `jitter_probe` A/B vs baseline (sha 66d8c9a): success = t60/t70 at least halved from 25.6%/17.4%, ideally toward the t100/t20 floor (2–5%); `blank_engaged_per_zc` in the healthy band.
2. `jitter_probe_mid` interleaved A/B for t40/t50/t80.
3. Full `efficiency_sweep` gate vs `baselines/ARK_4IN1_F051_HQ5136.json` — hard requirement **`demag_events == 0` and `bemf_timeout_samples == 0`** (the "blanking never loses a ZC" proof), efficiency and CPU/ctrl-exec within thresholds.
4. If residual jitter remains: widen `COMP_BLANK_ON_TICKS`/`COMP_BLANK_OFF_LEN` in +16 steps; a v2 refinement (timestamp compensation via INTERVAL_TIMER snapshot at ISR entry) is designed but deliberately out of v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pvp2XLcgsviGSVn9PaaP6

---
_Generated by [Claude Code](https://claude.ai/code/session_011pvp2XLcgsviGSVn9PaaP6)_