### PR TITLE
feat(demag): demag compensation — measure demag time, cut power on demag-past-ZC (PR #2 rebased)

### DIFF
--- a/Inc/common.h
+++ b/Inc/common.h
@@ -31,6 +31,8 @@ extern int16_t actual_current;
 extern uint16_t e_rpm;
 extern volatile uint32_t average_interval;
 extern volatile int16_t degrees_celsius;
+extern volatile uint8_t auto_blanking;
+extern volatile uint16_t blanking_length;
 
 #ifdef STMICRO
 extern GPIO_TypeDef* current_GPIO_PORT;

--- a/Inc/common.h
+++ b/Inc/common.h
@@ -33,6 +33,7 @@ extern volatile uint32_t average_interval;
 extern volatile int16_t degrees_celsius;
 extern volatile uint8_t auto_blanking;
 extern volatile uint16_t blanking_length;
+extern volatile uint16_t demag_wait_ticks; // zc->comm delay for armed demag step
 
 #ifdef STMICRO
 extern GPIO_TypeDef* current_GPIO_PORT;

--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -69,7 +69,7 @@ typedef union EEprom_u {
             uint8_t debug_rate; // 182
             uint8_t term_enable; // 183
             uint8_t demag_compensation; // 184  0=off 1=low 2=medium 3=high
-            uint8_t active_demag; // 185  0=off 1=on, requires demag_compensation
+            uint8_t active_demag; // 185  0=off 1=on (FET freewheel; arms demag measurement)
             uint8_t reserved[6]; // 186-191
         } can;
     };

--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -68,7 +68,9 @@ typedef union EEprom_u {
             uint8_t filter_hz; // 181
             uint8_t debug_rate; // 182
             uint8_t term_enable; // 183
-            uint8_t reserved[8]; // 184-191
+            uint8_t demag_compensation; // 184  0=off 1=low 2=medium 3=high
+            uint8_t active_demag; // 185  0=off 1=on, requires demag_compensation
+            uint8_t reserved[6]; // 186-191
         } can;
     };
     uint8_t buffer[192];

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -43,8 +43,9 @@
 /* v2: appended the zero-cross jitter block (zc_*) after host_cmd.
  * v3: appended zc_confirm_reject after the v2 jitter block (host_cmd stays
  *     frozen at offset 60).
- * v4: appended the 32-bin PWM-phase histogram of accepted zero-crossings. */
-#define HWCI_PERF_VERSION 4u
+ * v4: appended the 32-bin PWM-phase histogram of accepted zero-crossings.
+ * v5: appended the demag compensation block (demag_events, blanking_len_*). */
+#define HWCI_PERF_VERSION 5u
 
 /* PWM-phase histogram bins (power of two: the binning multiply-shift and the
  * host's modular math both assume it). */
@@ -130,7 +131,16 @@ typedef struct hwci_perf_s {
      * discriminator for the beat-band jitter hump investigation (PR #23
      * found 3.3x edge-window enrichment at t30). */
     uint16_t zc_phase_hist[HWCI_ZC_PHASE_BINS]; /* off 84..147              */
-} hwci_perf_t;                         /* total size: 148 bytes             */
+
+    /* --- v5: demag compensation stats (fed from the main-loop snapshot
+     * path, zero ISR cost). demag_events mirrors main.c's monotonic
+     * demag_happened counter; blanking_len_* mirror the measured demag time
+     * (INTERVAL_TIMER ticks) from demagEdgeRoutine(). Appended after the v4
+     * histogram so host_cmd stays frozen at offset 60. */
+    uint32_t demag_events;             /* off 148: demag_happened mirror    */
+    uint16_t blanking_len_last;        /* off 152: last measured demag time */
+    uint16_t blanking_len_max;         /* off 154: worst measured demag time*/
+} hwci_perf_t;                         /* total size: 156 bytes             */
 
 extern volatile hwci_perf_t hwci_perf;
 
@@ -307,6 +317,13 @@ void hwci_perf_reset_stats(void);
             hwci_perf.running = (uint8_t)running;                              \
             hwci_perf.zero_cross_count = zero_crosses;                         \
             hwci_perf.commutation_interval = _ci;                              \
+            {                                                                  \
+                uint16_t _bl = blanking_length; /* cache the ISR-written u16 */\
+                hwci_perf.demag_events = demag_happened;                       \
+                hwci_perf.blanking_len_last = _bl;                             \
+                if (_bl > hwci_perf.blanking_len_max)                          \
+                    hwci_perf.blanking_len_max = _bl;                          \
+            }                                                                  \
             if (_ci > hwci_perf.commutation_interval_max)                      \
                 hwci_perf.commutation_interval_max = _ci;                      \
             if (_armed && !_hwci_prev_armed)                                   \

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -44,8 +44,9 @@
  * v3: appended zc_confirm_reject after the v2 jitter block (host_cmd stays
  *     frozen at offset 60).
  * v4: appended the 32-bin PWM-phase histogram of accepted zero-crossings.
- * v5: appended the demag compensation block (demag_events, blanking_len_*). */
-#define HWCI_PERF_VERSION 5u
+ * v5: appended the demag compensation block (demag_events, blanking_len_*).
+ * v6: appended active_demag_interlock_skips (mapping-fault detector). */
+#define HWCI_PERF_VERSION 6u
 
 /* PWM-phase histogram bins (power of two: the binning multiply-shift and the
  * host's modular math both assume it). */
@@ -140,7 +141,13 @@ typedef struct hwci_perf_s {
     uint32_t demag_events;             /* off 148: demag_happened mirror    */
     uint16_t blanking_len_last;        /* off 152: last measured demag time */
     uint16_t blanking_len_max;         /* off 154: worst measured demag time*/
-} hwci_perf_t;                         /* total size: 156 bytes             */
+
+    /* --- v6: active-demag comparator interlock (monotonic; freewheel
+     * turn-ons skipped because the floating phase did not read as
+     * diode-clamped). ~0 healthy; ~= one per commutation means the
+     * step/rising -> FET mapping is wrong for this hardware/direction. */
+    uint32_t active_demag_interlock_skips; /* off 156: interlock vetoes   */
+} hwci_perf_t;                         /* total size: 160 bytes             */
 
 extern volatile hwci_perf_t hwci_perf;
 
@@ -323,6 +330,8 @@ void hwci_perf_reset_stats(void);
                 hwci_perf.blanking_len_last = _bl;                             \
                 if (_bl > hwci_perf.blanking_len_max)                          \
                     hwci_perf.blanking_len_max = _bl;                          \
+                /* active_demag_interlock_skips is incremented in-place from  \
+                 * demagAfterCommutate when HWCI_PERF is on */                \
             }                                                                  \
             if (_ci > hwci_perf.commutation_interval_max)                      \
                 hwci_perf.commutation_interval_max = _ci;                      \

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,14 @@ ifneq ($(DEMAG_COMP),)
 CFLAGS_COMMON += -DHWCI_DEMAG_COMP=$(DEMAG_COMP)
 endif
 
+# Observe-only demag (opt-in, bench diagnostics). With `make <TARGET>
+# DEMAG_COMP=<n> DEMAG_OBSERVE=1` the firmware measures blanking_length and
+# counts demag events but takes no action (no duty cut, no proxy commutation).
+# Used to gather stage-ordering evidence safely on the stand.
+ifeq ($(DEMAG_OBSERVE),1)
+CFLAGS_COMMON += -DHWCI_DEMAG_OBSERVE
+endif
+
 # Linker options
 LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 
@@ -84,7 +92,7 @@ BIN_DIR := $(ROOT)/$(OBJ)
 # Record the flags in a stamp file and make every ELF depend on it: when the
 # flags change, the stamp's contents (and mtime) change and the ELF rebuilds.
 # $(file) is used instead of the shell for portability (no cmd.exe/sh split).
-BUILD_FLAGS := HWCI_PERF=$(HWCI_PERF) DEMAG_COMP=$(DEMAG_COMP)
+BUILD_FLAGS := HWCI_PERF=$(HWCI_PERF) DEMAG_COMP=$(DEMAG_COMP) DEMAG_OBSERVE=$(DEMAG_OBSERVE)
 FLAGS_STAMP := $(OBJ)/.build_flags
 $(shell $(MKDIR) -p $(OBJ))
 PREV_BUILD_FLAGS := $(if $(wildcard $(FLAGS_STAMP)),$(strip $(file < $(FLAGS_STAMP))))

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,21 @@ SRC_COMMON := $(foreach dir,$(SRC_DIRS_COMMON),$(wildcard $(dir)/*.[cs]))
 OBJ := obj
 BIN_DIR := $(ROOT)/$(OBJ)
 
+# Feature flags passed on the command line (HWCI_PERF, DEMAG_COMP) become -D
+# defines but are NOT part of any object's path, so a rebuild with a changed
+# flag would silently reuse stale objects - e.g. an A/B bench run flashing
+# firmware built at the wrong DEMAG_COMP level, or without the perf struct.
+# Record the flags in a stamp file and make every ELF depend on it: when the
+# flags change, the stamp's contents (and mtime) change and the ELF rebuilds.
+# $(file) is used instead of the shell for portability (no cmd.exe/sh split).
+BUILD_FLAGS := HWCI_PERF=$(HWCI_PERF) DEMAG_COMP=$(DEMAG_COMP)
+FLAGS_STAMP := $(OBJ)/.build_flags
+$(shell $(MKDIR) -p $(OBJ))
+PREV_BUILD_FLAGS := $(if $(wildcard $(FLAGS_STAMP)),$(strip $(file < $(FLAGS_STAMP))))
+ifneq ($(PREV_BUILD_FLAGS),$(BUILD_FLAGS))
+$(file > $(FLAGS_STAMP),$(BUILD_FLAGS))
+endif
+
 # Function to check for _CAN suffix
 has_can_suffix = $(findstring _CAN,$1)
 
@@ -127,7 +142,7 @@ LDFLAGS_$(2) = $(LDFLAGS_COMMON) $(LDFLAGS_$(1)) -T$(xLDSCRIPT)
 
 -include $$($(2)_BASENAME).d
 
-$$($(2)_BASENAME).elf: $(SRC_COMMON) $$(SRC_$(1)) $(xSRC)
+$$($(2)_BASENAME).elf: $(SRC_COMMON) $$(SRC_$(1)) $(xSRC) $(FLAGS_STAMP)
 	@$(ECHO) Compiling $$(notdir $$@)
 	$(QUIET)$(MKDIR) -p $(OBJ)
 	$(QUIET)$(xCC) $$(CFLAGS_$(2)) $$(LDFLAGS_$(2)) -MMD -MP -MF $$(@:.elf=.d) -o $$(@) $(SRC_COMMON) $$(SRC_$(1)) $(xSRC)

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,15 @@ ifeq ($(DEMAG_OBSERVE),1)
 CFLAGS_COMMON += -DHWCI_DEMAG_OBSERVE
 endif
 
+# Active demag freewheel (opt-in, off by default). With
+# `make <TARGET> ACTIVE_DEMAG=1` (optionally with DEMAG_COMP for the
+# compensator) forces active_demag at boot without touching eeprom byte 185.
+# Measurement is auto-armed when active_demag is on; DEMAG_COMP is not
+# required for the efficiency path.
+ifeq ($(ACTIVE_DEMAG),1)
+CFLAGS_COMMON += -DHWCI_ACTIVE_DEMAG=1
+endif
+
 # Linker options
 LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 
@@ -92,7 +101,7 @@ BIN_DIR := $(ROOT)/$(OBJ)
 # Record the flags in a stamp file and make every ELF depend on it: when the
 # flags change, the stamp's contents (and mtime) change and the ELF rebuilds.
 # $(file) is used instead of the shell for portability (no cmd.exe/sh split).
-BUILD_FLAGS := HWCI_PERF=$(HWCI_PERF) DEMAG_COMP=$(DEMAG_COMP) DEMAG_OBSERVE=$(DEMAG_OBSERVE)
+BUILD_FLAGS := HWCI_PERF=$(HWCI_PERF) DEMAG_COMP=$(DEMAG_COMP) DEMAG_OBSERVE=$(DEMAG_OBSERVE) ACTIVE_DEMAG=$(ACTIVE_DEMAG)
 FLAGS_STAMP := $(OBJ)/.build_flags
 $(shell $(MKDIR) -p $(OBJ))
 PREV_BUILD_FLAGS := $(if $(wildcard $(FLAGS_STAMP)),$(strip $(file < $(FLAGS_STAMP))))

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,14 @@ ifeq ($(HWCI_PERF),1)
 CFLAGS_COMMON += -DHWCI_PERF
 endif
 
+# Bench enablement for demag compensation (opt-in, off by default).
+# `make <TARGET> DEMAG_COMP=<1|2|3>` forces demag_comp_level at boot regardless
+# of the eeprom (byte 184 stays untouched, so a config-tool flash is not
+# needed between A/B runs). Production/release builds leave it unset.
+ifneq ($(DEMAG_COMP),)
+CFLAGS_COMMON += -DHWCI_DEMAG_COMP=$(DEMAG_COMP)
+endif
+
 # Linker options
 LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 

--- a/Mcu/f051/Inc/phaseouts.h
+++ b/Mcu/f051/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/f051/Src/comparator.c
+++ b/Mcu/f051/Src/comparator.c
@@ -27,6 +27,11 @@ COMP->CSR = COMP->CSR & ~(1<<2);
 }else{
 COMP->CSR  = COMP->CSR | 1<<2;
 }
-  EXTI->RTSR = !rising << 21;
-  EXTI->FTSR = rising << 21;
+  if (auto_blanking) { // look for the demag release edge first, reversed polarity
+    EXTI->RTSR = rising << 21;
+    EXTI->FTSR = !rising << 21;
+  } else {
+    EXTI->RTSR = !rising << 21;
+    EXTI->FTSR = rising << 21;
+  }
 }

--- a/Mcu/f051/Src/comparator.c
+++ b/Mcu/f051/Src/comparator.c
@@ -17,7 +17,14 @@ RAM_FUNC void maskPhaseInterrupts()
   EXTI->PR = EXTI_LINE;
 }
 
-RAM_FUNC void enableCompInterrupts() { EXTI->IMR |= (1 << 21); }
+RAM_FUNC void enableCompInterrupts()
+{
+  EXTI->PR = EXTI_LINE; // discard any edge latched while masked (comStep/PWM
+                        // ring during the wait window) so the first edge after
+                        // unmask is genuine - critical for the demag release
+                        // edge, whose ISR branch has no interval/confirm gate
+  EXTI->IMR |= (1 << 21);
+}
 
 RAM_FUNC void changeCompInput()
 {

--- a/Mcu/f051/Src/phaseouts.c
+++ b/Mcu/f051/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -167,6 +167,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -283,6 +313,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -290,6 +350,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 RAM_FUNC void comStep(char newStep)

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -31,6 +31,7 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void doPWMChanges();
 extern void tenKhzRoutine();
 extern void sendDshotDma();
@@ -192,6 +193,11 @@ void DMA1_Channel4_5_IRQHandler(void)
 RAM_FUNC void ADC1_COMP_IRQHandler(void)
 {
   if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21) != RESET) {
+      if (auto_blanking) { // reversed polarity, this is the demag release edge
+          EXTI->PR = EXTI_LINE;
+          demagEdgeRoutine();
+          return;
+      }
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){
        EXTI->PR = EXTI_LINE;
       interruptRoutine();

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -193,9 +193,14 @@ void DMA1_Channel4_5_IRQHandler(void)
 RAM_FUNC void ADC1_COMP_IRQHandler(void)
 {
   if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21) != RESET) {
-      if (auto_blanking) { // reversed polarity, this is the demag release edge
+      if (auto_blanking) { // reversed polarity: demag release (or post-comm noise)
           EXTI->PR = EXTI_LINE;
-          demagEdgeRoutine();
+          // Min-time gate in the RAM ISR: a release edge cannot precede the
+          // commutation that starts demag. Discard commutation ring without a
+          // flash call into demagEdgeRoutine (major free-run CPU win).
+          if ((INTERVAL_TIMER->CNT) > demag_wait_ticks) {
+              demagEdgeRoutine();
+          }
           return;
       }
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){

--- a/Mcu/g071/Inc/phaseouts.h
+++ b/Mcu/g071/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/g071/Src/comparator.c
+++ b/Mcu/g071/Src/comparator.c
@@ -28,7 +28,20 @@ void maskPhaseInterrupts()
 #endif
 }
 
-void enableCompInterrupts() { EXTI->IMR1 |= current_EXTI_LINE; }
+void enableCompInterrupts()
+{
+    // discard any edge latched while masked so the first edge after unmask is
+    // genuine (the demag release edge branch in the ISR has no interval/confirm
+    // gate); clear both comparator lines so a stale flag on the non-current
+    // line cannot be consumed by the two-line ISR dispatch
+    EXTI->RPR1 = EXTI_LINE;
+    EXTI->FPR1 = EXTI_LINE;
+#ifdef N_VARIANT
+    LL_EXTI_ClearRisingFlag_0_31(LL_EXTI_LINE_17);
+    LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_17);
+#endif
+    EXTI->IMR1 |= current_EXTI_LINE;
+}
 
 void changeCompInput()
 {

--- a/Mcu/g071/Src/comparator.c
+++ b/Mcu/g071/Src/comparator.c
@@ -63,6 +63,17 @@ medium_speed_set = 1;
 #endif
         LL_COMP_ConfigInputs(active_COMP, PHASE_B_COMP, LL_COMP_INPUT_PLUS_IO3);
     }
+    if (auto_blanking) { // look for the demag release edge first, reversed polarity
+        if (rising) {
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_18);
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_17);
+            LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
+        } else {
+            LL_EXTI_EnableFallingTrig_0_31(current_EXTI_LINE);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_17);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_18);
+        }
+    } else {
     if (rising) {
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_18);
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_17);
@@ -71,6 +82,7 @@ medium_speed_set = 1;
         LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_17);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_18);
+    }
     }
 }
 

--- a/Mcu/g071/Src/phaseouts.c
+++ b/Mcu/g071/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -168,6 +168,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -284,6 +314,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -291,6 +351,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 void comStep(int newStep)

--- a/Mcu/g071/Src/stm32g0xx_it.c
+++ b/Mcu/g071/Src/stm32g0xx_it.c
@@ -237,25 +237,35 @@ void DMA1_Channel2_3_IRQHandler(void)
  */
 void ADC1_COMP_IRQHandler(void)
 {
-  if (auto_blanking) { // reversed polarity, this is the demag release edge
+  if (auto_blanking) { // reversed polarity: demag release (or post-comm noise)
+    // Min-time gate: discard edges before demag can start (no flash call).
+    const uint8_t demag_ok = (INTERVAL_TIMER->CNT) > demag_wait_ticks;
     if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_18)) {
       LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_18);
-      demagEdgeRoutine();
+      if (demag_ok) {
+          demagEdgeRoutine();
+      }
       return;
     }
     if (LL_EXTI_IsActiveRisingFlag_0_31(LL_EXTI_LINE_18)) {
       LL_EXTI_ClearRisingFlag_0_31(LL_EXTI_LINE_18);
-      demagEdgeRoutine();
+      if (demag_ok) {
+          demagEdgeRoutine();
+      }
       return;
     }
     if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_17)) {
       LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_17);
