### PR TITLE
feat(demag): active demag — freewheel through the FET channel instead of the body diode

### DIFF
--- a/Inc/common.h
+++ b/Inc/common.h
@@ -31,6 +31,8 @@ extern int16_t actual_current;
 extern uint16_t e_rpm;
 extern volatile uint32_t average_interval;
 extern volatile int16_t degrees_celsius;
+extern volatile uint8_t auto_blanking;
+extern volatile uint16_t blanking_length;
 
 #ifdef STMICRO
 extern GPIO_TypeDef* current_GPIO_PORT;

--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -68,7 +68,9 @@ typedef union EEprom_u {
             uint8_t filter_hz; // 181
             uint8_t debug_rate; // 182
             uint8_t term_enable; // 183
-            uint8_t reserved[8]; // 184-191
+            uint8_t demag_compensation; // 184  0=off 1=low 2=medium 3=high
+            uint8_t active_demag; // 185  0=off 1=on, requires demag_compensation
+            uint8_t reserved[6]; // 186-191
         } can;
     };
     uint8_t buffer[192];

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -42,8 +42,9 @@
 #define HWCI_PERF_MAGIC   0x31435748u
 /* v2: appended the zero-cross jitter block (zc_*) after host_cmd.
  * v3: appended zc_confirm_reject after the v2 jitter block (host_cmd stays
- *     frozen at offset 60). */
-#define HWCI_PERF_VERSION 3u
+ *     frozen at offset 60).
+ * v4: appended the demag compensation block (demag_events, blanking_len_*). */
+#define HWCI_PERF_VERSION 4u
 
 /* Commands the host may write to hwci_perf.host_cmd (cleared by firmware). */
 #define HWCI_CMD_NONE          0u
@@ -113,7 +114,16 @@ typedef struct hwci_perf_s {
      * rejected-edges-per-accepted-commutation ratio - the live monitor for
      * the F051 glitch-tolerant confirm loop's reject mechanism. */
     uint32_t zc_confirm_reject;        /* off 80 : confirm-loop early-outs  */
-} hwci_perf_t;                         /* total size: 84 bytes              */
+
+    /* --- v4: demag compensation stats (fed from the main-loop snapshot
+     * path, zero ISR cost). demag_events mirrors main.c's monotonic
+     * demag_happened counter; blanking_len_* mirror the measured demag time
+     * (INTERVAL_TIMER ticks) from demagEdgeRoutine(). Appended after the v3
+     * block so host_cmd stays frozen at offset 60. */
+    uint32_t demag_events;             /* off 84 : demag_happened mirror    */
+    uint16_t blanking_len_last;        /* off 88 : last measured demag time */
+    uint16_t blanking_len_max;         /* off 90 : worst measured demag time*/
+} hwci_perf_t;                         /* total size: 92 bytes              */
 
 extern volatile hwci_perf_t hwci_perf;
 
@@ -257,6 +267,13 @@ void hwci_perf_reset_stats(void);
             hwci_perf.running = (uint8_t)running;                              \
             hwci_perf.zero_cross_count = zero_crosses;                         \
             hwci_perf.commutation_interval = _ci;                              \
+            {                                                                  \
+                uint16_t _bl = blanking_length; /* cache the ISR-written u16 */\
+                hwci_perf.demag_events = demag_happened;                       \
+                hwci_perf.blanking_len_last = _bl;                             \
+                if (_bl > hwci_perf.blanking_len_max)                          \
+                    hwci_perf.blanking_len_max = _bl;                          \
+            }                                                                  \
             if (_ci > hwci_perf.commutation_interval_max)                      \
                 hwci_perf.commutation_interval_max = _ci;                      \
             if (_armed && !_hwci_prev_armed)                                   \

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -43,8 +43,9 @@
 /* v2: appended the zero-cross jitter block (zc_*) after host_cmd.
  * v3: appended zc_confirm_reject after the v2 jitter block (host_cmd stays
  *     frozen at offset 60).
- * v4: appended the demag compensation block (demag_events, blanking_len_*). */
-#define HWCI_PERF_VERSION 4u
+ * v4: appended the demag compensation block (demag_events, blanking_len_*).
+ * v5: appended active_demag_interlock_skips (comparator interlock vetoes). */
+#define HWCI_PERF_VERSION 5u
 
 /* Commands the host may write to hwci_perf.host_cmd (cleared by firmware). */
 #define HWCI_CMD_NONE          0u
@@ -123,7 +124,15 @@ typedef struct hwci_perf_s {
     uint32_t demag_events;             /* off 84 : demag_happened mirror    */
     uint16_t blanking_len_last;        /* off 88 : last measured demag time */
     uint16_t blanking_len_max;         /* off 90 : worst measured demag time*/
-} hwci_perf_t;                         /* total size: 92 bytes              */
+
+    /* --- v5: active-demag comparator interlock vetoes. Monotonic mirror of
+     * main.c's active_demag_interlock_skips: freewheel turn-ons skipped
+     * because the floating phase did not read as diode-clamped. Near zero in
+     * healthy operation; ~= one per commutation means the step/rising -> fet
+     * mapping is wrong for this hardware/direction (or demag never spans the
+     * scheduling point). */
+    uint32_t active_demag_interlock_skips; /* off 92 : interlock vetoes     */
+} hwci_perf_t;                         /* total size: 96 bytes              */
 
 extern volatile hwci_perf_t hwci_perf;
 
@@ -270,6 +279,8 @@ void hwci_perf_reset_stats(void);
             {                                                                  \
                 uint16_t _bl = blanking_length; /* cache the ISR-written u16 */\
                 hwci_perf.demag_events = demag_happened;                       \
+                hwci_perf.active_demag_interlock_skips =                       \
+                    active_demag_interlock_skips;                              \
                 hwci_perf.blanking_len_last = _bl;                             \
                 if (_bl > hwci_perf.blanking_len_max)                          \
                     hwci_perf.blanking_len_max = _bl;                          \

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ endif
 ifneq ($(DEMAG_COMP),)
 CFLAGS_COMMON += -DHWCI_DEMAG_COMP=$(DEMAG_COMP)
 endif
+# `ACTIVE_DEMAG=1` additionally enables the active freewheel (requires DEMAG_COMP).
+ifeq ($(ACTIVE_DEMAG),1)
+CFLAGS_COMMON += -DHWCI_ACTIVE_DEMAG=1
+endif
 
 # Linker options
 LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,14 @@ ifeq ($(HWCI_PERF),1)
 CFLAGS_COMMON += -DHWCI_PERF
 endif
 
+# Bench enablement for demag compensation (opt-in, off by default).
+# `make <TARGET> DEMAG_COMP=<1|2|3>` forces demag_comp_level at boot regardless
+# of the eeprom (byte 184 stays untouched, so a config-tool flash is not
+# needed between A/B runs). Production/release builds leave it unset.
+ifneq ($(DEMAG_COMP),)
+CFLAGS_COMMON += -DHWCI_DEMAG_COMP=$(DEMAG_COMP)
+endif
+
 # Linker options
 LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 

--- a/Mcu/f051/Inc/phaseouts.h
+++ b/Mcu/f051/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/f051/Src/comparator.c
+++ b/Mcu/f051/Src/comparator.c
@@ -27,6 +27,11 @@ COMP->CSR = COMP->CSR & ~(1<<2);
 }else{
 COMP->CSR  = COMP->CSR | 1<<2;
 }
-  EXTI->RTSR = !rising << 21;
-  EXTI->FTSR = rising << 21;
+  if (auto_blanking) { // look for the demag release edge first, reversed polarity
+    EXTI->RTSR = rising << 21;
+    EXTI->FTSR = !rising << 21;
+  } else {
+    EXTI->RTSR = !rising << 21;
+    EXTI->FTSR = rising << 21;
+  }
 }