-      demagEdgeRoutine();
+      if (demag_ok) {
+          demagEdgeRoutine();
+      }
       return;
     }
     if (LL_EXTI_IsActiveRisingFlag_0_31(LL_EXTI_LINE_17)) {
       LL_EXTI_ClearRisingFlag_0_31(LL_EXTI_LINE_17);
-      demagEdgeRoutine();
+      if (demag_ok) {
+          demagEdgeRoutine();
+      }
       return;
     }
   }

--- a/Mcu/g071/Src/stm32g0xx_it.c
+++ b/Mcu/g071/Src/stm32g0xx_it.c
@@ -77,6 +77,7 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void tenKhzRoutine();
 extern void processDshot();
 
@@ -236,6 +237,28 @@ void DMA1_Channel2_3_IRQHandler(void)
  */
 void ADC1_COMP_IRQHandler(void)
 {
+  if (auto_blanking) { // reversed polarity, this is the demag release edge
+    if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_18)) {
+      LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_18);
+      demagEdgeRoutine();
+      return;
+    }
+    if (LL_EXTI_IsActiveRisingFlag_0_31(LL_EXTI_LINE_18)) {
+      LL_EXTI_ClearRisingFlag_0_31(LL_EXTI_LINE_18);
+      demagEdgeRoutine();
+      return;
+    }
+    if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_17)) {
+      LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_17);
+      demagEdgeRoutine();
+      return;
+    }
+    if (LL_EXTI_IsActiveRisingFlag_0_31(LL_EXTI_LINE_17)) {
+      LL_EXTI_ClearRisingFlag_0_31(LL_EXTI_LINE_17);
+      demagEdgeRoutine();
+      return;
+    }
+  }
   if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_18)) {
     if((INTERVAL_TIMER->CNT) > (average_interval >> 1)){
       LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_18);

--- a/Mcu/g431/Inc/phaseouts.h
+++ b/Mcu/g431/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/g431/Src/comparator.c
+++ b/Mcu/g431/Src/comparator.c
@@ -78,6 +78,17 @@ void changeCompInput()
 
         LL_COMP_ConfigInputs(active_COMP, PHASE_B_COMP, PHASE_B_INPUT_PLUS);
     }
+    if (auto_blanking) { // look for the demag release edge first, reversed polarity
+        if (rising) {
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_22);
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_21);
+            LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
+        } else {
+            LL_EXTI_EnableFallingTrig_0_31(current_EXTI_LINE);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_21);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_22);
+        }
+    } else {
     if (rising) {
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_22);
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_21);
@@ -86,6 +97,7 @@ void changeCompInput()
         LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_21);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_22);
+    }
     }
 }
 

--- a/Mcu/g431/Src/comparator.c
+++ b/Mcu/g431/Src/comparator.c
@@ -51,7 +51,16 @@ void maskPhaseInterrupts()
     EXTI->PR1 = LL_EXTI_LINE_21;
 }
 
-void enableCompInterrupts() { EXTI->IMR1 |= current_EXTI_LINE; }
+void enableCompInterrupts()
+{
+    // discard any edge latched while masked so the first edge after unmask is
+    // genuine (the demag release edge branch in the ISR has no interval/confirm
+    // gate); clear both comparator lines so a stale flag on the non-current
+    // line cannot be consumed by the two-line ISR dispatch
+    EXTI->PR1 = LL_EXTI_LINE_22;
+    EXTI->PR1 = LL_EXTI_LINE_21;
+    EXTI->IMR1 |= current_EXTI_LINE;
+}
 
 void changeCompInput()
 {

--- a/Mcu/g431/Src/phaseouts.c
+++ b/Mcu/g431/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -168,6 +168,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -284,6 +314,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -291,6 +351,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 void comStep(int newStep)

--- a/Mcu/g431/Src/stm32g4xx_it.c
+++ b/Mcu/g431/Src/stm32g4xx_it.c
@@ -9,8 +9,10 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void tenKhzRoutine();
 extern void processDshot();
+extern volatile uint8_t auto_blanking;
 
 extern volatile char send_telemetry;
 uint16_t interrupt_time = 0;
@@ -97,6 +99,18 @@ void DMA1_Channel1_IRQHandler(void)
 
 void COMP1_2_3_IRQHandler(void)
 {
+	if (auto_blanking) { // reversed polarity, this is the demag release edge
+		if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_22)) {
+			LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_22);
+			demagEdgeRoutine();
+			return;
+		}
+		if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21)) {
+			LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_21);
+			demagEdgeRoutine();
+			return;
+		}
+	}
 	if(INTERVAL_TIMER->CNT > (commutation_interval>>1)){
     interrupt++;
     if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_22)) {

--- a/Mcu/g431/Src/stm32g4xx_it.c
+++ b/Mcu/g431/Src/stm32g4xx_it.c
@@ -13,6 +13,7 @@ extern void demagEdgeRoutine();
 extern void tenKhzRoutine();
 extern void processDshot();
 extern volatile uint8_t auto_blanking;
+extern volatile uint16_t demag_wait_ticks;
 
 extern volatile char send_telemetry;
 uint16_t interrupt_time = 0;
@@ -99,15 +100,20 @@ void DMA1_Channel1_IRQHandler(void)
 
 void COMP1_2_3_IRQHandler(void)
 {
-	if (auto_blanking) { // reversed polarity, this is the demag release edge
+	if (auto_blanking) { // reversed polarity: demag release (or post-comm noise)
+		const uint8_t demag_ok = (INTERVAL_TIMER->CNT) > demag_wait_ticks;
 		if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_22)) {
 			LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_22);
-			demagEdgeRoutine();
+			if (demag_ok) {
+				demagEdgeRoutine();
+			}
 			return;
 		}
 		if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21)) {
 			LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_21);
-			demagEdgeRoutine();
+			if (demag_ok) {
+				demagEdgeRoutine();
+			}
 			return;
 		}
 	}

--- a/Mcu/l431/Inc/phaseouts.h
+++ b/Mcu/l431/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/l431/Src/comparator.c
+++ b/Mcu/l431/Src/comparator.c
@@ -25,12 +25,22 @@ void changeCompInput() {
 	if (step == 3 || step == 6) {      // b floating
     LL_COMP_ConfigInputs(MAIN_COMP, PHASE_B_COMP, COMMON_COMP);
 	}
+	if (auto_blanking) { // look for the demag release edge first, reversed polarity
+	if (rising){
+		  LL_EXTI_DisableFallingTrig_0_31(EXTI_LINE);
+		  LL_EXTI_EnableRisingTrig_0_31(EXTI_LINE);
+	}else{
+		  LL_EXTI_DisableRisingTrig_0_31(EXTI_LINE);
+		  LL_EXTI_EnableFallingTrig_0_31(EXTI_LINE);
+	}
+	} else {
 	if (rising){
 		  LL_EXTI_DisableRisingTrig_0_31(EXTI_LINE);
 		  LL_EXTI_EnableFallingTrig_0_31(EXTI_LINE);
 	}else{                          // falling bemf
 		  LL_EXTI_EnableRisingTrig_0_31(EXTI_LINE);
 		  LL_EXTI_DisableFallingTrig_0_31(EXTI_LINE);
+	}
 	}
 }
 

--- a/Mcu/l431/Src/comparator.c
+++ b/Mcu/l431/Src/comparator.c
@@ -12,6 +12,9 @@ void maskPhaseInterrupts(){
 }
 
 void enableCompInterrupts(){
+	LL_EXTI_ClearFlag_0_31(EXTI_LINE); // discard any edge latched while masked so
+	                                   // the first edge after unmask is genuine
+	                                   // (demag release branch has no gate)
     EXTI->IMR1 |= EXTI_LINE;
 }
 

--- a/Mcu/l431/Src/phaseouts.c
+++ b/Mcu/l431/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -167,6 +167,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -283,6 +313,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -290,6 +350,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 void comStep(char newStep)