--- a/Mcu/f051/Src/phaseouts.c
+++ b/Mcu/f051/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -167,6 +167,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -283,6 +313,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -290,6 +350,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 RAM_FUNC void comStep(char newStep)

--- a/Mcu/f051/Src/stm32f0xx_it.c
+++ b/Mcu/f051/Src/stm32f0xx_it.c
@@ -31,6 +31,7 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void doPWMChanges();
 extern void tenKhzRoutine();
 extern void sendDshotDma();
@@ -192,6 +193,11 @@ void DMA1_Channel4_5_IRQHandler(void)
 RAM_FUNC void ADC1_COMP_IRQHandler(void)
 {
   if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21) != RESET) {
+      if (auto_blanking) { // reversed polarity, this is the demag release edge
+          EXTI->PR = EXTI_LINE;
+          demagEdgeRoutine();
+          return;
+      }
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){
        EXTI->PR = EXTI_LINE;
       interruptRoutine();

--- a/Mcu/g071/Inc/phaseouts.h
+++ b/Mcu/g071/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/g071/Src/comparator.c
+++ b/Mcu/g071/Src/comparator.c
@@ -63,6 +63,17 @@ medium_speed_set = 1;
 #endif
         LL_COMP_ConfigInputs(active_COMP, PHASE_B_COMP, LL_COMP_INPUT_PLUS_IO3);
     }
+    if (auto_blanking) { // look for the demag release edge first, reversed polarity
+        if (rising) {
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_18);
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_17);
+            LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
+        } else {
+            LL_EXTI_EnableFallingTrig_0_31(current_EXTI_LINE);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_17);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_18);
+        }
+    } else {
     if (rising) {
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_18);
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_17);
@@ -71,6 +82,7 @@ medium_speed_set = 1;
         LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_17);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_18);
+    }
     }
 }
 

--- a/Mcu/g071/Src/phaseouts.c
+++ b/Mcu/g071/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -168,6 +168,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -284,6 +314,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -291,6 +351,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 void comStep(int newStep)

--- a/Mcu/g071/Src/stm32g0xx_it.c
+++ b/Mcu/g071/Src/stm32g0xx_it.c
@@ -77,6 +77,7 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void tenKhzRoutine();
 extern void processDshot();
 
@@ -236,6 +237,28 @@ void DMA1_Channel2_3_IRQHandler(void)
  */
 void ADC1_COMP_IRQHandler(void)
 {
+  if (auto_blanking) { // reversed polarity, this is the demag release edge
+    if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_18)) {
+      LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_18);
+      demagEdgeRoutine();
+      return;
+    }
+    if (LL_EXTI_IsActiveRisingFlag_0_31(LL_EXTI_LINE_18)) {
+      LL_EXTI_ClearRisingFlag_0_31(LL_EXTI_LINE_18);
+      demagEdgeRoutine();
+      return;
+    }
+    if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_17)) {
+      LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_17);
+      demagEdgeRoutine();
+      return;
+    }
+    if (LL_EXTI_IsActiveRisingFlag_0_31(LL_EXTI_LINE_17)) {
+      LL_EXTI_ClearRisingFlag_0_31(LL_EXTI_LINE_17);
+      demagEdgeRoutine();
+      return;
+    }
+  }
   if (LL_EXTI_IsActiveFallingFlag_0_31(LL_EXTI_LINE_18)) {
     if((INTERVAL_TIMER->CNT) > (average_interval >> 1)){
       LL_EXTI_ClearFallingFlag_0_31(LL_EXTI_LINE_18);

--- a/Mcu/g431/Inc/phaseouts.h
+++ b/Mcu/g431/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/g431/Src/comparator.c
+++ b/Mcu/g431/Src/comparator.c
@@ -78,6 +78,17 @@ void changeCompInput()
 
         LL_COMP_ConfigInputs(active_COMP, PHASE_B_COMP, PHASE_B_INPUT_PLUS);
     }
+    if (auto_blanking) { // look for the demag release edge first, reversed polarity
+        if (rising) {
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_22);
+            LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_21);
+            LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
+        } else {
+            LL_EXTI_EnableFallingTrig_0_31(current_EXTI_LINE);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_21);
+            LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_22);
+        }
+    } else {
     if (rising) {
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_22);
         LL_EXTI_DisableRisingTrig_0_31(LL_EXTI_LINE_21);
@@ -86,6 +97,7 @@ void changeCompInput()
         LL_EXTI_EnableRisingTrig_0_31(current_EXTI_LINE);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_21);
         LL_EXTI_DisableFallingTrig_0_31(LL_EXTI_LINE_22);
+    }
     }
 }
 

--- a/Mcu/g431/Src/phaseouts.c
+++ b/Mcu/g431/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -168,6 +168,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -284,6 +314,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -291,6 +351,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 void comStep(int newStep)

--- a/Mcu/g431/Src/stm32g4xx_it.c
+++ b/Mcu/g431/Src/stm32g4xx_it.c
@@ -9,8 +9,10 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void tenKhzRoutine();
 extern void processDshot();
+extern volatile uint8_t auto_blanking;
 
 extern volatile char send_telemetry;
 uint16_t interrupt_time = 0;
@@ -97,6 +99,18 @@ void DMA1_Channel1_IRQHandler(void)
 
 void COMP1_2_3_IRQHandler(void)
 {
+	if (auto_blanking) { // reversed polarity, this is the demag release edge
+		if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_22)) {
+			LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_22);
+			demagEdgeRoutine();
+			return;
+		}
+		if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_21)) {
+			LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_21);
+			demagEdgeRoutine();
+			return;
+		}
+	}
 	if(INTERVAL_TIMER->CNT > (commutation_interval>>1)){
     interrupt++;
     if (LL_EXTI_IsActiveFlag_0_31(LL_EXTI_LINE_22)) {

--- a/Mcu/l431/Inc/phaseouts.h
+++ b/Mcu/l431/Inc/phaseouts.h
@@ -18,5 +18,18 @@ void allpwm();
 void proportionalBrake();
 void twoChannelForward();
 void twoChannelReverse();
+void phaseAHIGH();
+void phaseBHIGH();
+void phaseCHIGH();
+void phaseALOW();
+void phaseBLOW();
+void phaseCLOW();
+void phaseAFLOAT();
+void phaseBFLOAT();
+void phaseCFLOAT();
+void activeDemagFetOn();
+void activeDemagFetOff();
+#define HAS_PHASE_HIGH
+#define HAS_DEMAG_COMP
 
 #endif /* INC_PHASEOUTS_H_ */

--- a/Mcu/l431/Src/comparator.c
+++ b/Mcu/l431/Src/comparator.c
@@ -25,12 +25,22 @@ void changeCompInput() {
 	if (step == 3 || step == 6) {      // b floating
     LL_COMP_ConfigInputs(MAIN_COMP, PHASE_B_COMP, COMMON_COMP);
 	}
+	if (auto_blanking) { // look for the demag release edge first, reversed polarity
+	if (rising){
+		  LL_EXTI_DisableFallingTrig_0_31(EXTI_LINE);
+		  LL_EXTI_EnableRisingTrig_0_31(EXTI_LINE);
+	}else{
+		  LL_EXTI_DisableRisingTrig_0_31(EXTI_LINE);
+		  LL_EXTI_EnableFallingTrig_0_31(EXTI_LINE);
+	}
+	} else {
 	if (rising){
 		  LL_EXTI_DisableRisingTrig_0_31(EXTI_LINE);
 		  LL_EXTI_EnableFallingTrig_0_31(EXTI_LINE);
 	}else{                          // falling bemf
 		  LL_EXTI_EnableRisingTrig_0_31(EXTI_LINE);
 		  LL_EXTI_DisableFallingTrig_0_31(EXTI_LINE);
+	}
 	}
 }
 

--- a/Mcu/l431/Src/phaseouts.c
+++ b/Mcu/l431/Src/phaseouts.c
@@ -23,10 +23,10 @@ extern char prop_brake_active;
 
 #ifdef USE_INVERTED_HIGH
 #pragma message("using inverted high side output")
-// #define HIGH_BITREG_ON  BRR
+#define HIGH_BITREG_ON BRR
 #define HIGH_BITREG_OFF BSRR
 #else
-// #define HIGH_BITREG_ON  BSRR
+#define HIGH_BITREG_ON BSRR
 #define HIGH_BITREG_OFF BRR
 #endif
 
@@ -167,6 +167,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_OFF = PHASE_A_GPIO_HIGH;
 }
 
+void phaseAHIGH()
+{ // high mosfet hard on, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_LOW, PHASE_A_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_A_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_HIGH, PHASE_A_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_A_GPIO_HIGH;
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_LOW, PHASE_B_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_B_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_HIGH, PHASE_B_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_B_GPIO_HIGH;
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_LOW, PHASE_C_GPIO_LOW,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_LOW->LOW_BITREG_OFF = PHASE_C_GPIO_LOW;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_HIGH, PHASE_C_GPIO_HIGH,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_HIGH->HIGH_BITREG_ON = PHASE_C_GPIO_HIGH;
+}
+
 #else
 
 //////////////////////////////////PHASE 1//////////////////////
@@ -283,6 +313,36 @@ void phaseALOW()
     PHASE_A_GPIO_PORT_PWM->BRR = PHASE_A_GPIO_PWM;
 }
 
+void phaseAHIGH()
+{ // high side on steadily, used for active demag
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_ENABLE, PHASE_A_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_A_GPIO_PORT_ENABLE->BSRR = PHASE_A_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_A_GPIO_PORT_PWM, PHASE_A_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_A_GPIO_PORT_PWM->BSRR = PHASE_A_GPIO_PWM; // pwm pin high
+}
+
+void phaseBHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_ENABLE, PHASE_B_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_B_GPIO_PORT_ENABLE->BSRR = PHASE_B_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_B_GPIO_PORT_PWM, PHASE_B_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_B_GPIO_PORT_PWM->BSRR = PHASE_B_GPIO_PWM; // pwm pin high
+}
+
+void phaseCHIGH()
+{
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_ENABLE, PHASE_C_GPIO_ENABLE,
+        LL_GPIO_MODE_OUTPUT); // enable on
+    PHASE_C_GPIO_PORT_ENABLE->BSRR = PHASE_C_GPIO_ENABLE;
+    LL_GPIO_SetPinMode(PHASE_C_GPIO_PORT_PWM, PHASE_C_GPIO_PWM,
+        LL_GPIO_MODE_OUTPUT);
+    PHASE_C_GPIO_PORT_PWM->BSRR = PHASE_C_GPIO_PWM; // pwm pin high
+}
+
 #endif
 
 void allOff()
@@ -290,6 +350,52 @@ void allOff()
     phaseAFLOAT();
     phaseBFLOAT();
     phaseCFLOAT();
+}
+
+// Active demag: turn on the fet whose body diode is carrying the freewheel
+// current so the demag current circulates through the channel instead of the
+// body diode. The floating phase is selected by the commutation step and the
+// conducting side by the zero cross direction. Defined here (not main.c) so
+// gcc can inline the phaseX bodies in this translation unit. Deliberately NOT
+// RAM_FUNC: with the inlined phase bodies the pair costs ~500 B and does not
+// fit the F051's 8 KB RAM alongside the HWCI_PERF instrumentation; the flash
+// fetch penalty (1WS) is well under the 0.5 us timer tick that active demag
+// scheduling resolves.
+extern char step;
+extern volatile char rising;
+
+void activeDemagFetOn()
+{
+    if (step == 1 || step == 4) { // c floating
+        if (rising) {
+            phaseCHIGH();
+        } else {
+            phaseCLOW();
+        }
+    } else if (step == 2 || step == 5) { // a floating
+        if (rising) {
+            phaseAHIGH();
+        } else {
+            phaseALOW();
+        }
+    } else { // b floating
+        if (rising) {
+            phaseBHIGH();
+        } else {
+            phaseBLOW();
+        }
+    }
+}
+
+void activeDemagFetOff()
+{
+    if (step == 1 || step == 4) {
+        phaseCFLOAT();
+    } else if (step == 2 || step == 5) {
+        phaseAFLOAT();
+    } else {
+        phaseBFLOAT();
+    }
 }
 
 void comStep(char newStep)

--- a/Mcu/l431/Src/stm32l4xx_it.c
+++ b/Mcu/l431/Src/stm32l4xx_it.c
@@ -30,6 +30,7 @@
 extern void transfercomplete();
 extern void PeriodElapsedCallback();
 extern void interruptRoutine();
+extern void demagEdgeRoutine();
 extern void tenKhzRoutine();
 extern void processDshot();
 