--- a/Mcu/l431/Src/stm32l4xx_it.c
+++ b/Mcu/l431/Src/stm32l4xx_it.c
@@ -278,9 +278,12 @@ void COMP_IRQHandler(void)
 {
 
     if (LL_EXTI_IsActiveFlag_0_31(EXTI_LINE) != RESET) {
-      if (auto_blanking) { // reversed polarity, this is the demag release edge
+      if (auto_blanking) { // reversed polarity: demag release (or post-comm noise)
           LL_EXTI_ClearFlag_0_31(EXTI_LINE);
-          demagEdgeRoutine();
+          // Min-time gate: discard edges before demag can start (no flash call).
+          if ((INTERVAL_TIMER->CNT) > demag_wait_ticks) {
+              demagEdgeRoutine();
+          }
           return;
       }
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){

--- a/Mcu/l431/Src/stm32l4xx_it.c
+++ b/Mcu/l431/Src/stm32l4xx_it.c
@@ -30,6 +30,7 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void tenKhzRoutine();
 extern void processDshot();
 
@@ -277,10 +278,15 @@ void COMP_IRQHandler(void)
 {
 
     if (LL_EXTI_IsActiveFlag_0_31(EXTI_LINE) != RESET) {
+      if (auto_blanking) { // reversed polarity, this is the demag release edge
+          LL_EXTI_ClearFlag_0_31(EXTI_LINE);
+          demagEdgeRoutine();
+          return;
+      }
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){
        LL_EXTI_ClearFlag_0_31(EXTI_LINE);
       interruptRoutine();
-  }else{ 
+  }else{
       if (getCompOutputLevel() == rising){
       LL_EXTI_ClearFlag_0_31(EXTI_LINE);
   }

--- a/Src/hwci_perf.c
+++ b/Src/hwci_perf.c
@@ -47,6 +47,7 @@ void hwci_perf_reset_stats(void)
     hwci_perf.main_loop_us_max = 0;
     hwci_perf.commutation_interval_max = 0;
     hwci_perf.zc_jitter_max = 0;
+    hwci_perf.blanking_len_max = 0;
 }
 
 /*

--- a/Src/main.c
+++ b/Src/main.c
@@ -380,6 +380,13 @@ uint8_t active_demag = 0; // circulate demag current through the fet instead of 
 volatile uint8_t active_demag_fet_on = 0;
 volatile uint16_t active_demag_ticks = 0; // fet on time, half of last measured demag time
 volatile uint32_t demag_happened = 0;
+uint32_t demag_prev_interval = 0; // last commutation interval, for the arm stability gate
+volatile uint8_t demag_stable_count = 0; // consecutive low-slew commutations
+volatile uint16_t demag_cut_holdoff = 0; // 10khz ticks until another duty cut is allowed
+volatile uint8_t demag_restore_pending = 0; // COM_TIMER is restoring normal polarity, not commutating
+#define DEMAG_ARM_STABLE_COUNT 8 // steady commutations required before arming
+#define DEMAG_CUT_HOLDOFF_TICKS (LOOP_FREQUENCY_HZ / 100) // one duty cut per 10 ms
+#define DEMAG_RESTORE_MARGIN_TICKS 12 // restore normal polarity at least 6 us before expected ZC
 
 // Reset all per-run demag state. Called wherever commutation (re)starts or a
 // fault tears down the running state, so no stale armed polarity, cut, or
@@ -389,6 +396,12 @@ static inline void resetDemagState(void)
 {
     auto_blanking = 0;
     demag_cut_pending = 0;
+    demag_restore_pending = 0;
+    demag_wait_ticks = 0;
+    blanking_length = 0;
+    demag_prev_interval = 0;
+    demag_stable_count = 0; // require fresh stability evidence after any restart
+    demag_cut_holdoff = 0;
     active_demag_fet_on = 0;
     active_demag_ticks = 0;
 }
@@ -609,6 +622,109 @@ volatile uint16_t duty_cycle = 0;
 char step = 1;
 volatile uint32_t commutation_interval = 12500;
 volatile uint16_t waitTime = 0;
+#ifdef HAS_DEMAG_COMP
+static inline void demagClearMeasurement(void)
+{
+    blanking_length = 0;
+    active_demag_ticks = 0;
+}
+
+static inline uint8_t demagReleaseLevelReached(void)
+{
+    return getCompOutputLevel() == rising;
+}
+
+static inline void demagRestoreNormalPolarity(void)
+{
+    auto_blanking = 0;
+    changeCompInput();
+}
+
+static void __attribute__((noinline)) demagRecordReleaseLength(uint16_t time_since_zc, uint16_t wait_ticks)
+{
+    blanking_length = time_since_zc - wait_ticks;
+    if (blanking_length > average_interval) {
+        blanking_length = average_interval; // measurement can't be longer than a commutation
+    }
+    active_demag_ticks = blanking_length >> 1; // active freewheel for half the measured demag time
+    if (active_demag_ticks > (wait_ticks >> 1)) {
+        active_demag_ticks = wait_ticks >> 1; // fet always off well before the expected zero cross
+    }
+}
+
+static void __attribute__((noinline)) demagRecordRestoreTimeout(uint16_t time_since_zc, uint16_t wait_ticks)
+{
+    if (time_since_zc > wait_ticks) {
+        blanking_length = time_since_zc - wait_ticks;
+        if (blanking_length > average_interval) {
+            blanking_length = average_interval;
+        }
+    } else {
+        blanking_length = 0;
+    }
+    active_demag_ticks = 0;
+}
+
+#ifndef HWCI_DEMAG_OBSERVE
+static void __attribute__((noinline)) demagApplyDutyCut(void)
+{
+    if (demag_cut_holdoff) {
+        return;
+    }
+    demag_cut_holdoff = DEMAG_CUT_HOLDOFF_TICKS;
+    uint16_t dc = duty_cycle; // snapshot, ISRs can change duty_cycle between reads
+    uint16_t demag_cut;
+    switch (demag_comp_level) {
+    case 1:
+        demag_cut = dc - (dc >> 2); // cut 25 percent
+        break;
+    case 2:
+        demag_cut = dc >> 1; // cut 50 percent
+        break;
+    case 3:
+        demag_cut = dc >> 2; // cut 75 percent
+        break;
+    default:
+        demag_cut = dc; // no cut
+        break;
+    }
+    if (demag_cut < minimum_duty_cycle) {
+        demag_cut = minimum_duty_cycle;
+    }
+    demag_cut_latch = demag_cut;
+    demag_cut_pending = 1;
+}
+#endif
+
+static void __attribute__((noinline)) demagMaybeApplyCompensation(void)
+{
+    if (blanking_length > (average_interval >> 1)) { // demag ran past the expected zero cross point
+        demag_happened++;
+#ifndef HWCI_DEMAG_OBSERVE
+        demagApplyDutyCut();
+#endif
+    }
+}
+
+static uint16_t __attribute__((noinline)) demagRestoreDelayTicks(void)
+{
+    uint32_t restore_at = commutation_interval;
+    if (restore_at > DEMAG_RESTORE_MARGIN_TICKS) {
+        restore_at -= DEMAG_RESTORE_MARGIN_TICKS;
+    } else {
+        restore_at = 1;
+    }
+    uint32_t now = INTERVAL_TIMER_COUNT;
+    if (restore_at <= now + 1u) {
+        return 1;
+    }
+    uint32_t delay = restore_at - now;
+    if (delay > 0xFFFEu) {
+        return 0xFFFEu;
+    }
+    return (uint16_t)delay;
+}
+#endif
 // ISR-written, compared by the main loop signal-loss failsafe
 volatile uint16_t signaltimeout = 0;
 uint8_t ubAnalogWatchdogStatus = RESET;
@@ -961,6 +1077,24 @@ RAM_FUNC void commutate()
 RAM_FUNC void PeriodElapsedCallback()
 {
     DISABLE_COM_TIMER_INT(); // disable interrupt
+#ifdef HAS_DEMAG_COMP
+    if (demag_restore_pending) {
+        demag_restore_pending = 0;
+        if (auto_blanking) {
+            uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
+            uint16_t wait_ticks = demag_wait_ticks;
+            if (demagReleaseLevelReached()) {
+                demagClearMeasurement(); // release edge happened before/past the armed window
+            } else {
+                demagRecordRestoreTimeout(time_since_zc, wait_ticks);
+                demagMaybeApplyCompensation();
+            }
+            demagRestoreNormalPolarity();
+            enableCompInterrupts();
+        }
+        return;
+    }
+#endif
     commutate();
     commutation_interval = ((commutation_interval)+((lastzctime + thiszctime) >> 1))>>1;
   	if (!eepromBuffer.auto_advance) {
@@ -969,6 +1103,17 @@ RAM_FUNC void PeriodElapsedCallback()
 	  advance = (commutation_interval * auto_advance_level) >> 6; // 60 divde 64 0.9375 degree increments
     }
     waitTime = (commutation_interval >> 1) - advance;
+#ifdef HAS_DEMAG_COMP
+    if (!old_routine && auto_blanking) {
+        if (demagReleaseLevelReached()) {
+            demagClearMeasurement(); // edge was already past when interrupts were masked
+            demagRestoreNormalPolarity();
+        } else {
+            demag_restore_pending = 1;
+            SET_AND_ENABLE_COM_INT(demagRestoreDelayTicks());
+        }
+    }
+#endif
     if (!old_routine) {
         enableCompInterrupts(); // enable comp interrupt
     }
@@ -1111,13 +1256,39 @@ RAM_FUNC void interruptRoutine()
     thiszctime = INTERVAL_TIMER_COUNT;
 #endif
     SET_INTERVAL_TIMER_COUNT(0);
+#ifdef HAS_DEMAG_COMP
+    demag_restore_pending = 0; // this COM_TIMER schedule is for commutation
+#endif
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
 #ifdef HAS_DEMAG_COMP
-    if (demag_comp_level && (input > 400) && (commutation_interval > 100)) {
+    // Stability gate: only arm the demag watch on a locked, steady commutation.
+    // Bench (hwci/DEMAG_BENCH_FINDINGS.md): arming straight through a snap-step
+    // acceleration let the comp fire on switching transients exactly when
+    // timing margin was thinnest, collapsing the motor. Demag compensation
+    // only matters at sustained load, so require sync lock (zero_crosses) plus
+    // a run of consecutive low-slew commutation intervals before arming.
+    {
+        const uint32_t ci = commutation_interval;
+        const uint32_t slew = (ci > demag_prev_interval)
+            ? (ci - demag_prev_interval)
+            : (demag_prev_interval - ci);
+        demag_prev_interval = ci;
+        if (slew > (ci >> 3)) { // interval step >12.5 percent = transient
+            demag_stable_count = 0;
+        } else if (demag_stable_count < DEMAG_ARM_STABLE_COUNT) {
+            demag_stable_count++;
+        }
+    }
+    if (demag_comp_level && (input > 400) && (commutation_interval > 100)
+        && (zero_crosses >= 100)
+        && (demag_stable_count >= DEMAG_ARM_STABLE_COUNT)) {
         auto_blanking = 1; // next commutation watches for the demag release edge first
         demag_wait_ticks = waitTime; // the zc->commutation delay THIS cycle is
         // scheduled with; PeriodElapsedCallback recomputes waitTime for the next
         // cycle before the demag edge fires, so snapshot it for the measurement
+    } else {
+        auto_blanking = 0;
+        demag_wait_ticks = 0;
     }
 #endif
     __enable_irq();
@@ -1130,63 +1301,50 @@ RAM_FUNC void interruptRoutine()
  *          polarity edge fires while auto_blanking is armed. This is the
  *          moment the freewheel diode stops clamping the floating phase;
  *          the time from commutation to this edge is the demag time.
- *          RAM_FUNC is mandatory: the caller is a RAM-resident ISR.
+ *          Keep this in flash: the demag path is optional/diagnostic, and the
+ *          F051 HWCI build needs the RAM for the hot zero-cross/commutation
+ *          ISRs. The flash-call latency is below the 0.5 us timer tick.
  */
-RAM_FUNC void demagEdgeRoutine()
+void demagEdgeRoutine()
 {
     uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
     uint16_t wait_ticks = demag_wait_ticks; // the delay THIS cycle was scheduled with
-    auto_blanking = 0;
-    changeCompInput(); // polarity back to normal to catch the real zero cross
-    if (time_since_zc > wait_ticks) { // commutation happened at ~wait_ticks after the last zero cross
-        blanking_length = time_since_zc - wait_ticks;
-        if (blanking_length > average_interval) {
-            blanking_length = average_interval; // measurement can't be longer than a commutation
-        }
-        active_demag_ticks = blanking_length >> 1; // active freewheel for half the measured demag time
-        if (active_demag_ticks > (wait_ticks >> 1)) {
-            active_demag_ticks = wait_ticks >> 1; // fet always off well before the expected zero cross
-        }
-    } else { // edge fired before commutation: noise, measurement is invalid
-        blanking_length = 0;
-        active_demag_ticks = 0; // no stale active freewheel from a bad measurement
+    // Keep demag_restore_pending set while cancelling: if the fallback update
+    // was already pending, PeriodElapsedCallback() must consume it as a stale
+    // restore timer instead of treating it as a commutation timer.
+    DISABLE_COM_TIMER_INT();
+    demagRestoreNormalPolarity(); // catch the real zero cross after the release edge
+    if (time_since_zc <= wait_ticks) {
+        // Minimum-time gate, mirroring the normal ZC path's interval gate: a
+        // release edge cannot precede the commutation that starts the demag,
+        // so this is switching noise. Skip this cycle's measurement; the
+        // normal-polarity zero-cross hunt is already restored above.
+        demagClearMeasurement();
+        return;
     }
-    if (blanking_length > (average_interval >> 1)) { // demag ran past the expected zero cross point
-        demag_happened++;
-        allOff(); // power off until next commutation, winding current must decay
-        uint16_t dc = duty_cycle; // snapshot, ISRs can change duty_cycle between reads
-        uint16_t demag_cut;
-        switch (demag_comp_level) {
-        case 1:
-            demag_cut = dc - (dc >> 2); // cut 25 percent
-            break;
-        case 2:
-            demag_cut = dc >> 1; // cut 50 percent
-            break;
-        case 3:
-            demag_cut = dc >> 2; // cut 75 percent
-            break;
-        default:
-            demag_cut = dc; // no cut
-            break;
+    // Confirm the edge with the same glitch-tolerant discipline as the normal
+    // zero-cross path: polarity is reversed while armed, so the settled
+    // post-release level reads == rising (the normal path rejects on == rising).
+    // Rejection means commutation ringing, not a release: skip the measurement
+    // and let the restored normal-polarity hunt catch the real zero cross.
+    {
+        int bad = 0;
+        const int tolerance = filter_level >> 2;
+        for (int i = 0; i < filter_level; i++) {
+            if (getCompOutputLevel() != rising) {
+                if (++bad > tolerance) {
+                    demagClearMeasurement();
+                    return;
+                }
+            }
         }
-        if (demag_cut < minimum_duty_cycle) {
-            demag_cut = minimum_duty_cycle;
-        }
-        // Hand the cut to tenKhzRoutine instead of writing duty_cycle/
-        // last_duty_cycle here: this ISR preempts tenKhzRoutine, and its
-        // unguarded "last_duty_cycle = duty_cycle" write-back would otherwise
-        // clobber a directly-written cut. The PWM CCRs only change in
-        // tenKhzRoutine anyway, so applying the cut there is race-free and
-        // takes effect on the same tick the old direct write would have.
-        demag_cut_latch = demag_cut;
-        demag_cut_pending = 1;
-        // Re-entering interruptRoutine() is safe: auto_blanking is already
-        // cleared so the comparator re-arms with normal polarity, and the
-        // zero-cross confirm loop at its top guards against treating this
-        // demag edge as a false commutation.
-        interruptRoutine();
     }
+    demagRecordReleaseLength(time_since_zc, wait_ticks);
+    // Softened response (bench: allOff() + uncapped cuts + proxy commutation
+    // sustained the very desync this feature should prevent). No allOff() and
+    // no re-entrant interruptRoutine(); restore normal polarity and let the
+    // confirmed zero-cross path schedule the next commutation.
+    demagMaybeApplyCompensation();
 }
 #endif
 
@@ -1590,6 +1748,9 @@ RAM_FUNC void tenKhzRoutine()
         if (duty_cycle > cut) {
             duty_cycle = cut; // and cut this tick's output immediately
         }
+    }
+    if (demag_cut_holdoff) {
+        demag_cut_holdoff--; // walk down the cut rate-limit window
     }
 #endif
     tenkhzcounter++;

--- a/Src/main.c
+++ b/Src/main.c
@@ -384,9 +384,21 @@ uint32_t demag_prev_interval = 0; // last commutation interval, for the arm stab
 volatile uint8_t demag_stable_count = 0; // consecutive low-slew commutations
 volatile uint16_t demag_cut_holdoff = 0; // 10khz ticks until another duty cut is allowed
 volatile uint8_t demag_restore_pending = 0; // COM_TIMER is restoring normal polarity, not commutating
+volatile uint8_t demag_miss_streak = 0; // consecutive failed demag measures (CPU gate)
 #define DEMAG_ARM_STABLE_COUNT 8 // steady commutations required before arming
+// Min commutation interval to arm demag (INTERVAL_TIMER 0.5 us ticks). Below
+// this the step is too short for freewheel benefit and the reverse-polarity
+// path starves DShot (bench: ark-release holds 95% free-run at ~79% CPU;
+// armed demag path hit 100% and signaltimeout-reset near ci~70).
+// 120 ticks = 60 us => ~16.7 k commutations/s ceiling for the demag path.
+#define DEMAG_ARM_MIN_INTERVAL 120u
 #define DEMAG_CUT_HOLDOFF_TICKS (LOOP_FREQUENCY_HZ / 100) // one duty cut per 10 ms
 #define DEMAG_RESTORE_MARGIN_TICKS 12 // restore normal polarity at least 6 us before expected ZC
+#define ACTIVE_DEMAG_MIN_TICKS 3 // skip freewheel if the scheduled window is too short
+// After this many failed measures, stop arming every step (free-run has no
+// demag). Re-probe every 32 zero-crosses so load return re-enables freewheel.
+#define DEMAG_MISS_STREAK_MAX 24u
+#define DEMAG_MISS_REPROBE_MASK 31u
 
 // Reset all per-run demag state. Called wherever commutation (re)starts or a
 // fault tears down the running state, so no stale armed polarity, cut, or
@@ -404,7 +416,32 @@ static inline void resetDemagState(void)
     demag_cut_holdoff = 0;
     active_demag_fet_on = 0;
     active_demag_ticks = 0;
+    demag_miss_streak = 0;
 }
+
+// Hot-path FET off: only call into phaseouts when the freewheel FET is on.
+static inline void activeDemagForceOff(void)
+{
+#ifdef HAS_PHASE_HIGH
+    if (active_demag_fet_on) {
+        activeDemagFetOff();
+        active_demag_fet_on = 0;
+    }
+#endif
+}
+
+static inline void demagNoteMiss(void)
+{
+    if (demag_miss_streak < 255u) {
+        demag_miss_streak++;
+    }
+}
+
+static inline void demagNoteHit(void)
+{
+    demag_miss_streak = 0;
+}
+
 char maximum_throttle_change_ramp = 1;
 
 char crawler_mode = 0; // no longer used //
@@ -627,6 +664,7 @@ static inline void demagClearMeasurement(void)
 {
     blanking_length = 0;
     active_demag_ticks = 0;
+    demagNoteMiss();
 }
 
 static inline uint8_t demagReleaseLevelReached(void)
@@ -650,6 +688,7 @@ static void __attribute__((noinline)) demagRecordReleaseLength(uint16_t time_sin
     if (active_demag_ticks > (wait_ticks >> 1)) {
         active_demag_ticks = wait_ticks >> 1; // fet always off well before the expected zero cross
     }
+    demagNoteHit();
 }
 
 static void __attribute__((noinline)) demagRecordRestoreTimeout(uint16_t time_since_zc, uint16_t wait_ticks)
@@ -724,7 +763,91 @@ static uint16_t __attribute__((noinline)) demagRestoreDelayTicks(void)
     }
     return (uint16_t)delay;
 }
+
+// Flash helpers (NOT RAM_FUNC): PeriodElapsedCallback is RAM-resident on F051;
+// demag/active-demag bodies stay in flash to fit the 8 KB HWCI RAM budget.
+// Call sites MUST gate on auto_blanking / active_demag_fet_on so the free-run
+// hot path does not pay a flash call every commutation when demag is idle.
+
+// COM_TIMER fired for demag polarity restore (no active freewheel pending).
+static void __attribute__((noinline)) demagOnRestoreTimer(void)
+{
+    demag_restore_pending = 0;
+    if (auto_blanking) {
+        uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
+        uint16_t wait_ticks = demag_wait_ticks;
+        if (demagReleaseLevelReached()) {
+            demagClearMeasurement(); // demag already done / never saw release
+        } else {
+            demagRecordRestoreTimeout(time_since_zc, wait_ticks);
+            demagMaybeApplyCompensation();
+            // No release edge within the restore window: treat as a miss so
+            // free-run (empty demag) stops paying the reverse-polarity tax.
+            demagNoteMiss();
+        }
+        demagRestoreNormalPolarity();
+        enableCompInterrupts();
+    }
+}
+
+#ifdef HAS_PHASE_HIGH
+// COM_TIMER fired for the end of the active freewheel window.
+static void __attribute__((noinline)) activeDemagOnFetOffTimer(void)
+{
+    activeDemagFetOff();
+    active_demag_fet_on = 0;
+    if (!old_routine && auto_blanking) {
+        if (demagReleaseLevelReached()) {
+            demagClearMeasurement();
+            demagRestoreNormalPolarity();
+        } else {
+            demag_restore_pending = 1;
+            SET_AND_ENABLE_COM_INT(demagRestoreDelayTicks());
+        }
+    }
+}
+
+// After commutation + ZC metrics: arm demag restore / active freewheel.
+// Caller only invokes this when auto_blanking is set.
+static void __attribute__((noinline)) demagAfterCommutate(void)
+{
+    uint8_t demag_need_restore = 0;
+    if (!old_routine) {
+        if (demagReleaseLevelReached()) {
+            demagClearMeasurement();
+            demagRestoreNormalPolarity();
+            return; // demag already over; normal ZC hunt restored, no extra COM
+        }
+        demag_need_restore = 1;
+    }
+    if (active_demag && running
+        && (active_demag_ticks > ACTIVE_DEMAG_MIN_TICKS)) {
+        // Interlock: diode-clamped floating phase reads post-cross (!rising).
+        // Pre-cross = wrong FET mapping or demag already released.
+        if (getCompOutputLevel() == (uint8_t)rising) {
+#ifdef HWCI_PERF
+            hwci_perf.active_demag_interlock_skips++;
 #endif
+        } else {
+            uint16_t t = active_demag_ticks;
+            if (t > (waitTime >> 1)) {
+                t = waitTime >> 1;
+            }
+            if (t > ACTIVE_DEMAG_MIN_TICKS) {
+                activeDemagFetOn();
+                active_demag_fet_on = 1;
+                SET_AND_ENABLE_COM_INT(t);
+                return; // restore re-armed on FET-off
+            }
+        }
+    }
+    if (demag_need_restore) {
+        demag_restore_pending = 1;
+        SET_AND_ENABLE_COM_INT(demagRestoreDelayTicks());
+    }
+}
+#endif /* HAS_PHASE_HIGH */
+#endif /* HAS_DEMAG_COMP */
 // ISR-written, compared by the main loop signal-loss failsafe
 volatile uint16_t signaltimeout = 0;
 uint8_t ubAnalogWatchdogStatus = RESET;
@@ -957,7 +1080,13 @@ void loadEEpromSettings()
     if (eepromBuffer.can.active_demag > 1) { // erased flash reads 0xff, default off
         eepromBuffer.can.active_demag = 0;
     }
-    active_demag = eepromBuffer.can.active_demag && demag_comp_level; // needs the demag time measurement running
+    // Active demag is independent of the duty-cut compensator: it only needs
+    // the demag-time measurement (armed whenever active_demag OR demag_comp
+    // is on). Compensation level 0 + active_demag 1 is the efficiency path.
+    active_demag = eepromBuffer.can.active_demag;
+#ifdef HWCI_ACTIVE_DEMAG
+    active_demag = 1; // bench build: force freewheel on without touching eeprom
+#endif
 #else
     demag_comp_level = 0;
     active_demag = 0;
@@ -1079,19 +1208,15 @@ RAM_FUNC void PeriodElapsedCallback()
     DISABLE_COM_TIMER_INT(); // disable interrupt
 #ifdef HAS_DEMAG_COMP
     if (demag_restore_pending) {
-        demag_restore_pending = 0;
-        if (auto_blanking) {
-            uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
-            uint16_t wait_ticks = demag_wait_ticks;
-            if (demagReleaseLevelReached()) {
-                demagClearMeasurement(); // release edge happened before/past the armed window
-            } else {
-                demagRecordRestoreTimeout(time_since_zc, wait_ticks);
-                demagMaybeApplyCompensation();
-            }
-            demagRestoreNormalPolarity();
-            enableCompInterrupts();
-        }
+        demagOnRestoreTimer(); // flash helper: keeps this RAM_FUNC small
+        return;
+    }
+#endif
+#ifdef HAS_PHASE_HIGH
+    // Second COM_TIMER event this step: end of active freewheel. Guard before
+    // commutate()/HWCI_PERF_ZC so this never double-counts a commutation.
+    if (active_demag_fet_on) {
+        activeDemagOnFetOffTimer(); // flash helper
         return;
     }
 #endif
@@ -1103,24 +1228,20 @@ RAM_FUNC void PeriodElapsedCallback()
 	  advance = (commutation_interval * auto_advance_level) >> 6; // 60 divde 64 0.9375 degree increments
     }
     waitTime = (commutation_interval >> 1) - advance;
-#ifdef HAS_DEMAG_COMP
-    if (!old_routine && auto_blanking) {
-        if (demagReleaseLevelReached()) {
-            demagClearMeasurement(); // edge was already past when interrupts were masked
-            demagRestoreNormalPolarity();
-        } else {
-            demag_restore_pending = 1;
-            SET_AND_ENABLE_COM_INT(demagRestoreDelayTicks());
-        }
-    }
-#endif
     if (!old_routine) {
         enableCompInterrupts(); // enable comp interrupt
     }
     if (zero_crosses < 10000) {
         zero_crosses++;
     }
-    HWCI_PERF_ZC();
+    HWCI_PERF_ZC(); // demag/active-demag scheduling stays after so jitter is unaffected
+#ifdef HAS_PHASE_HIGH
+    // Only when this step is demag-armed: a flash call every commutation while
+    // auto_blanking==0 cost ~5-10% CPU at free-run (bench A/B vs ark-release).
+    if (auto_blanking) {
+        demagAfterCommutate();
+    }
+#endif
 }
 
 /*
@@ -1249,6 +1370,13 @@ RAM_FUNC void interruptRoutine()
 #endif
     __disable_irq();
     maskPhaseInterrupts();
+#ifdef HAS_PHASE_HIGH
+    // True ZC arrived before the active freewheel off-event: float the phase
+    // and clear the flag or the next COM_TIMER event is eaten by the FET-off
+    // guard at the top of PeriodElapsedCallback (and would skip commutation).
+    // Inline check: no flash call when freewheel is idle (common path).
+    activeDemagForceOff();
+#endif
     lastzctime = thiszctime;
 #ifdef MCU_F051
     thiszctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
@@ -1261,13 +1389,10 @@ RAM_FUNC void interruptRoutine()
 #endif
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
 #ifdef HAS_DEMAG_COMP
-    // Stability gate: only arm the demag watch on a locked, steady commutation.
-    // Bench (hwci/DEMAG_BENCH_FINDINGS.md): arming straight through a snap-step
-    // acceleration let the comp fire on switching transients exactly when
-    // timing margin was thinnest, collapsing the motor. Demag compensation
-    // only matters at sustained load, so require sync lock (zero_crosses) plus
-    // a run of consecutive low-slew commutation intervals before arming.
-    {
+    // Arm demag measurement only when a feature wants it and the step is long
+    // enough that reverse-polarity watching is affordable. Skip all of this
+    // when demag is off so the ZC path matches ark-release cost.
+    if (demag_comp_level || active_demag) {
         const uint32_t ci = commutation_interval;
         const uint32_t slew = (ci > demag_prev_interval)
             ? (ci - demag_prev_interval)
@@ -1278,14 +1403,21 @@ RAM_FUNC void interruptRoutine()
         } else if (demag_stable_count < DEMAG_ARM_STABLE_COUNT) {
             demag_stable_count++;
         }
-    }
-    if (demag_comp_level && (input > 400) && (commutation_interval > 100)
-        && (zero_crosses >= 100)
-        && (demag_stable_count >= DEMAG_ARM_STABLE_COUNT)) {
-        auto_blanking = 1; // next commutation watches for the demag release edge first
-        demag_wait_ticks = waitTime; // the zc->commutation delay THIS cycle is
-        // scheduled with; PeriodElapsedCallback recomputes waitTime for the next
-        // cycle before the demag edge fires, so snapshot it for the measurement
+        // Re-probe occasionally after a miss streak so a prop load can
+        // re-enable freewheel without staying dark forever.
+        const uint8_t miss_ok = (demag_miss_streak < DEMAG_MISS_STREAK_MAX)
+            || ((zero_crosses & DEMAG_MISS_REPROBE_MASK) == 0u);
+        if ((input > 400)
+            && (ci > DEMAG_ARM_MIN_INTERVAL)
+            && (zero_crosses >= 100)
+            && (demag_stable_count >= DEMAG_ARM_STABLE_COUNT)
+            && miss_ok) {
+            auto_blanking = 1;
+            demag_wait_ticks = waitTime; // snapshot: waitTime recomputed next cycle
+        } else {
+            auto_blanking = 0;
+            demag_wait_ticks = 0;
+        }
     } else {
         auto_blanking = 0;
         demag_wait_ticks = 0;
@@ -1309,30 +1441,37 @@ void demagEdgeRoutine()
 {
     uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
     uint16_t wait_ticks = demag_wait_ticks; // the delay THIS cycle was scheduled with
+    // Demag is over: freewheel current is gone. If the active freewheel FET is
+    // still on it would now fight BEMF - float it and cancel the COM FET-off
+    // (or demag-restore) event that may still be pending.
+    activeDemagForceOff();
     DISABLE_COM_TIMER_INT();
 #ifdef MCU_F051
     LL_TIM_ClearFlag_UPDATE(COM_TIMER);
     NVIC_ClearPendingIRQ(COM_TIMER_IRQ);
-    demag_restore_pending = 0;
 #endif
+    demag_restore_pending = 0;
     demagRestoreNormalPolarity(); // catch the real zero cross after the release edge
     if (time_since_zc <= wait_ticks) {
-        // Minimum-time gate, mirroring the normal ZC path's interval gate: a
-        // release edge cannot precede the commutation that starts the demag,
-        // so this is switching noise. Skip this cycle's measurement; the
-        // normal-polarity zero-cross hunt is already restored above.
+        // Minimum-time gate (also applied in the MCU ISR before this call when
+        // possible): release cannot precede commutation - switching noise.
         demagClearMeasurement();
         return;
     }
-    // Confirm the edge with the same glitch-tolerant discipline as the normal
-    // zero-cross path: polarity is reversed while armed, so the settled
-    // post-release level reads == rising (the normal path rejects on == rising).
-    // Rejection means commutation ringing, not a release: skip the measurement
-    // and let the restored normal-polarity hunt catch the real zero cross.
+    // Confirm with glitch-tolerant sampling. Cap the window at high eRPM so a
+    // reverse-polarity noise burst cannot burn a full filter_level of samples
+    // every step (bench CPU regression at free-run).
     {
         int bad = 0;
-        const int tolerance = filter_level >> 2;
-        for (int i = 0; i < filter_level; i++) {
+        int n = filter_level;
+        if (n > 12) {
+            n = 12;
+        }
+        if (average_interval < 200u && n > 6) {
+            n = 6; // short steps: less confirm budget
+        }
+        const int tolerance = n >> 2;
+        for (int i = 0; i < n; i++) {
             if (getCompOutputLevel() != rising) {
                 if (++bad > tolerance) {
                     demagClearMeasurement();
@@ -1342,10 +1481,7 @@ void demagEdgeRoutine()
         }
     }
     demagRecordReleaseLength(time_since_zc, wait_ticks);
-    // Softened response (bench: allOff() + uncapped cuts + proxy commutation
-    // sustained the very desync this feature should prevent). No allOff() and
-    // no re-entrant interruptRoutine(); restore normal polarity and let the
-    // confirmed zero-cross path schedule the next commutation.
+    // Softened response: no allOff, no re-entrant interruptRoutine.
     demagMaybeApplyCompensation();
 }
 #endif

--- a/Src/main.c
+++ b/Src/main.c
@@ -824,6 +824,9 @@ void loadEEpromSettings()
         eepromBuffer.can.active_demag = 0;
     }
     active_demag = eepromBuffer.can.active_demag && demag_comp_level; // needs the demag time measurement running
+#ifdef HWCI_DEMAG_COMP
+    demag_comp_level = HWCI_DEMAG_COMP; // bench build: force on without touching the eeprom
+#endif
 #else
     demag_comp_level = 0;
     active_demag = 0;

--- a/Src/main.c
+++ b/Src/main.c
@@ -1309,10 +1309,12 @@ void demagEdgeRoutine()
 {
     uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
     uint16_t wait_ticks = demag_wait_ticks; // the delay THIS cycle was scheduled with
-    // Keep demag_restore_pending set while cancelling: if the fallback update
-    // was already pending, PeriodElapsedCallback() must consume it as a stale
-    // restore timer instead of treating it as a commutation timer.
     DISABLE_COM_TIMER_INT();
+#ifdef MCU_F051
+    LL_TIM_ClearFlag_UPDATE(COM_TIMER);
+    NVIC_ClearPendingIRQ(COM_TIMER_IRQ);
+    demag_restore_pending = 0;
+#endif
     demagRestoreNormalPolarity(); // catch the real zero cross after the release edge
     if (time_since_zc <= wait_ticks) {
         // Minimum-time gate, mirroring the normal ZC path's interval gate: a

--- a/Src/main.c
+++ b/Src/main.c
@@ -1094,9 +1094,71 @@ RAM_FUNC void interruptRoutine()
 #endif
     SET_INTERVAL_TIMER_COUNT(0);
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
+    if (demag_comp_level && (input > 400) && (commutation_interval > 100)) {
+        auto_blanking = 1; // next commutation watches for the demag release edge first
+    }
     __enable_irq();
     HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase
 }
+
+#ifdef HAS_DEMAG_COMP
+/*
+ * @brief   Called by the comparator interrupt handler when the reversed
+ *          polarity edge fires while auto_blanking is armed. This is the
+ *          moment the freewheel diode stops clamping the floating phase;
+ *          the time from commutation to this edge is the demag time.
+ *          RAM_FUNC is mandatory: the caller is a RAM-resident ISR.
+ */
+RAM_FUNC void demagEdgeRoutine()
+{
+    uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
+    auto_blanking = 0;
+    changeCompInput(); // polarity back to normal to catch the real zero cross
+    if (time_since_zc > waitTime) { // commutation happened at ~waitTime after the last zero cross
+        blanking_length = time_since_zc - waitTime;
+        if (blanking_length > average_interval) {
+            blanking_length = average_interval; // measurement can't be longer than a commutation
+        }
+        active_demag_ticks = blanking_length >> 1; // active freewheel for half the measured demag time
+        if (active_demag_ticks > (waitTime >> 1)) {
+            active_demag_ticks = waitTime >> 1; // fet always off well before the expected zero cross
+        }
+    } else { // edge fired before commutation: noise, measurement is invalid
+        blanking_length = 0;
+        active_demag_ticks = 0; // no stale active freewheel from a bad measurement
+    }
+    if (blanking_length > (average_interval >> 1)) { // demag ran past the expected zero cross point
+        demag_happened++;
+        allOff(); // power off until next commutation, winding current must decay
+        uint16_t dc = duty_cycle; // snapshot, ISRs can change duty_cycle between reads
+        uint16_t demag_cut;
+        switch (demag_comp_level) {
+        case 1:
+            demag_cut = dc - (dc >> 2); // cut 25 percent
+            break;
+        case 2:
+            demag_cut = dc >> 1; // cut 50 percent
+            break;
+        case 3:
+            demag_cut = dc >> 2; // cut 75 percent
+            break;
+        default:
+            demag_cut = dc; // no cut
+            break;
+        }
+        if (demag_cut < minimum_duty_cycle) {
+            demag_cut = minimum_duty_cycle;
+        }
+        last_duty_cycle = demag_cut;
+        duty_cycle = demag_cut;
+        // Re-entering interruptRoutine() is safe: auto_blanking is already
+        // cleared so the comparator re-arms with normal polarity, and the
+        // zero-cross confirm loop at its top guards against treating this
+        // demag edge as a false commutation.
+        interruptRoutine();
+    }
+}
+#endif
 
 void startMotor()
 {
@@ -1105,6 +1167,9 @@ void startMotor()
         commutation_interval = 10000;
         SET_INTERVAL_TIMER_COUNT(5000);
         running = 1;
+        auto_blanking = 0;
+        active_demag_fet_on = 0;
+        active_demag_ticks = 0;
     }
     enableCompInterrupts();
 }