@@ -277,10 +278,15 @@ void COMP_IRQHandler(void)
 {
 
     if (LL_EXTI_IsActiveFlag_0_31(EXTI_LINE) != RESET) {
+      if (auto_blanking) { // reversed polarity, this is the demag release edge
+          LL_EXTI_ClearFlag_0_31(EXTI_LINE);
+          demagEdgeRoutine();
+          return;
+      }
       if((INTERVAL_TIMER->CNT) > ((average_interval>>1))){
        LL_EXTI_ClearFlag_0_31(EXTI_LINE);
       interruptRoutine();
-  }else{ 
+  }else{
       if (getCompOutputLevel() == rising){
       LL_EXTI_ClearFlag_0_31(EXTI_LINE);
   }

--- a/Src/hwci_perf.c
+++ b/Src/hwci_perf.c
@@ -42,6 +42,7 @@ void hwci_perf_reset_stats(void)
     hwci_perf.main_loop_us_max = 0;
     hwci_perf.commutation_interval_max = 0;
     hwci_perf.zc_jitter_max = 0;
+    hwci_perf.blanking_len_max = 0;
 }
 
 /*

--- a/Src/main.c
+++ b/Src/main.c
@@ -376,6 +376,7 @@ volatile uint8_t auto_blanking = 0; // comparator armed for the demag release ed
 uint8_t active_demag = 0; // circulate demag current through the fet instead of the body diode
 volatile uint8_t active_demag_fet_on = 0;
 volatile uint16_t active_demag_ticks = 0; // fet on time, half of last measured demag time
+volatile uint32_t active_demag_interlock_skips = 0; // freewheels vetoed by the comparator interlock
 volatile uint32_t demag_happened = 0;
 char maximum_throttle_change_ramp = 1;
 
@@ -973,15 +974,29 @@ RAM_FUNC void PeriodElapsedCallback()
     HWCI_PERF_ZC(); // active demag scheduling stays after this so jitter metrics are unaffected
 #ifdef HAS_PHASE_HIGH
     if (active_demag && auto_blanking && running && (active_demag_ticks > 3)) {
-        // The previously conducting fet has been off since comStep() at the top
-        // of commutate(), several microseconds ago, so no cross conduction here.
-        uint16_t t = active_demag_ticks;
-        if (t > (waitTime >> 1)) {
-            t = waitTime >> 1; // re-cap: waitTime may have shrunk since the measurement
+        // Interlock: during demag the floating phase is diode-clamped to the
+        // far rail, which the comparator reads as the post-cross level
+        // (!rising - see the reversed-polarity demag-edge arm). Reading the
+        // pre-cross level here means either the step/rising -> fet mapping is
+        // wrong for this hardware/direction (energizing that fet would fight
+        // the conducting diode with an uncontrolled VBAT/L current ramp) or
+        // demag has already released (the fet would short the bemf). Both
+        // veto the freewheel for this step; the counter makes a systematic
+        // mapping fault visible on the bench as skips ~= commutations.
+        if (getCompOutputLevel() == (uint8_t)rising) {
+            active_demag_interlock_skips++;
+        } else {
+            // The previously conducting fet has been off since comStep() at the
+            // top of commutate(), several microseconds ago, so no cross
+            // conduction here.
+            uint16_t t = active_demag_ticks;
+            if (t > (waitTime >> 1)) {
+                t = waitTime >> 1; // re-cap: waitTime may have shrunk since the measurement
+            }
+            activeDemagFetOn();
+            active_demag_fet_on = 1;
+            SET_AND_ENABLE_COM_INT(t); // schedule the fet off event
         }
-        activeDemagFetOn();
-        active_demag_fet_on = 1;
-        SET_AND_ENABLE_COM_INT(t); // schedule the fet off event
     }
 #endif
 }

--- a/Src/main.c
+++ b/Src/main.c
@@ -824,6 +824,9 @@ void loadEEpromSettings()
         eepromBuffer.can.active_demag = 0;
     }
     active_demag = eepromBuffer.can.active_demag && demag_comp_level; // needs the demag time measurement running
+#ifdef HWCI_DEMAG_COMP
+    demag_comp_level = HWCI_DEMAG_COMP; // bench build: force on without touching the eeprom
+#endif
 #else
     demag_comp_level = 0;
     active_demag = 0;

--- a/Src/main.c
+++ b/Src/main.c
@@ -946,6 +946,13 @@ RAM_FUNC void commutate()
 RAM_FUNC void PeriodElapsedCallback()
 {
     DISABLE_COM_TIMER_INT(); // disable interrupt
+#ifdef HAS_PHASE_HIGH
+    if (active_demag_fet_on) { // second COM_TIMER event this step: end of active freewheel.
+        activeDemagFetOff(); // Guard sits before commutate() and HWCI_PERF_ZC() so this
+        active_demag_fet_on = 0; // event never double-counts a commutation.
+        return;
+    }
+#endif
     commutate();
     commutation_interval = ((commutation_interval)+((lastzctime + thiszctime) >> 1))>>1;
   	if (!eepromBuffer.auto_advance) {
@@ -960,7 +967,20 @@ RAM_FUNC void PeriodElapsedCallback()
     if (zero_crosses < 10000) {
         zero_crosses++;
     }
-    HWCI_PERF_ZC();
+    HWCI_PERF_ZC(); // active demag scheduling stays after this so jitter metrics are unaffected
+#ifdef HAS_PHASE_HIGH
+    if (active_demag && auto_blanking && running && (active_demag_ticks > 3)) {
+        // The previously conducting fet has been off since comStep() at the top
+        // of commutate(), several microseconds ago, so no cross conduction here.
+        uint16_t t = active_demag_ticks;
+        if (t > (waitTime >> 1)) {
+            t = waitTime >> 1; // re-cap: waitTime may have shrunk since the measurement
+        }
+        activeDemagFetOn();
+        active_demag_fet_on = 1;
+        SET_AND_ENABLE_COM_INT(t); // schedule the fet off event
+    }
+#endif
 }
 
 /*
@@ -1025,6 +1045,14 @@ RAM_FUNC void interruptRoutine()
 #endif
     __disable_irq();
     maskPhaseInterrupts();
+#ifdef HAS_PHASE_HIGH
+    if (active_demag_fet_on) { // zero cross arrived before the off event fired
+        activeDemagFetOff();
+        active_demag_fet_on = 0; // must clear or the COM_TIMER event armed below
+                                 // would be eaten by the guard at the top of
+                                 // PeriodElapsedCallback()
+    }
+#endif
     lastzctime = thiszctime;
     thiszctime = INTERVAL_TIMER_COUNT;
     SET_INTERVAL_TIMER_COUNT(0);

--- a/Src/main.c
+++ b/Src/main.c
@@ -1023,11 +1023,73 @@ RAM_FUNC void interruptRoutine()
     __disable_irq();
     maskPhaseInterrupts();
     lastzctime = thiszctime;
-    thiszctime = INTERVAL_TIMER_COUNT;  
+    thiszctime = INTERVAL_TIMER_COUNT;
     SET_INTERVAL_TIMER_COUNT(0);
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
+    if (demag_comp_level && (input > 400) && (commutation_interval > 100)) {
+        auto_blanking = 1; // next commutation watches for the demag release edge first
+    }
     __enable_irq();
 }
+
+#ifdef HAS_DEMAG_COMP
+/*
+ * @brief   Called by the comparator interrupt handler when the reversed
+ *          polarity edge fires while auto_blanking is armed. This is the
+ *          moment the freewheel diode stops clamping the floating phase;
+ *          the time from commutation to this edge is the demag time.
+ *          RAM_FUNC is mandatory: the caller is a RAM-resident ISR.
+ */
+RAM_FUNC void demagEdgeRoutine()
+{
+    uint16_t time_since_zc = INTERVAL_TIMER_COUNT;
+    auto_blanking = 0;
+    changeCompInput(); // polarity back to normal to catch the real zero cross
+    if (time_since_zc > waitTime) { // commutation happened at ~waitTime after the last zero cross
+        blanking_length = time_since_zc - waitTime;
+        if (blanking_length > average_interval) {
+            blanking_length = average_interval; // measurement can't be longer than a commutation
+        }
+        active_demag_ticks = blanking_length >> 1; // active freewheel for half the measured demag time
+        if (active_demag_ticks > (waitTime >> 1)) {
+            active_demag_ticks = waitTime >> 1; // fet always off well before the expected zero cross
+        }
+    } else { // edge fired before commutation: noise, measurement is invalid
+        blanking_length = 0;
+        active_demag_ticks = 0; // no stale active freewheel from a bad measurement
+    }
+    if (blanking_length > (average_interval >> 1)) { // demag ran past the expected zero cross point
+        demag_happened++;
+        allOff(); // power off until next commutation, winding current must decay
+        uint16_t dc = duty_cycle; // snapshot, ISRs can change duty_cycle between reads
+        uint16_t demag_cut;
+        switch (demag_comp_level) {
+        case 1:
+            demag_cut = dc - (dc >> 2); // cut 25 percent
+            break;
+        case 2:
+            demag_cut = dc >> 1; // cut 50 percent
+            break;
+        case 3:
+            demag_cut = dc >> 2; // cut 75 percent
+            break;
+        default:
+            demag_cut = dc; // no cut
+            break;
+        }
+        if (demag_cut < minimum_duty_cycle) {
+            demag_cut = minimum_duty_cycle;
+        }
+        last_duty_cycle = demag_cut;
+        duty_cycle = demag_cut;
+        // Re-entering interruptRoutine() is safe: auto_blanking is already
+        // cleared so the comparator re-arms with normal polarity, and the
+        // zero-cross confirm loop at its top guards against treating this
+        // demag edge as a false commutation.
+        interruptRoutine();
+    }
+}
+#endif
 
 void startMotor()
 {
@@ -1036,6 +1098,9 @@ void startMotor()
         commutation_interval = 10000;
         SET_INTERVAL_TIMER_COUNT(5000);
         running = 1;
+        auto_blanking = 0;
+        active_demag_fet_on = 0;
+        active_demag_ticks = 0;
     }
     enableCompInterrupts();
 }
@@ -2134,6 +2199,9 @@ if(zero_crosses < 5){
                     average_interval = 5000;
                 }
                 last_duty_cycle = min_startup_duty / 2;
+                auto_blanking = 0;
+                active_demag_fet_on = 0;
+                active_demag_ticks = 0;
             }
             desync_check = 0;
             //	}