@@ -2203,6 +2268,9 @@ if(zero_crosses < 5){
                     average_interval = 5000;
                 }
                 last_duty_cycle = min_startup_duty / 2;
+                auto_blanking = 0;
+                active_demag_fet_on = 0;
+                active_demag_ticks = 0;
             }
             desync_check = 0;
             //	}
@@ -2403,6 +2471,9 @@ if(zero_crosses < 5){
                 bemf_timeout_happened++;
 
                 maskPhaseInterrupts();
+                auto_blanking = 0;
+                active_demag_fet_on = 0;
+                active_demag_ticks = 0;
                 old_routine = 1;
                 if (input < 48) {
                     running = 0;

--- a/Src/main.c
+++ b/Src/main.c
@@ -370,6 +370,13 @@ uint32_t desync_happened = 0;
 #else
 uint8_t desync_happened = 0;
 #endif
+uint8_t demag_comp_level = 0; // 0=off, 1=low, 2=medium, 3=high
+volatile uint16_t blanking_length = 0; // measured demag time in interval timer ticks
+volatile uint8_t auto_blanking = 0; // comparator armed for the demag release edge first
+uint8_t active_demag = 0; // circulate demag current through the fet instead of the body diode
+volatile uint8_t active_demag_fet_on = 0;
+volatile uint16_t active_demag_ticks = 0; // fet on time, half of last measured demag time
+volatile uint32_t demag_happened = 0;
 char maximum_throttle_change_ramp = 1;
 
 char crawler_mode = 0; // no longer used //
@@ -406,7 +413,7 @@ uint16_t low_pin_count = 0;
 uint8_t max_duty_cycle_change = 2;
 char fast_accel = 1;
 char fast_deccel = 0;
-uint16_t last_duty_cycle = 0;
+volatile uint16_t last_duty_cycle = 0;
 uint16_t duty_cycle_setpoint = 0;
 char play_tone_flag = 0;
 
@@ -806,8 +813,21 @@ void loadEEpromSettings()
             low_rpm_throttle_limit = 0;
         }
         low_rpm_level = motor_kv / 100 / (32 / eepromBuffer.motor_poles);
-        high_rpm_level = motor_kv / 12 / (32 / eepromBuffer.motor_poles);				
+        high_rpm_level = motor_kv / 12 / (32 / eepromBuffer.motor_poles);
     }