@@ -2334,6 +2402,9 @@ if(zero_crosses < 5){
                 bemf_timeout_happened++;
 
                 maskPhaseInterrupts();
+                auto_blanking = 0;
+                active_demag_fet_on = 0;
+                active_demag_ticks = 0;
                 old_routine = 1;
                 if (input < 48) {
                     running = 0;

--- a/Src/main.c
+++ b/Src/main.c
@@ -370,6 +370,13 @@ uint32_t desync_happened = 0;
 #else
 uint8_t desync_happened = 0;
 #endif
+uint8_t demag_comp_level = 0; // 0=off, 1=low, 2=medium, 3=high
+volatile uint16_t blanking_length = 0; // measured demag time in interval timer ticks
+volatile uint8_t auto_blanking = 0; // comparator armed for the demag release edge first
+uint8_t active_demag = 0; // circulate demag current through the fet instead of the body diode
+volatile uint8_t active_demag_fet_on = 0;
+volatile uint16_t active_demag_ticks = 0; // fet on time, half of last measured demag time
+volatile uint32_t demag_happened = 0;
 char maximum_throttle_change_ramp = 1;
 
 char crawler_mode = 0; // no longer used //
@@ -406,7 +413,7 @@ uint16_t low_pin_count = 0;
 uint8_t max_duty_cycle_change = 2;
 char fast_accel = 1;
 char fast_deccel = 0;
-uint16_t last_duty_cycle = 0;
+volatile uint16_t last_duty_cycle = 0;
 uint16_t duty_cycle_setpoint = 0;
 char play_tone_flag = 0;
 
@@ -806,8 +813,21 @@ void loadEEpromSettings()
             low_rpm_throttle_limit = 0;
         }
         low_rpm_level = motor_kv / 100 / (32 / eepromBuffer.motor_poles);
-        high_rpm_level = motor_kv / 12 / (32 / eepromBuffer.motor_poles);				
+        high_rpm_level = motor_kv / 12 / (32 / eepromBuffer.motor_poles);
     }
+#ifdef HAS_DEMAG_COMP
+    if (eepromBuffer.can.demag_compensation > 3) { // erased flash reads 0xff, default off
+        eepromBuffer.can.demag_compensation = 0;
+    }
+    demag_comp_level = eepromBuffer.can.demag_compensation;
+    if (eepromBuffer.can.active_demag > 1) { // erased flash reads 0xff, default off
+        eepromBuffer.can.active_demag = 0;
+    }
+    active_demag = eepromBuffer.can.active_demag && demag_comp_level; // needs the demag time measurement running
+#else
+    demag_comp_level = 0;
+    active_demag = 0;
+#endif
     reverse_speed_threshold = map(motor_kv, 300, 3000, 1000, 500);
     if (eepromBuffer.bi_direction){
       polling_mode_changeover = POLLING_MODE_THRESHOLD / 2;

--- a/Src/main.c
+++ b/Src/main.c
@@ -827,6 +827,9 @@ void loadEEpromSettings()
 #ifdef HWCI_DEMAG_COMP
     demag_comp_level = HWCI_DEMAG_COMP; // bench build: force on without touching the eeprom
 #endif
+#ifdef HWCI_ACTIVE_DEMAG
+    active_demag = (demag_comp_level != 0); // bench build: active demag rides on demag comp
+#endif
 #else
     demag_comp_level = 0;
     active_demag = 0;

--- a/Src/main.c
+++ b/Src/main.c
@@ -2398,7 +2398,13 @@ if(zero_crosses < 5){
                 }
             }
 #endif
-            if (INTERVAL_TIMER_COUNT > 45000 && running == 1) {
+            uint32_t interval_threshold;
+            if (zero_crosses > 50) { // running steadily: a missing zero cross shows up
+                interval_threshold = average_interval * 4; // within a few commutations
+            } else {
+                interval_threshold = 45000; // starting: keep the long fixed timeout
+            }
+            if (INTERVAL_TIMER_COUNT > interval_threshold && running == 1) {
                 bemf_timeout_happened++;
 
                 maskPhaseInterrupts();

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -222,6 +222,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
     zc_jmax = _col(rows, "perf_zc_jitter_max")
     zc_reject = _col(rows, "perf_zc_confirm_reject")
     fw_demag = _col(rows, "perf_demag_events")
+    fw_interlock = _col(rows, "perf_interlock_skips")
 
     steady_points = []
     for s in profile.segments:
@@ -297,6 +298,11 @@ def compute(run: RunResult, profile: Profile) -> dict:
         # baselines stay comparable.
         "fw_demag_events": fw_counter_delta(
             fw_demag, np.arange(len(rows))),
+        # Active-demag interlock vetoes over the whole run (struct v5+, None
+        # on older firmware). ~0 healthy; ~= total commutations means the
+        # step/rising -> fet mapping is wrong - abort active-demag benching.
+        "fw_interlock_skips": fw_counter_delta(
+            fw_interlock, np.arange(len(rows))),
         "bemf_timeout_samples": demag["bemf_timeout_samples"],
         # start-attempt outcomes; None/0 unless the profile has start* segments
         "start_attempts": starts["attempts"] or None,

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -181,6 +181,22 @@ def counter_per_zc(counter: np.ndarray, count: np.ndarray,
     return round(_wrap32(counter[a], counter[b]) / n, 4)
 
 
+def fw_counter_delta(counter: np.ndarray, idx: np.ndarray) -> int | None:
+    """Delta of a monotonic firmware u32 counter over the sample window ``idx``.
+
+    Differencing the first and last valid snapshot counts every increment
+    regardless of the host sampling rate (wrap-safe like the zc_* sums).
+    Returns ``None`` when the firmware predates the counter (all blank) or the
+    window has fewer than two valid samples.
+    """
+    if idx.size == 0:
+        return None
+    valid = idx[~np.isnan(counter[idx])]
+    if valid.size < 2:
+        return None
+    return _wrap32(counter[valid[0]], counter[valid[-1]])
+
+
 def compute(run: RunResult, profile: Profile) -> dict:
     rows = run.rows
     seg = np.array([r.get("segment") for r in rows], dtype=object)
@@ -205,6 +221,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
     zc_isum = _col(rows, "perf_zc_interval_sum")
     zc_jmax = _col(rows, "perf_zc_jitter_max")
     zc_reject = _col(rows, "perf_zc_confirm_reject")
+    fw_demag = _col(rows, "perf_demag_events")
 
     steady_points = []
     for s in profile.segments:
@@ -235,6 +252,10 @@ def compute(run: RunResult, profile: Profile) -> dict:
             "zc_jitter_max_pct": jitter["max_pct"],
             # rejected edges per accepted zero-cross (report-only, v3+)
             "confirm_rejects_per_zc": counter_per_zc(zc_reject, zc_count, tail),
+            # firmware-counted demag events in this steady tail (struct v4+,
+            # monotonic demag_happened mirror). A NEW key alongside the
+            # host-derived detection so old baselines stay comparable.
+            "fw_demag_events": fw_counter_delta(fw_demag, tail),
         })
 
     demag = detect_demag(run, profile)
@@ -270,6 +291,12 @@ def compute(run: RunResult, profile: Profile) -> dict:
             (p["zc_jitter_max_pct"] for p in steady_points
              if p.get("zc_jitter_max_pct") is not None), default=None),
         "demag_events": demag["event_count"],