+#ifdef HAS_DEMAG_COMP
+    if (eepromBuffer.can.demag_compensation > 3) { // erased flash reads 0xff, default off
+        eepromBuffer.can.demag_compensation = 0;
+    }
+    demag_comp_level = eepromBuffer.can.demag_compensation;
+    if (eepromBuffer.can.active_demag > 1) { // erased flash reads 0xff, default off
+        eepromBuffer.can.active_demag = 0;
+    }
+    active_demag = eepromBuffer.can.active_demag && demag_comp_level; // needs the demag time measurement running
+#else
+    demag_comp_level = 0;
+    active_demag = 0;
+#endif
     reverse_speed_threshold = map(motor_kv, 300, 3000, 1000, 500);
     if (eepromBuffer.bi_direction){
       polling_mode_changeover = POLLING_MODE_THRESHOLD / 2;

--- a/Src/main.c
+++ b/Src/main.c
@@ -2467,7 +2467,13 @@ if(zero_crosses < 5){
                 }
             }
 #endif
-            if (INTERVAL_TIMER_COUNT > 45000 && running == 1) {
+            uint32_t interval_threshold;
+            if (zero_crosses > 50) { // running steadily: a missing zero cross shows up
+                interval_threshold = average_interval * 4; // within a few commutations
+            } else {
+                interval_threshold = 45000; // starting: keep the long fixed timeout
+            }
+            if (INTERVAL_TIMER_COUNT > interval_threshold && running == 1) {
                 bemf_timeout_happened++;
 
                 maskPhaseInterrupts();

--- a/Src/main.c
+++ b/Src/main.c
@@ -373,10 +373,25 @@ uint8_t desync_happened = 0;
 uint8_t demag_comp_level = 0; // 0=off, 1=low, 2=medium, 3=high
 volatile uint16_t blanking_length = 0; // measured demag time in interval timer ticks
 volatile uint8_t auto_blanking = 0; // comparator armed for the demag release edge first
+volatile uint16_t demag_wait_ticks = 0; // zc-to-commutation delay that scheduled the armed cycle
+volatile uint16_t demag_cut_latch = 0; // duty cut written by demagEdgeRoutine
+volatile uint8_t demag_cut_pending = 0; // tells tenKhzRoutine a cut landed mid-tick
 uint8_t active_demag = 0; // circulate demag current through the fet instead of the body diode
 volatile uint8_t active_demag_fet_on = 0;
 volatile uint16_t active_demag_ticks = 0; // fet on time, half of last measured demag time
 volatile uint32_t demag_happened = 0;
+
+// Reset all per-run demag state. Called wherever commutation (re)starts or a
+// fault tears down the running state, so no stale armed polarity, cut, or
+// measurement survives into the next spin-up. static inline because callers
+// include RAM_FUNC ISRs - this must not become a flash call.
+static inline void resetDemagState(void)
+{
+    auto_blanking = 0;
+    demag_cut_pending = 0;
+    active_demag_fet_on = 0;
+    active_demag_ticks = 0;
+}
 char maximum_throttle_change_ramp = 1;
 
 char crawler_mode = 0; // no longer used //
@@ -820,13 +835,13 @@ void loadEEpromSettings()
         eepromBuffer.can.demag_compensation = 0;
     }
     demag_comp_level = eepromBuffer.can.demag_compensation;
+#ifdef HWCI_DEMAG_COMP
+    demag_comp_level = HWCI_DEMAG_COMP; // bench build: force on without touching the eeprom
+#endif
     if (eepromBuffer.can.active_demag > 1) { // erased flash reads 0xff, default off
         eepromBuffer.can.active_demag = 0;
     }
     active_demag = eepromBuffer.can.active_demag && demag_comp_level; // needs the demag time measurement running
-#ifdef HWCI_DEMAG_COMP
-    demag_comp_level = HWCI_DEMAG_COMP; // bench build: force on without touching the eeprom
-#endif
 #else
     demag_comp_level = 0;
     active_demag = 0;
@@ -1097,9 +1112,14 @@ RAM_FUNC void interruptRoutine()
 #endif
     SET_INTERVAL_TIMER_COUNT(0);
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
+#ifdef HAS_DEMAG_COMP
     if (demag_comp_level && (input > 400) && (commutation_interval > 100)) {
         auto_blanking = 1; // next commutation watches for the demag release edge first
+        demag_wait_ticks = waitTime; // the zc->commutation delay THIS cycle is
+        // scheduled with; PeriodElapsedCallback recomputes waitTime for the next
+        // cycle before the demag edge fires, so snapshot it for the measurement
     }
+#endif
     __enable_irq();
     HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase
 }