+        # Firmware's own demag counter over the whole run (struct v3+, None on
+        # older firmware). Reported ALONGSIDE the host-derived demag_events
+        # above - it does not replace the host detection, so runs against old
+        # baselines stay comparable.
+        "fw_demag_events": fw_counter_delta(
+            fw_demag, np.arange(len(rows))),
         "bemf_timeout_samples": demag["bemf_timeout_samples"],
         # start-attempt outcomes; None/0 unless the profile has start* segments
         "start_attempts": starts["attempts"] or None,

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -36,6 +36,9 @@ COLUMNS = [
     "perf_zc_jitter_max",
     # confirm-loop rejection counter (struct v3+; blank on older firmware)
     "perf_zc_confirm_reject",
+    # demag compensation stats (struct v4+; blank when the flashed firmware
+    # predates them - metrics treat blank as "metric unavailable")
+    "perf_demag_events", "perf_blanking_len_last", "perf_blanking_len_max",
     "perf_bemf_timeout", "perf_e_rpm",
     # ESC input/arming state (proves the ESC decoded the throttle protocol)
     "perf_input", "perf_armed", "perf_running",
@@ -101,6 +104,12 @@ def make_row(t: float, segment: str, throttle_cmd: float,
             )
         if "zc_confirm_reject" in r:  # struct v3+
             row.update(perf_zc_confirm_reject=r["zc_confirm_reject"])
+        if "demag_events" in r:  # struct v4+
+            row.update(
+                perf_demag_events=r["demag_events"],
+                perf_blanking_len_last=r["blanking_len_last"],
+                perf_blanking_len_max=r["blanking_len_max"],
+            )
     return row
 
 

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -39,6 +39,8 @@ COLUMNS = [
     # demag compensation stats (struct v4+; blank when the flashed firmware
     # predates them - metrics treat blank as "metric unavailable")
     "perf_demag_events", "perf_blanking_len_last", "perf_blanking_len_max",
+    # active-demag interlock vetoes (struct v5+; blank on older firmware)
+    "perf_interlock_skips",
     "perf_bemf_timeout", "perf_e_rpm",
     # ESC input/arming state (proves the ESC decoded the throttle protocol)
     "perf_input", "perf_armed", "perf_running",
@@ -110,6 +112,8 @@ def make_row(t: float, segment: str, throttle_cmd: float,
                 perf_blanking_len_last=r["blanking_len_last"],
                 perf_blanking_len_max=r["blanking_len_max"],
             )
+        if "active_demag_interlock_skips" in r:  # struct v5+
+            row.update(perf_interlock_skips=r["active_demag_interlock_skips"])
     return row
 
 

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 4
+VERSION = 5
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -79,10 +79,17 @@ FIELDS_V4: list[tuple[str, str]] = FIELDS_V3 + [
     ("blanking_len_max", "H"),
 ]
 
-FIELDS: list[tuple[str, str]] = FIELDS_V4  # canonical == newest
+# v5 appends the active-demag comparator-interlock veto counter (monotonic;
+# freewheel turn-ons skipped because the floating phase did not read as
+# diode-clamped - the mapping-fault detector for active demag).
+FIELDS_V5: list[tuple[str, str]] = FIELDS_V4 + [
+    ("active_demag_interlock_skips", "I"),
+]
+
+FIELDS: list[tuple[str, str]] = FIELDS_V5  # canonical == newest
 
 FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
-    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4}
+    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4, 5: FIELDS_V5}
 
 
 def _format(fields: list[tuple[str, str]]) -> str:
@@ -93,7 +100,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 92 bytes (v3: 84, v2: 80, v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 96 bytes (v4: 92, v3: 84, v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 3
+VERSION = 4
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -70,10 +70,19 @@ FIELDS_V3: list[tuple[str, str]] = FIELDS_V2 + [
     ("zc_confirm_reject", "I"),
 ]
 
-FIELDS = FIELDS_V3
+# v4 appends the demag compensation block (demag_events mirrors the firmware's
+# monotonic demag_happened counter; blanking_len_* mirror the measured demag
+# time from demagEdgeRoutine, in INTERVAL_TIMER ticks).
+FIELDS_V4: list[tuple[str, str]] = FIELDS_V3 + [
+    ("demag_events", "I"),
+    ("blanking_len_last", "H"),
+    ("blanking_len_max", "H"),
+]
+
+FIELDS: list[tuple[str, str]] = FIELDS_V4  # canonical == newest
 
 FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
-    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3}
+    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4}
 
 
 def _format(fields: list[tuple[str, str]]) -> str:
@@ -84,7 +93,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 84 bytes (v2: 80, v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 92 bytes (v3: 84, v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.
@@ -114,7 +123,8 @@ class PerfSample:
     """One decoded snapshot of the firmware instrumentation struct.
 
     ``raw`` holds only the fields the sampled firmware actually has: a v1
-    sample has no ``zc_*`` keys. Downstream consumers use ``raw.get()``.
+    sample has no ``zc_*`` keys, and pre-v3 samples have no ``demag_events``
+    or ``blanking_len_*`` keys. Downstream consumers use ``raw.get()``.
     """
 
     raw: dict

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -52,7 +52,9 @@ class PerfReader:
             return
         # Pick the canonical layout matching the firmware's vintage by probing
         # for version-marker members, then verify every field of THAT layout.
-        if "demag_events" in members:
+        if "active_demag_interlock_skips" in members:
+            fields = perf.FIELDS_V5
+        elif "demag_events" in members:
             fields = perf.FIELDS_V4
         elif "zc_confirm_reject" in members:
             fields = perf.FIELDS_V3

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -52,7 +52,9 @@ class PerfReader:
             return
         # Pick the canonical layout matching the firmware's vintage by probing
         # for version-marker members, then verify every field of THAT layout.
-        if "zc_confirm_reject" in members:
+        if "demag_events" in members:
+            fields = perf.FIELDS_V4
+        elif "zc_confirm_reject" in members:
             fields = perf.FIELDS_V3
         elif "zc_count" in members:
             fields = perf.FIELDS_V2

--- a/hwci/hwci/report.py
+++ b/hwci/hwci/report.py
@@ -43,7 +43,7 @@ def render_markdown(metrics: dict, comparison: dict | None = None,
         cols = ["segment", "throttle", "rpm", "thrust_gf", "current_a",
                 "voltage_v", "elec_power_w", "eff_gf_per_w",
                 "ctrl_exec_us_max", "cpu_load_pct",
-                "zc_jitter_pct", "zc_jitter_max_pct"]
+                "zc_jitter_pct", "zc_jitter_max_pct", "fw_demag_events"]
         out.append("| " + " | ".join(cols) + " |")
         out.append("|" + "---|" * len(cols))
         for p in pts:
@@ -63,7 +63,10 @@ def render_markdown(metrics: dict, comparison: dict | None = None,
 
     d = metrics.get("demag", {})
     out.append("## Demag / desync\n")
-    out.append(f"- events: **{d.get('event_count', 0)}**")
+    out.append(f"- events (host-derived): **{d.get('event_count', 0)}**")
+    fw_ev = metrics.get("summary", {}).get("fw_demag_events")
+    out.append(f"- firmware demag counter (struct v3+): "
+               f"{_fmt(fw_ev)}")
     out.append(f"- bemf-timeout samples: {d.get('bemf_timeout_samples', 0)}")
     out.append(f"- commutation-spike samples: {d.get('comm_spike_samples', 0)}")
     out.append(f"- ESC-eRPM vs stand-RPM mismatch samples: "

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -69,6 +69,13 @@ class RigSimulator:
         self.zc_jitter_max = 0
         # confirm-loop rejection counter (perf struct v3)
         self.zc_confirm_reject = 0
+        # demag compensation stats (perf struct v4). The sim maps each injected
+        # desync to one firmware-counted demag event; blanking_len_* stay 0
+        # (the sim has no demag-time model - 0 is what real firmware reports
+        # with demag compensation disabled).
+        self.demag_events = 0
+        self.blanking_len_last = 0
+        self.blanking_len_max = 0
 
     # --- model -------------------------------------------------------
     def _rpm_max(self) -> float:
@@ -89,6 +96,7 @@ class RigSimulator:
                 and provisional_current > p.demag_current_a):
             self.desync_remaining = p.desync_ticks
             self.desync_count += 1
+            self.demag_events = (self.demag_events + 1) & 0xFFFFFFFF
 
         if self.desync_remaining > 0:
             # Loss of sync: rotor falls back, electrical drive flails.
@@ -237,4 +245,7 @@ class RigSimulator:
             "zc_interval_sum": self.zc_interval_sum,
             "zc_jitter_max": self.zc_jitter_max,
             "zc_confirm_reject": self.zc_confirm_reject,
+            "demag_events": self.demag_events,
+            "blanking_len_last": self.blanking_len_last,
+            "blanking_len_max": self.blanking_len_max,
         })

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -76,6 +76,9 @@ class RigSimulator:
         self.demag_events = 0
         self.blanking_len_last = 0
         self.blanking_len_max = 0
+        # active-demag interlock vetoes (perf struct v5); the sim never
+        # freewheels, so a healthy rig reports 0
+        self.active_demag_interlock_skips = 0
 
     # --- model -------------------------------------------------------
     def _rpm_max(self) -> float:
@@ -248,4 +251,5 @@ class RigSimulator:
             "demag_events": self.demag_events,
             "blanking_len_last": self.blanking_len_last,
             "blanking_len_max": self.blanking_len_max,
+            "active_demag_interlock_skips": self.active_demag_interlock_skips,
         })

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 92
+    assert sym.size == perf.SIZE == 96
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 84
+    assert sym.size == perf.SIZE == 92
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -361,3 +361,16 @@ def test_fw_demag_events_survives_u32_wrap():
                  % (1 << 32))
     m = metricsmod.compute(RunResult(rows=rows), _profile())
     assert m["summary"]["fw_demag_events"] == 1