@@ -1115,16 +1135,17 @@ RAM_FUNC void interruptRoutine()
 RAM_FUNC void demagEdgeRoutine()
 {
     uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
+    uint16_t wait_ticks = demag_wait_ticks; // the delay THIS cycle was scheduled with
     auto_blanking = 0;
     changeCompInput(); // polarity back to normal to catch the real zero cross
-    if (time_since_zc > waitTime) { // commutation happened at ~waitTime after the last zero cross
-        blanking_length = time_since_zc - waitTime;
+    if (time_since_zc > wait_ticks) { // commutation happened at ~wait_ticks after the last zero cross
+        blanking_length = time_since_zc - wait_ticks;
         if (blanking_length > average_interval) {
             blanking_length = average_interval; // measurement can't be longer than a commutation
         }
         active_demag_ticks = blanking_length >> 1; // active freewheel for half the measured demag time
-        if (active_demag_ticks > (waitTime >> 1)) {
-            active_demag_ticks = waitTime >> 1; // fet always off well before the expected zero cross
+        if (active_demag_ticks > (wait_ticks >> 1)) {
+            active_demag_ticks = wait_ticks >> 1; // fet always off well before the expected zero cross
         }
     } else { // edge fired before commutation: noise, measurement is invalid
         blanking_length = 0;
@@ -1152,8 +1173,14 @@ RAM_FUNC void demagEdgeRoutine()
         if (demag_cut < minimum_duty_cycle) {
             demag_cut = minimum_duty_cycle;
         }
-        last_duty_cycle = demag_cut;
-        duty_cycle = demag_cut;
+        // Hand the cut to tenKhzRoutine instead of writing duty_cycle/
+        // last_duty_cycle here: this ISR preempts tenKhzRoutine, and its
+        // unguarded "last_duty_cycle = duty_cycle" write-back would otherwise
+        // clobber a directly-written cut. The PWM CCRs only change in
+        // tenKhzRoutine anyway, so applying the cut there is race-free and
+        // takes effect on the same tick the old direct write would have.
+        demag_cut_latch = demag_cut;
+        demag_cut_pending = 1;
         // Re-entering interruptRoutine() is safe: auto_blanking is already
         // cleared so the comparator re-arms with normal polarity, and the
         // zero-cross confirm loop at its top guards against treating this
@@ -1166,13 +1193,13 @@ RAM_FUNC void demagEdgeRoutine()
 void startMotor()
 {
     if (running == 0) {
+        resetDemagState(); // clear BEFORE commutate(): commutate()->changeCompInput()
+                           // programs comparator polarity off auto_blanking, so a
+                           // stale arm from a prior run must be cleared first
         commutate();
         commutation_interval = 10000;
         SET_INTERVAL_TIMER_COUNT(5000);
         running = 1;
-        auto_blanking = 0;
-        active_demag_fet_on = 0;
-        active_demag_ticks = 0;
     }
     enableCompInterrupts();
 }
@@ -1554,6 +1581,17 @@ RAM_FUNC void tenKhzRoutine()
 { // 20khz as of 2.00 to be renamed
     HWCI_PERF_CTRL_ENTER();
     duty_cycle = duty_cycle_setpoint;
+#ifdef HAS_DEMAG_COMP
+    if (demag_cut_pending) { // demagEdgeRoutine detected demag past the zero cross
+        demag_cut_pending = 0;
+        uint16_t cut = demag_cut_latch;
+        last_duty_cycle = cut; // anchor the ramp at the cut; the slew block below
+                               // ramps back up from here over the next ticks
+        if (duty_cycle > cut) {
+            duty_cycle = cut; // and cut this tick's output immediately
+        }
+    }
+#endif
     tenkhzcounter++;
     ledcounter++;
     ramp_count++;
@@ -2271,9 +2309,7 @@ if(zero_crosses < 5){
                     average_interval = 5000;
                 }
                 last_duty_cycle = min_startup_duty / 2;
-                auto_blanking = 0;
-                active_demag_fet_on = 0;
-                active_demag_ticks = 0;
+                resetDemagState();
             }
             desync_check = 0;
             //	}
@@ -2473,6 +2509,11 @@ if(zero_crosses < 5){
             uint32_t interval_threshold;
             if (zero_crosses > 50) { // running steadily: a missing zero cross shows up
                 interval_threshold = average_interval * 4; // within a few commutations
+                if (interval_threshold > 45000) {
+                    // INTERVAL_TIMER counts to 0xffff: an unclamped threshold
+                    // above that is unreachable and stall detection never fires
+                    interval_threshold = 45000;
+                }
             } else {
                 interval_threshold = 45000; // starting: keep the long fixed timeout
             }
@@ -2480,9 +2521,7 @@ if(zero_crosses < 5){
                 bemf_timeout_happened++;
 
                 maskPhaseInterrupts();
-                auto_blanking = 0;
-                active_demag_fet_on = 0;
-                active_demag_ticks = 0;
+                resetDemagState();
                 old_routine = 1;
                 if (input < 48) {
                     running = 0;

--- a/hwci/DEMAG_BENCH_FINDINGS.md
+++ b/hwci/DEMAG_BENCH_FINDINGS.md
@@ -1,0 +1,119 @@
+# Demag compensation — bench validation findings (PR #24)
+
+Hardware: ARK 4IN1 (STM32F051), JS Technology 2306 1800KV (12N14P), Flight
+Stand 50, ST-Link V3 over SWD. Firmware built with `HWCI_PERF=1`.
+
+**Verdict: land the comp-OFF path; do NOT enable demag compensation. The
+compensation, as implemented, is net-harmful under load and needs a rework
+before it is enabled on hardware.**
+
+Demag compensation is off by default (eeprom bytes 184/185 default `0xff` →
+0), so this branch is safe to merge as-is: the feature ships compiled-in but
+dormant. The `DEMAG_COMP=<1|2|3>` build knob is the only way to force it on,
+and should stay a bench-only experiment until the rework below lands.
+
+## Result 1 — inertness A/B (no prop, 25.0 V / 3.0 A supply): PASS
+
+Both sides ran `noprop_smoke_3a` (10 %/20 % throttle, 2.8 A abort). **A** =
+ark-release HEAD (7d3b771, no demag code, perf v4). **B** = this branch (perf
+v5, demag compiled in but off). The question: does the compiled-in-but-inert
+demag port perturb normal operation?
+
+| metric              | A: ark-release | B: demag (off) |
+|---------------------|---------------:|---------------:|
+| zc jitter, mean     | 2.31 %         | 2.35 %         |
+| zc jitter, max      | 12.2 %         | 12.2 %         |
+| peak current        | 0.51 A         | 0.51 A         |
+| CPU load, max       | 62.2 %         | 61.1 %         |
+| idle loop rate      | 55.1 kHz       | 52.1 kHz       |
+| demag / bemf-timeout| 0 / 0          | 0 / 0          |
+
+Zero-cross jitter is flat (the load-bearing "port adds no jitter" metric). The
+idle-loop-rate dip is the compiled-in `HAS_DEMAG_COMP` checks; CPU load did not
+rise, so there is no systematic regression and ~40 % headroom remains. n=1 per
+side, so treat the small deltas as run-to-run noise and the flat jitter as the
+signal. Runs: `runs/inertness-ab-arkrelease`, `runs/demag-rebase-inertness-smoke`.
+
+## Result 2 — demag-event A/B (HQ5136 prop + 6S battery): comp-ON net-harmful
+
+Both sides ran `demag_step_stress` (snap-steps to 90/95/100 %, 55 A abort).
+Only the feature flag differed. Peak current ~38 A both sides (partly
+discharged pack; profile expects 42–49 A fresh).
+
+| step100 (100 % throttle) | comp OFF | comp ON (DEMAG_COMP=2) |
+|--------------------------|---------:|-----------------------:|
+| mean stand RPM           | ~28,650  | **~8,500 (collapsed)**  |
+| samples < 60 % of max    | 17 / 400 | **321 / 400**           |
+| bemf-timeout samples (run)| **0**   | **595**                 |
+| host desync events        | 0       | 3                       |
+| fw_demag_events           | 0       | 290                     |
+
+With compensation **off** the motor rode the snap-steps cleanly; with it **on**
+it lost sync hard — at 100 % throttle it collapsed from ~30,000 RPM to a mean
+of ~8,500 while still commanding full throttle. The feature induces the very
+desync it is meant to prevent. Runs: `runs/demag-stress-off`,
+`runs/demag-stress-on`.
+
+## Root cause
+
+Verified in code and run data (`runs/demag-stress-on`):
+
+- **Ungated, unconfirmed demag edge path.** The F051 comparator ISR
+  ([Mcu/f051/Src/stm32f0xx_it.c](../Mcu/f051/Src/stm32f0xx_it.c), the
+  `auto_blanking` branch) accepts the first comparator edge after unmask and
+  calls `demagEdgeRoutine()` with **no** `INTERVAL_TIMER > average_interval/2`
+  gate and **no** confirm loop — both of which protect the normal zero-cross
+  path right below it. During the high-current snap transient the demag edge
+  fires on noise/commutation ringing.
+- **Arm gate has no stability check.** `interruptRoutine()` arms
+  `auto_blanking` whenever `demag_comp_level && input>400 &&
+  commutation_interval>100`, so it arms every commutation straight through a
+  fast acceleration — exactly when timing margin is thinnest.
+- **Aggressive response.** Each detected demag event does `allOff()` + duty cut
+  + a **re-entrant `interruptRoutine()`** from ISR context, which kicks the
+  bridge off and forces a commutation mid-recovery, sustaining the desync.
+
+What the data shows: both OFF and ON accelerate identically and cleanly
+(commutation_interval decreasing smoothly) until the interval reaches ~120
+ticks (high RPM, near the `commutation_interval>100` arm boundary). OFF
+continues to ~100 and holds; ON's cadence collapses within one 5 ms sample
+(interval 120→541→11,690, bemf timeout), coincident with the first
+demag_events. At 200 Hz perf sampling the demag-edge mistiming and the
+`allOff`/cut/re-enter response fall in the same window, so their ordering is
+not resolvable from this data — both are implicated. (Note: the
+`e_rpm/(pole_pairs·stand_rpm)` "sync lead" seen early in the step is a
+stand-RPM-estimator lag artifact present in BOTH runs, not a demag effect; use
+`commutation_interval` + bemf flag as the discriminator.)
+
+## Fix path (for the rework, tracked separately from this PR)
+
+1. **Stability gate on the arm** (highest leverage, lowest risk): only arm when
+   `input` high **and** `commutation_interval > floor` **and** `zero_crosses`
+   stable **and** recent commutation-interval slew below a threshold. Demag
+   compensation only matters at sustained load; disarm during transients.
+2. **Gate/confirm the demag edge** like the normal ZC path (minimum-time gate +
+   a confirm sample) so noise cannot trigger it.
+3. **Soften the response**: rate-limit the cut and drop the re-entrant
+   `interruptRoutine()` call.
+4. **Altitude**: route demag-release detection through the same glitch-tolerant
+   confirm discipline as the normal ZC instead of a parallel ungated edge path.
+
+Suggested next bench experiment: an **observe-only** build (measure
+`blanking_len`/`demag_events` but skip `allOff`/cut/re-enter) plus the
+stability gate, to gather stage-ordering evidence safely.
+
+## Fixes already applied in this PR (from the code review)
+
+These are correct and were validated by the inertness A/B; they are not the
+cause of Result 2 (a feature-level flaw, above):
+
+- `blanking_length` measured against a snapshotted scheduling delay
+  (`demag_wait_ticks`) instead of the next-cycle `waitTime`.
+- Adaptive bemf stall timeout clamped to 45000 (the 16-bit INTERVAL_TIMER would
+  otherwise make the threshold unreachable at low RPM).
+- Demag duty cut handed to `tenKhzRoutine` via a latch/pending flag instead of
+  a direct write raced by the slew write-back.
+- Stale comparator EXTI pending cleared before unmask (all ported MCUs).
+- `resetDemagState()` clears demag state before `commutate()` on start, and at
+  the desync / bemf-timeout sites.
+- Makefile flag-stamp so `HWCI_PERF`/`DEMAG_COMP` changes force a rebuild.

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -300,7 +300,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
             "zc_jitter_max_pct": jitter["max_pct"],
             # rejected edges per accepted zero-cross (report-only, v3+)
             "confirm_rejects_per_zc": counter_per_zc(zc_reject, zc_count, tail),
-            # firmware-counted demag events in this steady tail (struct v4+,
+            # firmware-counted demag events in this steady tail (struct v5+,
             # monotonic demag_happened mirror). A NEW key alongside the
             # host-derived detection so old baselines stay comparable.
             "fw_demag_events": fw_counter_delta(fw_demag, tail),

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -270,6 +270,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
     zc_jmax = _col(rows, "perf_zc_jitter_max")
     zc_reject = _col(rows, "perf_zc_confirm_reject")
     fw_demag = _col(rows, "perf_demag_events")
+    fw_interlock = _col(rows, "perf_interlock_skips")
 
     steady_points = []
     for s in profile.segments:
@@ -352,6 +353,11 @@ def compute(run: RunResult, profile: Profile) -> dict:
         # baselines stay comparable.
         "fw_demag_events": fw_counter_delta(
             fw_demag, np.arange(len(rows))),
+        # Active-demag interlock vetoes over the whole run (struct v6+, None
+        # on older firmware). ~0 healthy; ~= total commutations means the
+        # step/rising -> FET mapping is wrong - abort active-demag benching.
+        "fw_interlock_skips": fw_counter_delta(
+            fw_interlock, np.arange(len(rows))),
         "bemf_timeout_samples": demag["bemf_timeout_samples"],
         # start-attempt outcomes; None/0 unless the profile has start* segments
         "start_attempts": starts["attempts"] or None,

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -229,6 +229,22 @@ def zc_phase_window(rows: list[dict], idx: np.ndarray) -> dict | None:
             "peak_ratio": round(hist[peak_bin] / uniform, 2)}
 
 
+def fw_counter_delta(counter: np.ndarray, idx: np.ndarray) -> int | None:
+    """Delta of a monotonic firmware u32 counter over the sample window ``idx``.
+
+    Differencing the first and last valid snapshot counts every increment
+    regardless of the host sampling rate (wrap-safe like the zc_* sums).
+    Returns ``None`` when the firmware predates the counter (all blank) or the
+    window has fewer than two valid samples.
+    """
+    if idx.size == 0:
+        return None
+    valid = idx[~np.isnan(counter[idx])]
+    if valid.size < 2:
+        return None
+    return _wrap32(counter[valid[0]], counter[valid[-1]])
+
+
 def compute(run: RunResult, profile: Profile) -> dict:
     rows = run.rows
     seg = np.array([r.get("segment") for r in rows], dtype=object)
@@ -253,6 +269,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
     zc_isum = _col(rows, "perf_zc_interval_sum")
     zc_jmax = _col(rows, "perf_zc_jitter_max")
     zc_reject = _col(rows, "perf_zc_confirm_reject")
+    fw_demag = _col(rows, "perf_demag_events")
 
     steady_points = []
     for s in profile.segments:
@@ -283,6 +300,10 @@ def compute(run: RunResult, profile: Profile) -> dict:
             "zc_jitter_max_pct": jitter["max_pct"],
             # rejected edges per accepted zero-cross (report-only, v3+)
             "confirm_rejects_per_zc": counter_per_zc(zc_reject, zc_count, tail),
+            # firmware-counted demag events in this steady tail (struct v4+,
+            # monotonic demag_happened mirror). A NEW key alongside the
+            # host-derived detection so old baselines stay comparable.
+            "fw_demag_events": fw_counter_delta(fw_demag, tail),
         })
         # PWM-phase distribution of accepted ZC edges (report-only, v4+)
         phase = zc_phase_window(rows, tail)
@@ -325,6 +346,12 @@ def compute(run: RunResult, profile: Profile) -> dict:
             (p["zc_jitter_max_pct"] for p in steady_points
              if p.get("zc_jitter_max_pct") is not None), default=None),
         "demag_events": demag["event_count"],
+        # Firmware's own demag counter over the whole run (struct v3+, None on
+        # older firmware). Reported ALONGSIDE the host-derived demag_events
+        # above - it does not replace the host detection, so runs against old
+        # baselines stay comparable.
+        "fw_demag_events": fw_counter_delta(
+            fw_demag, np.arange(len(rows))),
         "bemf_timeout_samples": demag["bemf_timeout_samples"],
         # start-attempt outcomes; None/0 unless the profile has start* segments
         "start_attempts": starts["attempts"] or None,

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -41,6 +41,8 @@ COLUMNS = [
     # demag compensation stats (struct v5+; blank when the flashed firmware
     # predates them - metrics treat blank as "metric unavailable")
     "perf_demag_events", "perf_blanking_len_last", "perf_blanking_len_max",
+    # active-demag interlock vetoes (struct v6+; blank on older firmware)
+    "perf_interlock_skips",
     "perf_bemf_timeout", "perf_e_rpm",
     # ESC input/arming state (proves the ESC decoded the throttle protocol)
     "perf_input", "perf_armed", "perf_running",
@@ -116,6 +118,8 @@ def make_row(t: float, segment: str, throttle_cmd: float,
                 perf_blanking_len_last=r["blanking_len_last"],
                 perf_blanking_len_max=r["blanking_len_max"],
             )
+        if "active_demag_interlock_skips" in r:  # struct v6+
+            row.update(perf_interlock_skips=r["active_demag_interlock_skips"])
     return row
 
 

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -38,6 +38,9 @@ COLUMNS = [
     "perf_zc_confirm_reject",
     # 32-bin PWM-phase histogram, semicolon-joined (struct v4+)
     "perf_zc_phase_hist",
+    # demag compensation stats (struct v5+; blank when the flashed firmware
+    # predates them - metrics treat blank as "metric unavailable")
+    "perf_demag_events", "perf_blanking_len_last", "perf_blanking_len_max",
     "perf_bemf_timeout", "perf_e_rpm",
     # ESC input/arming state (proves the ESC decoded the throttle protocol)
     "perf_input", "perf_armed", "perf_running",
@@ -107,6 +110,12 @@ def make_row(t: float, segment: str, throttle_cmd: float,
             # one CSV cell, not 32 columns; _coerce leaves it a string on load
             row["perf_zc_phase_hist"] = ";".join(
                 str(v) for v in r["zc_phase_hist"])
+        if "demag_events" in r:  # struct v5+
+            row.update(
+                perf_demag_events=r["demag_events"],
+                perf_blanking_len_last=r["blanking_len_last"],
+                perf_blanking_len_max=r["blanking_len_max"],
+            )
     return row
 
 

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 5
+VERSION = 6
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -86,10 +86,18 @@ FIELDS_V5: list[tuple[str, str]] = FIELDS_V4 + [
     ("blanking_len_max", "H"),
 ]
 
-FIELDS = FIELDS_V5  # canonical == newest
+# v6 appends the active-demag comparator-interlock veto counter (monotonic;
+# freewheel turn-ons skipped because the floating phase did not read as
+# diode-clamped - the mapping-fault detector for active demag).
+FIELDS_V6: list[tuple[str, str]] = FIELDS_V5 + [
+    ("active_demag_interlock_skips", "I"),
+]
+
+FIELDS = FIELDS_V6  # canonical == newest
 
 FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
-    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4, 5: FIELDS_V5}
+    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4, 5: FIELDS_V5,
+    6: FIELDS_V6}
 
 
 def _field_count(code: str) -> int:
@@ -105,7 +113,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 156 bytes (v4: 148, v3: 84, v2: 80, v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 160 bytes (v5: 156, v4: 148, v3: 84, v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 4
+VERSION = 5
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -77,10 +77,19 @@ FIELDS_V4: list[tuple[str, str]] = FIELDS_V3 + [
     ("zc_phase_hist", f"{ZC_PHASE_BINS}H"),
 ]
 
-FIELDS = FIELDS_V4
+# v5 appends the demag compensation block (demag_events mirrors the firmware's
+# monotonic demag_happened counter; blanking_len_* mirror the measured demag
+# time from demagEdgeRoutine, in INTERVAL_TIMER ticks).
+FIELDS_V5: list[tuple[str, str]] = FIELDS_V4 + [
+    ("demag_events", "I"),
+    ("blanking_len_last", "H"),
+    ("blanking_len_max", "H"),
+]
+
+FIELDS = FIELDS_V5  # canonical == newest
 
 FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
-    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4}
+    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4, 5: FIELDS_V5}
 
 
 def _field_count(code: str) -> int:
@@ -96,7 +105,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 148 bytes (v3: 84, v2: 80, v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 156 bytes (v4: 148, v3: 84, v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.
@@ -126,7 +135,8 @@ class PerfSample:
     """One decoded snapshot of the firmware instrumentation struct.
 
     ``raw`` holds only the fields the sampled firmware actually has: a v1
-    sample has no ``zc_*`` keys. Downstream consumers use ``raw.get()``.
+    sample has no ``zc_*`` keys, and pre-v3 samples have no ``demag_events``
+    or ``blanking_len_*`` keys. Downstream consumers use ``raw.get()``.
     """
 
     raw: dict

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -52,7 +52,9 @@ class PerfReader:
             return
         # Pick the canonical layout matching the firmware's vintage by probing
         # for version-marker members, then verify every field of THAT layout.
-        if "demag_events" in members:
+        if "active_demag_interlock_skips" in members:
+            fields = perf.FIELDS_V6
+        elif "demag_events" in members:
             fields = perf.FIELDS_V5
         elif "zc_phase_hist" in members:
             fields = perf.FIELDS_V4

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -52,7 +52,9 @@ class PerfReader:
             return
         # Pick the canonical layout matching the firmware's vintage by probing
         # for version-marker members, then verify every field of THAT layout.
-        if "zc_phase_hist" in members:
+        if "demag_events" in members:
+            fields = perf.FIELDS_V5
+        elif "zc_phase_hist" in members:
             fields = perf.FIELDS_V4
         elif "zc_confirm_reject" in members:
             fields = perf.FIELDS_V3

--- a/hwci/hwci/profiles/noprop_smoke_100pct_3a.yaml
+++ b/hwci/hwci/profiles/noprop_smoke_100pct_3a.yaml
@@ -1,0 +1,31 @@
+name: noprop_smoke_100pct_3a
+description: >
+  No-prop free-run climb to 100% on a 25 V / 3.0 A current-limited supply.
+  Gentle ramps through 20/40/60/80/100 so transition spikes stay under the
+  2.8 A host abort. Steady holds at each step for demag/active-demag telemetry.
+  Free-run current is typically well under 2 A; abort is the supply backstop.
+  ~55 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 2.8     # trip below the 3.0 A supply limit
+  max_thrust_n: 2.0      # ~0 expected with no prop
+  max_rpm: 55000         # 1800KV @ 25 V theoretical free-run ~45k
+  max_motor_temp_c: 90.0
+
+segments:
+  - {label: idle,     throttle: 0.00, duration_s: 2.0}
+  - {label: ramp20,   throttle: 0.20, duration_s: 3.0, ramp: true}
+  - {label: hold20,   throttle: 0.20, duration_s: 3.0, steady: true}
+  - {label: ramp40,   throttle: 0.40, duration_s: 4.0, ramp: true}
+  - {label: hold40,   throttle: 0.40, duration_s: 3.0, steady: true}
+  - {label: ramp60,   throttle: 0.60, duration_s: 4.0, ramp: true}
+  - {label: hold60,   throttle: 0.60, duration_s: 3.0, steady: true}
+  - {label: ramp80,   throttle: 0.80, duration_s: 4.0, ramp: true}
+  - {label: hold80,   throttle: 0.80, duration_s: 3.0, steady: true}
+  - {label: ramp100,  throttle: 1.00, duration_s: 4.0, ramp: true}
+  - {label: hold100,  throttle: 1.00, duration_s: 4.0, steady: true}
+  - {label: rampdn,   throttle: 0.00, duration_s: 5.0, ramp: true}
+  - {label: stop,     throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/noprop_smoke_2p5a.yaml
+++ b/hwci/hwci/profiles/noprop_smoke_2p5a.yaml
@@ -1,0 +1,29 @@
+name: noprop_smoke_2p5a
+description: >
+  No-prop climb aimed at ~2.5 A on a 25 V / 3.0 A current-limited supply.
+  Free-running no-load current is usually well under 2 A even at high duty;
+  this profile ramps gently through 20/40/60/80 % so transition spikes stay
+  below the 2.8 A host abort (and the supply's 3.0 A CC limit). Use for
+  active-demag plumbing at higher input/blanking without a prop. ~45 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 2.8     # trip below the 3.0 A supply limit
+  max_thrust_n: 2.0      # ~0 expected with no prop; sensor-fault trip
+  max_rpm: 50000         # 1800KV @ 25 V free-run theoretical ~45k
+  max_motor_temp_c: 80.0
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: ramp20,  throttle: 0.20, duration_s: 3.0, ramp: true}
+  - {label: hold20,  throttle: 0.20, duration_s: 3.0, steady: true}
+  - {label: ramp40,  throttle: 0.40, duration_s: 4.0, ramp: true}
+  - {label: hold40,  throttle: 0.40, duration_s: 4.0, steady: true}
+  - {label: ramp60,  throttle: 0.60, duration_s: 4.0, ramp: true}
+  - {label: hold60,  throttle: 0.60, duration_s: 4.0, steady: true}
+  - {label: ramp80,  throttle: 0.80, duration_s: 4.0, ramp: true}
+  - {label: hold80,  throttle: 0.80, duration_s: 4.0, steady: true}
+  - {label: rampdn,  throttle: 0.00, duration_s: 4.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/noprop_smoke_3a.yaml
+++ b/hwci/hwci/profiles/noprop_smoke_3a.yaml
@@ -1,0 +1,24 @@
+name: noprop_smoke_3a
+description: >
+  noprop_smoke with the current abort tightened to 2.8 A for a 25.0 V / 3.0 A
+  current-limited bench supply: abort before the supply hits its CC limit and
+  the rail sags. NO propeller. Validates the pipeline (arming, throttle path,
+  perf-over-SWD, loop time / jitter) after the demag-comp rebase + review
+  fixes. Demag stays OFF (firmware built without DEMAG_COMP) - this is the
+  inertness gate. Thrust/efficiency are meaningless with no prop. ~18 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+
+safety:
+  max_current_a: 2.8     # trip below the 3.0 A supply limit (host + stand side)
+  max_thrust_n: 2.0      # ~0 expected with no prop; catches a sensor fault
+  max_rpm: 25000         # 1800KV @ 25V free-runs ~45k at 100%; 20% is ~10k
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: ramp10,  throttle: 0.10, duration_s: 2.0, ramp: true}
+  - {label: hold10,  throttle: 0.10, duration_s: 4.0, steady: true}
+  - {label: ramp20,  throttle: 0.20, duration_s: 2.0, ramp: true}
+  - {label: hold20,  throttle: 0.20, duration_s: 4.0, steady: true}
+  - {label: rampdn,  throttle: 0.00, duration_s: 2.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/noprop_smoke_90pct_3a.yaml
+++ b/hwci/hwci/profiles/noprop_smoke_90pct_3a.yaml
@@ -1,0 +1,30 @@
+name: noprop_smoke_90pct_3a
+description: >
+  No-prop free-run climb to 90% hold on a 25 V / 3.0 A current-limited supply.
+  Prior 100% climb was stable through 80% (~34k RPM) but the app dropped out
+  near ~95%; this profile stops at 90% with a longer steady hold to confirm
+  that operating point. Gentle ramps; host abort 2.8 A. ~50 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 2.8
+  max_thrust_n: 2.0
+  max_rpm: 55000
+  max_motor_temp_c: 90.0
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: ramp20,  throttle: 0.20, duration_s: 3.0, ramp: true}
+  - {label: hold20,  throttle: 0.20, duration_s: 2.0, steady: true}
+  - {label: ramp40,  throttle: 0.40, duration_s: 4.0, ramp: true}
+  - {label: hold40,  throttle: 0.40, duration_s: 2.0, steady: true}
+  - {label: ramp60,  throttle: 0.60, duration_s: 4.0, ramp: true}
+  - {label: hold60,  throttle: 0.60, duration_s: 2.0, steady: true}
+  - {label: ramp80,  throttle: 0.80, duration_s: 4.0, ramp: true}
+  - {label: hold80,  throttle: 0.80, duration_s: 3.0, steady: true}
+  - {label: ramp90,  throttle: 0.90, duration_s: 3.0, ramp: true}
+  - {label: hold90,  throttle: 0.90, duration_s: 6.0, steady: true}
+  - {label: rampdn,  throttle: 0.00, duration_s: 5.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/noprop_smoke_95pct_3a.yaml
+++ b/hwci/hwci/profiles/noprop_smoke_95pct_3a.yaml
@@ -1,0 +1,31 @@
+name: noprop_smoke_95pct_3a
+description: >
+  No-prop free-run climb to 95% hold on a 25 V / 3.0 A current-limited supply.
+  90% held clean for 6 s; prior 100% climb dropped the app near ~95.3%. This
+  profile holds 95% to bracket the dropout. Gentle ramps; host abort 2.8 A. ~55 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 2.8
+  max_thrust_n: 2.0
+  max_rpm: 55000
+  max_motor_temp_c: 90.0
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: ramp20,  throttle: 0.20, duration_s: 3.0, ramp: true}
+  - {label: hold20,  throttle: 0.20, duration_s: 2.0, steady: true}
+  - {label: ramp40,  throttle: 0.40, duration_s: 4.0, ramp: true}
+  - {label: hold40,  throttle: 0.40, duration_s: 2.0, steady: true}
+  - {label: ramp60,  throttle: 0.60, duration_s: 4.0, ramp: true}
+  - {label: hold60,  throttle: 0.60, duration_s: 2.0, steady: true}
+  - {label: ramp80,  throttle: 0.80, duration_s: 4.0, ramp: true}
+  - {label: hold80,  throttle: 0.80, duration_s: 2.0, steady: true}
+  - {label: ramp90,  throttle: 0.90, duration_s: 3.0, ramp: true}
+  - {label: hold90,  throttle: 0.90, duration_s: 2.0, steady: true}
+  - {label: ramp95,  throttle: 0.95, duration_s: 2.0, ramp: true}
+  - {label: hold95,  throttle: 0.95, duration_s: 6.0, steady: true}
+  - {label: rampdn,  throttle: 0.00, duration_s: 5.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/report.py
+++ b/hwci/hwci/report.py
@@ -46,7 +46,7 @@ def render_markdown(metrics: dict, comparison: dict | None = None,
         cols = ["segment", "throttle", "rpm", "thrust_gf", "current_a",
                 "voltage_v", "elec_power_w", "eff_gf_per_w",
                 "ctrl_exec_us_max", "cpu_load_pct",
-                "zc_jitter_pct", "zc_jitter_max_pct"]
+                "zc_jitter_pct", "zc_jitter_max_pct", "fw_demag_events"]
         out.append("| " + " | ".join(cols) + " |")
         out.append("|" + "---|" * len(cols))
         for p in pts:
@@ -66,7 +66,10 @@ def render_markdown(metrics: dict, comparison: dict | None = None,
 
     d = metrics.get("demag", {})
     out.append("## Demag / desync\n")
-    out.append(f"- events: **{d.get('event_count', 0)}**")
+    out.append(f"- events (host-derived): **{d.get('event_count', 0)}**")
+    fw_ev = metrics.get("summary", {}).get("fw_demag_events")
+    out.append(f"- firmware demag counter (struct v3+): "
+               f"{_fmt(fw_ev)}")
     out.append(f"- bemf-timeout samples: {d.get('bemf_timeout_samples', 0)}")
     out.append(f"- commutation-spike samples: {d.get('comm_spike_samples', 0)}")
     out.append(f"- ESC-eRPM vs stand-RPM mismatch samples: "

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -127,6 +127,9 @@ class RigSimulator:
         self.demag_events = 0
         self.blanking_len_last = 0
         self.blanking_len_max = 0
+        # active-demag interlock vetoes (perf struct v6); the sim never
+        # freewheels, so a healthy rig reports 0
+        self.active_demag_interlock_skips = 0
 
     # --- model -------------------------------------------------------
     def set_settings(self, settings: SimSettings | None) -> None:
@@ -375,4 +378,5 @@ class RigSimulator:
             "demag_events": self.demag_events,
             "blanking_len_last": self.blanking_len_last,
             "blanking_len_max": self.blanking_len_max,
+            "active_demag_interlock_skips": self.active_demag_interlock_skips,
         })

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -120,6 +120,13 @@ class RigSimulator:
         # models mild phase locking - 20% of edges pile onto one bin
         self.zc_phase_hist = [0] * 32
         self._phase_rr = 0
+        # demag compensation stats (perf struct v5). The sim maps each injected
+        # desync to one firmware-counted demag event; blanking_len_* stay 0
+        # (the sim has no demag-time model - 0 is what real firmware reports
+        # with demag compensation disabled).
+        self.demag_events = 0
+        self.blanking_len_last = 0
+        self.blanking_len_max = 0
 
     # --- model -------------------------------------------------------
     def set_settings(self, settings: SimSettings | None) -> None:
@@ -193,6 +200,7 @@ class RigSimulator:
                 and provisional_current > p.demag_current_a):
             self.desync_remaining = p.desync_ticks
             self.desync_count += 1
+            self.demag_events = (self.demag_events + 1) & 0xFFFFFFFF
 
         if self.desync_remaining > 0:
             # Loss of sync: rotor falls back, electrical drive flails.
@@ -364,4 +372,7 @@ class RigSimulator:
             "zc_jitter_max": self.zc_jitter_max,
             "zc_confirm_reject": self.zc_confirm_reject,
             "zc_phase_hist": tuple(self.zc_phase_hist),
+            "demag_events": self.demag_events,
+            "blanking_len_last": self.blanking_len_last,
+            "blanking_len_max": self.blanking_len_max,
         })

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 148
+    assert sym.size == perf.SIZE == 156
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 156
+    assert sym.size == perf.SIZE == 160
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -370,3 +370,33 @@ def test_zc_phase_none_for_pre_v4_runs():
     pt = m["steady_points"][0]
     assert pt["zc_phase_peak_ratio"] is None
     assert pt["zc_phase_hist"] is None
+
+
+def test_fw_demag_events_from_counter_delta():
+    # Firmware demag_happened is a monotonic u32 (struct v5+): the metric is
+    # the first-to-last snapshot delta, per steady tail and over the run.
+    n = 100
+    rows = _rows(n, perf_demag_events=lambda i: 3 + (2 if i >= 50 else 0))
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_demag_events"] == 2
+    # the steady tail (last half of the segment) starts after the jump
+    assert m["steady_points"][0]["fw_demag_events"] == 0
+    # host-derived detection is untouched by the firmware counter
+    assert m["summary"]["demag_events"] == 0
+
+
+def test_fw_demag_events_none_for_pre_v5_runs():
+    # Runs captured on pre-v5 firmware have no perf_demag_events column: the
+    # metric must report None (unavailable), never 0.
+    rows = _rows(50, perf_loop_iters=lambda i: 1200 * i)
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_demag_events"] is None
+    assert m["steady_points"][0]["fw_demag_events"] is None
+
+
+def test_fw_demag_events_survives_u32_wrap():
+    start = (1 << 32) - 1
+    rows = _rows(50, perf_demag_events=lambda i: (start + (1 if i >= 25 else 0))
+                 % (1 << 32))
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_demag_events"] == 1

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -400,3 +400,16 @@ def test_fw_demag_events_survives_u32_wrap():
                  % (1 << 32))
     m = metricsmod.compute(RunResult(rows=rows), _profile())
     assert m["summary"]["fw_demag_events"] == 1
+
+
+def test_fw_interlock_skips_from_counter_delta():
+    # v6 interlock veto counter: whole-run first-to-last delta in the summary.
+    rows = _rows(100, perf_interlock_skips=lambda i: 1 + (5 if i >= 80 else 0))
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_interlock_skips"] == 5
+
+
+def test_fw_interlock_skips_none_for_pre_v6_runs():
+    rows = _rows(50, perf_loop_iters=lambda i: 1200 * i)
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_interlock_skips"] is None

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -10,7 +10,8 @@ def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[1] == 64
     assert perf.SIZE_BY_VERSION[2] == 80
     assert perf.SIZE_BY_VERSION[3] == 84
-    assert perf.SIZE == perf.SIZE_BY_VERSION[4] == 148
+    assert perf.SIZE_BY_VERSION[4] == 148
+    assert perf.SIZE == perf.SIZE_BY_VERSION[5] == 156
 
 
 def test_host_cmd_offset_matches_layout():
@@ -131,7 +132,40 @@ def test_v2_roundtrip_has_no_reject_key():
 
 def test_v4_roundtrip_phase_histogram():
     hist = tuple((i * 7) % 65536 for i in range(32))
-    blob = perf.encode({"zc_phase_hist": hist})
+    blob = perf.encode({"zc_phase_hist": hist}, version=4)
     assert len(blob) == 148
     s = perf.decode(blob)
     assert s.raw["zc_phase_hist"] == hist
+    assert "demag_events" not in s.raw
+
+
+def test_roundtrip_demag_fields():
+    blob = perf.encode({
+        "demag_events": 4000000001,   # near the u32 wrap
+        "blanking_len_last": 512,
+        "blanking_len_max": 4100,
+    })
+    r = perf.decode(blob).raw
+    assert r["demag_events"] == 4000000001
+    assert r["blanking_len_last"] == 512
+    assert r["blanking_len_max"] == 4100
+
+
+def test_v2_roundtrip_has_no_demag_keys():
+    # v2 firmware (pre demag block) must decode cleanly and simply not carry
+    # the demag fields - mirrors the v1/zc backward-compat guarantee.
+    blob = perf.encode({"zc_count": 7, "loop_iters": 42}, version=2)
+    assert len(blob) == perf.SIZE_BY_VERSION[2]
+    s = perf.decode(blob)
+    assert s.raw["zc_count"] == 7
+    assert s.loop_iters == 42
+    assert "demag_events" not in s.raw
+    assert "blanking_len_last" not in s.raw
+
+
+def test_v2_decodes_from_oversized_read():
+    # an oversized buffer holding a v2 struct (plus junk) must decode as v2
+    blob = perf.encode({"zc_count": 9}, version=2) + b"\xa5" * 8
+    s = perf.decode(blob)
+    assert s.raw["zc_count"] == 9
+    assert "demag_events" not in s.raw

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -11,7 +11,8 @@ def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[2] == 80
     assert perf.SIZE_BY_VERSION[3] == 84
     assert perf.SIZE_BY_VERSION[4] == 148
-    assert perf.SIZE == perf.SIZE_BY_VERSION[5] == 156
+    assert perf.SIZE_BY_VERSION[5] == 156
+    assert perf.SIZE == perf.SIZE_BY_VERSION[6] == 160
 
 
 def test_host_cmd_offset_matches_layout():
@@ -144,11 +145,32 @@ def test_roundtrip_demag_fields():
         "demag_events": 4000000001,   # near the u32 wrap
         "blanking_len_last": 512,
         "blanking_len_max": 4100,
-    })
+    }, version=5)
     r = perf.decode(blob).raw
     assert r["demag_events"] == 4000000001
     assert r["blanking_len_last"] == 512
     assert r["blanking_len_max"] == 4100