+
+
+def test_fw_interlock_skips_from_counter_delta():
+    # v5 interlock veto counter: whole-run first-to-last delta in the summary.
+    rows = _rows(100, perf_interlock_skips=lambda i: 1 + (5 if i >= 80 else 0))
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_interlock_skips"] == 5
+
+
+def test_fw_interlock_skips_none_for_pre_v5_runs():
+    rows = _rows(50, perf_loop_iters=lambda i: 1200 * i)
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_interlock_skips"] is None

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -332,3 +332,32 @@ def test_confirm_rejects_none_for_v2_runs():
     )
     m = metricsmod.compute(RunResult(rows=rows), _profile())
     assert m["steady_points"][0]["confirm_rejects_per_zc"] is None
+
+def test_fw_demag_events_from_counter_delta():
+    # Firmware demag_happened is a monotonic u32 (struct v3+): the metric is
+    # the first-to-last snapshot delta, per steady tail and over the run.
+    n = 100
+    rows = _rows(n, perf_demag_events=lambda i: 3 + (2 if i >= 50 else 0))
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_demag_events"] == 2
+    # the steady tail (last half of the segment) starts after the jump
+    assert m["steady_points"][0]["fw_demag_events"] == 0
+    # host-derived detection is untouched by the firmware counter
+    assert m["summary"]["demag_events"] == 0
+
+
+def test_fw_demag_events_none_for_pre_v3_runs():
+    # Runs captured on pre-v3 firmware have no perf_demag_events column: the
+    # metric must report None (unavailable), never 0.
+    rows = _rows(50, perf_loop_iters=lambda i: 1200 * i)
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_demag_events"] is None
+    assert m["steady_points"][0]["fw_demag_events"] is None
+
+
+def test_fw_demag_events_survives_u32_wrap():
+    start = (1 << 32) - 1
+    rows = _rows(50, perf_demag_events=lambda i: (start + (1 if i >= 25 else 0))
+                 % (1 << 32))
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["summary"]["fw_demag_events"] == 1

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -10,7 +10,8 @@ def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[1] == 64
     assert perf.SIZE_BY_VERSION[2] == 80
     assert perf.SIZE_BY_VERSION[3] == 84
-    assert perf.SIZE == perf.SIZE_BY_VERSION[4] == 92
+    assert perf.SIZE_BY_VERSION[4] == 92
+    assert perf.SIZE == perf.SIZE_BY_VERSION[5] == 96
 
 
 def test_host_cmd_offset_matches_layout():
@@ -157,3 +158,19 @@ def test_v2_decodes_from_oversized_read():
     s = perf.decode(blob)
     assert s.raw["zc_count"] == 9
     assert "demag_events" not in s.raw
+
+
+def test_v5_roundtrip_interlock_skips():
+    blob = perf.encode({"active_demag_interlock_skips": 31337})
+    assert len(blob) == 96
+    assert perf.decode(blob).raw["active_demag_interlock_skips"] == 31337
+
+
+def test_v4_roundtrip_has_no_interlock_key():
+    # v4 firmware (demag block, pre interlock counter) must keep decoding
+    # without the v5 key - the base demag-comp PR flashes exactly this layout.
+    blob = perf.encode({"demag_events": 3}, version=4)
+    assert len(blob) == perf.SIZE_BY_VERSION[4]
+    s = perf.decode(blob)
+    assert s.raw["demag_events"] == 3
+    assert "active_demag_interlock_skips" not in s.raw

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -9,7 +9,8 @@ from hwci import perf
 def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[1] == 64
     assert perf.SIZE_BY_VERSION[2] == 80
-    assert perf.SIZE == perf.SIZE_BY_VERSION[3] == 84
+    assert perf.SIZE_BY_VERSION[3] == 84
+    assert perf.SIZE == perf.SIZE_BY_VERSION[4] == 92
 
 
 def test_host_cmd_offset_matches_layout():
@@ -111,7 +112,7 @@ def test_negative_current_is_signed():
 
 
 def test_v3_roundtrip_confirm_reject():
-    blob = perf.encode({"zc_confirm_reject": 424242})
+    blob = perf.encode({"zc_confirm_reject": 424242}, version=3)
     assert len(blob) == 84
     assert perf.decode(blob).raw["zc_confirm_reject"] == 424242
 
@@ -124,3 +125,35 @@ def test_v2_roundtrip_has_no_reject_key():
     s = perf.decode(blob)
     assert s.raw["zc_count"] == 7
     assert "zc_confirm_reject" not in s.raw
+
+
+def test_roundtrip_demag_fields():
+    blob = perf.encode({
+        "demag_events": 4000000001,   # near the u32 wrap
+        "blanking_len_last": 512,
+        "blanking_len_max": 4100,
+    })
+    r = perf.decode(blob).raw
+    assert r["demag_events"] == 4000000001
+    assert r["blanking_len_last"] == 512
+    assert r["blanking_len_max"] == 4100
+
+
+def test_v2_roundtrip_has_no_demag_keys():
+    # v2 firmware (pre demag block) must decode cleanly and simply not carry
+    # the demag fields - mirrors the v1/zc backward-compat guarantee.
+    blob = perf.encode({"zc_count": 7, "loop_iters": 42}, version=2)
+    assert len(blob) == perf.SIZE_BY_VERSION[2]
+    s = perf.decode(blob)
+    assert s.raw["zc_count"] == 7
+    assert s.loop_iters == 42
+    assert "demag_events" not in s.raw
+    assert "blanking_len_last" not in s.raw
+
+
+def test_v2_decodes_from_oversized_read():
+    # an oversized buffer holding a v2 struct (plus junk) must decode as v2
+    blob = perf.encode({"zc_count": 9}, version=2) + b"\xa5" * 8
+    s = perf.decode(blob)
+    assert s.raw["zc_count"] == 9
+    assert "demag_events" not in s.raw

--- a/hwci/tests/test_perf_reader.py
+++ b/hwci/tests/test_perf_reader.py
@@ -100,16 +100,19 @@ def test_missing_struct_die_fails_hard(host_perf_elf, monkeypatch):
 
 
 def test_v2_firmware_reads_and_resets(host_perf_elf_v2):
-    # v2 vintage (jitter block, no confirm-reject counter): the reader must
-    # size its read from the ELF, pass the DWARF cross-check against the v2
-    # canonical table, decode without the v3 key, and land RESET_STATS at
-    # the version-stable offset 60.
+    # v2 vintage (jitter block, no v3 reject counter, no v4 demag block):
+    # the reader must size its read from the ELF, pass the DWARF cross-check
+    # against the v2 canonical table, decode without the newer keys, and
+    # land RESET_STATS at the version-stable offset 60.
     reader, dbg = _reader_with_mock(host_perf_elf_v2)
     assert reader._read_size == perf.SIZE_BY_VERSION[2]
-    dbg.poke(reader.address, perf.encode({"zc_count": 55}, version=2))
+    dbg.poke(reader.address, perf.encode(
+        {"zc_count": 55, "loop_iters": 999}, version=2))
     sample = reader.read()
     assert sample.raw["zc_count"] == 55
+    assert sample.loop_iters == 999
     assert "zc_confirm_reject" not in sample.raw
+    assert "demag_events" not in sample.raw
     reader.reset_stats(verify=False)
     word = dbg.read_memory(reader.address + perf.HOST_CMD_OFFSET, 4)
     assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -93,3 +93,21 @@ def test_perf_channel_carries_confirm_reject_counter():
     ratio = (b["zc_confirm_reject"] - a["zc_confirm_reject"]) / (
         b["zc_count"] - a["zc_count"])
     assert 0.001 < ratio < 0.05
+
+
+def test_perf_channel_carries_demag_fields():
+    # v4 struct: demag fields present, zero on a clean (non-demag-prone) run.
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.7)
+    r = perf.decode(rig.perf_bytes()).raw
+    assert r["demag_events"] == 0
+    assert r["blanking_len_last"] == 0
+    assert r["blanking_len_max"] == 0
+
+
+def test_demag_events_count_injected_desyncs():
+    rig = RigSimulator(params=MotorParams(demag_prone=True), noise=0.0)
+    _settle(rig, 0.1, n=50)
+    rig.step(0.005, 1.0)  # aggressive step into high current -> desync
+    r = perf.decode(rig.perf_bytes()).raw
+    assert r["demag_events"] == rig.desync_count == 1


### PR DESCRIPTION
## Summary

**Stacked on #24** (demag compensation) — the active-demag half of draft PR #2. During normal PWM chopping AM32 already turns on the opposite-side FET (`comp_pwm` complementary drive, default on); the remaining body-diode conduction window is **post-commutation demag**: the winding that just switched off dumps its stored current through a body diode (~0.7–1 V drop) until it decays. This PR turns on the FET whose body diode is carrying that freewheel current, so the demag current circulates through the channel (mΩ Rds(on)) instead — measurable g/W at mid/high load, where demag current is largest.

**Rebased 2026-07-06** onto the rebased #24 (perf v4 world), and now includes a **comparator interlock** (below) that turns the wrong-mapping hazard into a diagnostic counter.

## How it works

`PeriodElapsedCallback()`, after `commutate()` and the hwci ZC hook (so jitter metrics are unaffected): if active demag is enabled and #24's measurement is armed, `activeDemagFetOn()` drives the floating phase's conducting-side FET (chosen from `step` + `rising`) and re-arms COM_TIMER for `active_demag_ticks` = **half the last measured demag time**, re-capped at `waitTime/2` at use time. The second COM event hits a guard at the top of the callback that floats the phase again and returns. If the true zero-cross arrives before the off-event, `interruptRoutine()` force-floats and clears the flag so the pending COM event isn't swallowed.

The FET-on window therefore always ends well before the zero-cross is expected, leaving the BEMF sensing window untouched. The previously conducting FET has been off since `comStep()` at the top of `commutate()` several µs earlier, so there is no cross-conduction with the outgoing drive.

Implementation: `phaseXHIGH()` outputs + `activeDemagFetOn/Off()` live in each MCU's `phaseouts.c` (in-TU so the phase bodies inline; f051/g071/g431/l431, `HAS_PHASE_HIGH`-gated). On F051 the helpers stay in **flash** deliberately: RAM_FUNC placement cost 504 B and overflowed the HWCI-build RAM; the 1-wait-state penalty is well under the 0.5 µs COM-timer tick that schedules them.

## Comparator interlock — wrong mapping becomes a counter, not a damage event

The failure mode if `activeDemagFetOn()`'s `step`/`rising` → FET mapping is wrong for a board/direction combo is **not** a rail short (the conducting body diode commutates off when the node is pulled to the opposite rail) — it's worse in a quieter way: the full bus voltage lands across the "floating" winding in the re-magnetizing direction, an uncontrolled VBAT/L current ramp (~2.4 A/µs at 24 V/10 µH) that the DRV8328 (no VDS trip) and the 1 kHz firmware current loop cannot catch. The DRV8328's built-in dead-time enforcement does **not** protect here: only one gate is commanded, which is a perfectly legal input pattern — it only guards same-leg INH/INL overlap.

So this PR adds a one-comparator-read interlock: during demag the floating phase is diode-clamped to the far rail, which the comparator reads as the post-cross level (`!rising`) — the same signal #24's reversed-polarity demag-edge arm watches. Just before `activeDemagFetOn()`, if the comparator instead reads the pre-cross level, the mapping is wrong (or demag has already released, where energizing the FET would short the BEMF) — **skip the freewheel for that step and count it** in `active_demag_interlock_skips` (perf struct **v5**, offset 92, `fw_interlock_skips` in run summaries). Interpretation: ~0 healthy; ≈ one per commutation = wrong mapping — the veto keeps the hardware safe while you scope it.

## Bench protocol (still applies — the interlock is a backstop, not a substitute)

1. First runs with `DEMAG_COMP=1` only, `ACTIVE_DEMAG` **off**, to establish the measurement baseline.
2. Scope the floating phase to confirm the commanded FET matches the freewheel diode's side on **both** `rising` polarities and **both** directions.
3. Then `make ARK_4IN1_F051 HWCI_PERF=1 DEMAG_COMP=2 ACTIVE_DEMAG=1`, first run **low duty** with current + FET-thermal watch, checking `fw_interlock_skips ≈ 0`.
4. `efficiency_sweep` A/B (`ACTIVE_DEMAG=0` vs `=1`): expect a g/W gain at mid/high load; `fw_demag_events == 0`, `bemf_timeout_samples == 0`, `fw_interlock_skips ≈ 0`, FET temps flat.

`USE_INVERTED_HIGH` targets get the inverted `HIGH_BITREG_ON` mapping — compile-time correct but untested on such hardware.

## Memory (ARK_4IN1_F051)

| Build | FLASH | RAM |
|---|---|---|
| HWCI_PERF=1 DEMAG_COMP=2 ACTIVE_DEMAG=1 | 25328 B (92.4%) | 7728 B (96.6%) |

272 B RAM free on the HWCI build — flagged as the binding constraint for the next F051 feature.

hwci offline tests: **143 passed**. Builds verified: ARK_4IN1_F051 (plain / HWCI_PERF / both knobs), GEN_64K_G071, REF_G431, NEUTRON_L431, SEQURE_4IN1_F421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pvp2XLcgsviGSVn9PaaP6