+    assert "active_demag_interlock_skips" not in r
+
+
+def test_roundtrip_interlock_skips():
+    blob = perf.encode({
+        "demag_events": 10,
+        "blanking_len_last": 100,
+        "blanking_len_max": 200,
+        "active_demag_interlock_skips": 42,
+    })
+    r = perf.decode(blob).raw
+    assert r["active_demag_interlock_skips"] == 42
+    assert r["demag_events"] == 10
+
+
+def test_v5_roundtrip_has_no_interlock_key():
+    blob = perf.encode({"demag_events": 3}, version=5)
+    assert len(blob) == perf.SIZE_BY_VERSION[5]
+    s = perf.decode(blob)
+    assert s.raw["demag_events"] == 3
+    assert "active_demag_interlock_skips" not in s.raw
 
 
 def test_v2_roundtrip_has_no_demag_keys():

--- a/hwci/tests/test_perf_reader.py
+++ b/hwci/tests/test_perf_reader.py
@@ -100,16 +100,19 @@ def test_missing_struct_die_fails_hard(host_perf_elf, monkeypatch):
 
 
 def test_v2_firmware_reads_and_resets(host_perf_elf_v2):
-    # v2 vintage (jitter block, no confirm-reject counter): the reader must
-    # size its read from the ELF, pass the DWARF cross-check against the v2
-    # canonical table, decode without the v3 key, and land RESET_STATS at
-    # the version-stable offset 60.
+    # v2 vintage (jitter block, no v3 reject counter, no v4 demag block):
+    # the reader must size its read from the ELF, pass the DWARF cross-check
+    # against the v2 canonical table, decode without the newer keys, and
+    # land RESET_STATS at the version-stable offset 60.
     reader, dbg = _reader_with_mock(host_perf_elf_v2)
     assert reader._read_size == perf.SIZE_BY_VERSION[2]
-    dbg.poke(reader.address, perf.encode({"zc_count": 55}, version=2))
+    dbg.poke(reader.address, perf.encode(
+        {"zc_count": 55, "loop_iters": 999}, version=2))
     sample = reader.read()
     assert sample.raw["zc_count"] == 55
+    assert sample.loop_iters == 999
     assert "zc_confirm_reject" not in sample.raw
+    assert "demag_events" not in sample.raw
     reader.reset_stats(verify=False)
     word = dbg.read_memory(reader.address + perf.HOST_CMD_OFFSET, 4)
     assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -110,13 +110,14 @@ def test_perf_channel_carries_phase_histogram():
 
 
 def test_perf_channel_carries_demag_fields():
-    # v5 struct: demag fields present, zero on a clean (non-demag-prone) run.
+    # v5/v6 struct: demag + interlock fields present, zero on a clean run.
     rig = RigSimulator(noise=0.0)
     _settle(rig, 0.7)
     r = perf.decode(rig.perf_bytes()).raw
     assert r["demag_events"] == 0
     assert r["blanking_len_last"] == 0
     assert r["blanking_len_max"] == 0
+    assert r["active_demag_interlock_skips"] == 0
 
 
 def test_demag_events_count_injected_desyncs():

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -109,6 +109,24 @@ def test_perf_channel_carries_phase_histogram():
     assert max(range(32), key=delta.__getitem__) == peak
 
 
+def test_perf_channel_carries_demag_fields():
+    # v5 struct: demag fields present, zero on a clean (non-demag-prone) run.
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.7)
+    r = perf.decode(rig.perf_bytes()).raw
+    assert r["demag_events"] == 0
+    assert r["blanking_len_last"] == 0
+    assert r["blanking_len_max"] == 0
+
+
+def test_demag_events_count_injected_desyncs():
+    rig = RigSimulator(params=MotorParams(demag_prone=True), noise=0.0)
+    _settle(rig, 0.1, n=50)
+    rig.step(0.005, 1.0)  # aggressive step into high current -> desync
+    r = perf.decode(rig.perf_bytes()).raw
+    assert r["demag_events"] == rig.desync_count == 1
+
+
 # --------------------------------------------------------------------------
 # AM32 settings model (SimSettings)
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## ⚠️ Status: bench-validated — ship comp-OFF, do NOT enable demag compensation

Bench validation is complete (ARK 4IN1 F051 + Flight Stand 50). Full report:
[`hwci/DEMAG_BENCH_FINDINGS.md`](hwci/DEMAG_BENCH_FINDINGS.md).

- **Inertness (comp OFF): PASS.** A no-prop A/B against ark-release HEAD shows
  the compiled-in-but-off demag port adds no zero-cross jitter (2.31 % → 2.35 %
  mean, flat max) and no CPU regression.
- **Demag compensation (comp ON): NET-HARMFUL — do not enable.** With a prop +
  6S, the `demag_step_stress` snap-steps ran clean with comp **off** but
  desynced hard with `DEMAG_COMP=2`: at 100 % throttle the motor collapsed from
  ~30 000 RPM to a mean of ~8 500 (595 bemf-timeout samples vs **0** off). Root
  cause: the F051 demag-edge ISR branch is an ungated/unconfirmed parallel edge
  path, the arm has no stability check (arms through fast accel), and the
  `allOff` + duty-cut + re-entrant `interruptRoutine()` response sustains the
  desync.

Demag comp is **off by default** (eeprom 184/185 default `0xff`), so this branch
is safe to merge as the **comp-OFF path** — adaptive stall timeout + perf v5
telemetry + the review fixes below, all bench-clean. The compensation itself
needs the rework in the report (stability-gate the arm, gate/confirm the demag
edge, soften the response) before it is enabled; `DEMAG_COMP=<n>` stays a
bench-only experiment until then.

---

## Summary

Rebase of the demag-compensation half of draft PR #2 onto `ark-release`. The original branch predates #14/#19/#21, which rewrote the F051 comparator ISR path it patches (inlined comparator read, RAM-resident hot path, glitch-tolerant confirm loop), so this is a hand re-application as a reviewable commit series rather than a textual rebase. The **active demag** half (freewheel through the FET channel instead of the body diode) is split out into stacked PR #25 so its hazard profile can be reviewed and bench-gated separately.

**Rebased 2026-07-06** onto current `ark-release`. Since #29 now owns perf **struct v4** (the 32-bin PWM-phase histogram) and #30 added the turn-on grid compensation, the demag perf fields were renumbered to **struct v5** (offsets 148–154), appended after the histogram; `host_cmd` stays frozen at 60. Both features coexist; all **244** offline tests pass.

## What it does

After each zero-cross (when `demag_comp_level` is set, throttle > 20%, and the motor is up to speed), `interruptRoutine()` arms `auto_blanking`: `changeCompInput()` then configures the comparator EXTI with **reversed polarity**, so the first edge seen after commutation is the **demag release edge** — the moment the freewheel diode stops clamping the floating phase. The new `demagEdgeRoutine()` (RAM_FUNC) timestamps it: `blanking_length = time-since-ZC − waitTime` (measured against the snapshotted scheduling delay, see fixes) is the measured demag duration, and the comparator is flipped back to normal polarity to catch the true zero-cross.

If demag runs past half the commutation interval (the ZC is being swallowed), it counts `demag_happened`, powers off the bridge, cuts duty by 25/50/75% per compensation level, and re-enters `interruptRoutine()`. **Bench-proven inadequate** — see the status banner: this response path sustains desync under load rather than recovering from it.

Also included, as a deliberately separable commit (`feat(bemf-timeout)`): the stall threshold adapts to the commutation rate (`average_interval * 4` once `zero_crosses > 50`, clamped to 45000 — see fixes) instead of the fixed 22.5 ms — revert alone if it misbehaves on aggressive throttle chops.

## Fixes to the original PR logic (found during the port + code review)

- `demag_happened` was `uint8_t` on non-CAN builds (saturates at 255 — useless for hwci gating); now unconditionally `volatile uint32_t`.
- The level-3 duty cut was a mislabeled `default:` case; now an explicit `case 3:` with a no-cut default so out-of-range values can't apply the harshest cut.
- `duty_cycle` (volatile) was double-read while computing the cut; now snapshotted once.
- An early/noise edge (`time_since_zc <= waitTime`) now zeroes both the measurement **and** the derived active-freewheel time, so a garbage measurement can't persist.
- `blanking_length` is clamped to `average_interval`.
- `auto_blanking`/measurement state is reset on startup, desync, and bemf-timeout paths (via `resetDemagState()`, cleared *before* `commutate()` on start so a stale arm can't set the wrong polarity).
- **[review]** `blanking_length` is measured against a snapshotted scheduling delay (`demag_wait_ticks`), not the next-cycle `waitTime` that `PeriodElapsedCallback` recomputes before the demag edge fires.
- **[review]** Adaptive bemf stall timeout clamped to 45000 — the 16-bit INTERVAL_TIMER (ARR 0xffff) would otherwise make `average_interval*4` unreachable at low RPM, disabling stall detection.
- **[review]** Demag duty cut handed to `tenKhzRoutine` via a latch/pending flag instead of a direct ISR write raced by the slew write-back.
- **[review]** Stale comparator EXTI pending cleared before unmask (all ported MCUs) so ring latched while masked can't fire `demagEdgeRoutine` with a bogus timestamp.
- **[review]** Makefile flag-stamp so `HWCI_PERF`/`DEMAG_COMP` changes force a rebuild (an A/B session could otherwise flash a stale artifact).

## Scope & gating

MCU layer ported for **f051, g071, g431, l431** (all compile; g431's `uint32_t commutation_interval` extern fix preserved). A `HAS_DEMAG_COMP` gate keeps every other MCU family fully inert (verified: SEQURE_4IN1_F421 builds with the feature compiled out). Both eeprom fields (bytes 184/185, in the CAN-block reserved space) default off via 0xff guards. New hot-path code is RAM_FUNC on F051.

## hwci integration

- **perf struct v5** (append-only after #29's v4 histogram, `host_cmd` frozen at 60): `demag_events` (offset 148, mirror of `demag_happened`), `blanking_len_last` (152), `blanking_len_max` (154); total 156 bytes. Host decode with full v1–v5 back-compat (used live to decode the v4 ark-release firmware during the inertness A/B), `fw_demag_events` metric (a new key alongside the host-derived detection, so old baselines stay comparable), report, sim, and tests: **244 passed**.
- **Bench knob**: `make ARK_4IN1_F051 HWCI_PERF=1 DEMAG_COMP=2` forces the level at boot without touching the eeprom, so A/B sessions flip the feature by reflashing.

## Memory (ARK_4IN1_F051, HWCI_PERF=1 DEMAG_COMP=2)

| Region | Used | %age |
|---|---|---|
| FLASH | 24496 B | 89.3% |
| RAM | 7856 B | 98.2% |

RAM headroom on HWCI builds is thin: the v5 struct now carries #29's 64-byte histogram *and* the demag block. The next RAM-costing F051 feature (or a comp-ON A/B that also wants the histogram) will need a trade — dropping the phase histogram from the bench build frees the most.

## Bench validation — RESULTS (2026-07-06)

Full report and data pointers: [`hwci/DEMAG_BENCH_FINDINGS.md`](hwci/DEMAG_BENCH_FINDINGS.md).

1. **Inertness A/B (no prop, 25 V/3 A supply, `noprop_smoke_3a`) — PASS.** vs ark-release HEAD: zero-cross jitter flat (2.31 % → 2.35 % mean, 12.2 % → 12.2 % max), CPU 62 % → 61 %, demag/bemf-timeout 0/0. The `auto_blanking` branch adds no jitter when off.
2. **`demag_step_stress` A/B (HQ5136 prop + 6S) — comp-ON FAILS.** comp-off ran the 90/95/100 % snap-steps clean (0 bemf timeouts, RPM held ~28 650 at 100 %); `DEMAG_COMP=2` desynced hard (595 bemf-timeout samples, 3 host desync events, 290 fw_demag_events; step100 RPM collapsed to a mean ~8 500). `fw_demag_events` did **not** drop with comp on — it caused the desyncs. See report for the root cause and the rework fix path.
3. `efficiency_sweep` gate vs `baselines/ARK_4IN1_F051_HQ5136.json` — not run (blocked on the comp-ON failure; efficiency is moot until the feature works).
4. Adaptive-bemf-timeout — present in both A/B builds and clean with comp off (0 timeouts), so it is not implicated in the comp-ON desync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pvp2XLcgsviGSVn9PaaP6
