### PR TITLE
hwci: auto settings tuner — find the best AM32 settings for a motor on the rig

### DIFF
--- a/hwci/README.md
+++ b/hwci/README.md
@@ -184,6 +184,75 @@ non-zero on regression** so CI fails the build.
 Built-in profiles: `ci_smoke` (fast gate), `efficiency_sweep` (10–100 %
 staircase, the primary baseline), `demag_step_stress` (aggressive steps).
 
+## Auto-tuning AM32 settings (`hwci tune`)
+
+Given a motor/prop on the rig, `hwci tune` automatically searches the AM32
+EEPROM settings (`advance_level`, `pwm_frequency`, `variable_pwm`,
+`auto_advance`, `max_ramp`, …) for the combination that maximizes efficiency
+(g/W), subject to hard constraints: no demag/desync/bemf timeouts, zero-cross
+jitter not regressed vs the default settings, temperatures bounded, and
+reliable startup. **No rebuild per trial**: AM32 reads its 192-byte EEprom
+page once at boot, so each trial one-shot-flashes the page over SWD (+ reset)
+and runs a ~28 s probe. The live page address is read from the firmware's
+`eeprom_address` global (the bootloader can relocate it) and the field
+offsets are cross-checked against the flashed ELF's DWARF before anything is
+written. Trial blobs are seeded from the device's current page and mutate
+only the tuned bytes, so version/identity bytes and rig calibration survive.
+
+```bash
+hwci tune --spec tunes/example.yaml --config rig.yaml --battery-cells 4 \
+          --out runs/tune-1            # hardware
+hwci tune --spec tunes/example.yaml --sim --out runs/tune-sim   # offline dry run
+hwci tune --resume runs/tune-1        # continue an interrupted session
+```
+
+**Spec format** (`tunes/example.yaml`, strict validation — unknown keys or
+parameters fail loudly): `parameters:` declares the tunable fields and their
+grids (unknown-to-hwci fields can be addressed with an explicit `offset:`);
+`stages:` runs coordinate sweeps (`sweep:` one parameter, others at the
+incumbent, optional `refine_step` around the argmax) and A/B mode stages
+(`ab_candidates:` with interleaved `repeats`); `objective:` weights the
+steady probe points (points under `min_power_w` are bench noise and never
+score); `constraints:` are hard disqualifiers, never traded against score. A
+`constraint_only: true` sweep (e.g. `max_ramp` on the step-stress profile)
+tries values in listed order and picks the first with zero failures — list
+them best-first.
+
+**Noise handling**: same-firmware g/W spread reaches ~10 % on the bench and
+the pack sags within a session, so the incumbent is re-run every
+`anchors_every` trials and every score is reported raw *and* normalized to
+the interpolation between surrounding anchors (cancels drift). Candidates
+within `noise_floor_pct` of the best tie-break toward lower jitter, then
+lower FET temperature, then closest-to-default. The finals run winner vs
+default in interleaved ABBA blocks on the full efficiency sweep (plus a
+startup-reliability check); the winner is confirmed only with a positive
+median paired delta and zero constraint failures — otherwise
+`best_settings.bin` keeps the defaults.
+
+**Session dir / resume**: `runs/tune-1/` holds `manifest.json` (atomically
+rewritten after every trial), `spec.yaml`, `base_settings.bin`, one standard
+run dir per trial under `trials/T007-advance_level_22/` (plus its
+`settings.bin` + `trial.json`), and at the end `report.md`,
+`best_settings.bin`, `settings_diff.md`. `--resume` replays the
+deterministic plan: completed trials are reused from disk, partial trial
+dirs are quarantined as `*.incomplete` and redone, and the incumbent page is
+re-programmed first (a crash may have left arbitrary trial settings
+flashed).
+
+**Pack swaps**: when the resting voltage drops below
+`battery_cells * pack.min_resting_cell_v`, the session checkpoints and
+prompts you to swap the pack (recorded as a `pack_event`; ABBA blocks that
+straddle a swap are discarded and restarted). With `--no-prompt` it exits
+cleanly (code 3) instead — swap, then `--resume`.
+
+The settings page is also scriptable directly:
+
+```bash
+hwci settings read  --config rig.yaml --bin page.bin   # dump current page
+hwci settings diff  --config rig.yaml --bin other.bin  # exit 1 if different
+hwci settings write --config rig.yaml --bin page.bin   # flash + verify
+```
+
 ## Capturing the first baseline
 
 Once wired and configured:

--- a/hwci/README.md
+++ b/hwci/README.md
@@ -233,7 +233,10 @@ median paired delta and zero constraint failures — otherwise
 rewritten after every trial), `spec.yaml`, `base_settings.bin`, one standard
 run dir per trial under `trials/T007-advance_level_22/` (plus its
 `settings.bin` + `trial.json`), and at the end `report.md`,
-`best_settings.bin`, `settings_diff.md`. `--resume` replays the
+`best_settings.bin`, `settings_diff.md`, and — when the `plot` extra
+(matplotlib) is installed — a `tune_report.pdf` (verdict, settings diff,
+per-trial objective + ABBA-delta plots, and the full stage/trial tables).
+`--resume` replays the
 deterministic plan: completed trials are reused from disk, partial trial
 dirs are quarantined as `*.incomplete` and redone, and the incumbent page is
 re-programmed first (a crash may have left arbitrary trial settings

--- a/hwci/hwci/cli.py
+++ b/hwci/hwci/cli.py
@@ -23,6 +23,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+import yaml
+
 from . import baseline as bl
 from . import metrics as metricsmod
 from . import report as reportmod
@@ -274,6 +276,143 @@ def cmd_ci(args) -> int:
     return _verdict_rc(result, comparison)
 
 
+def cmd_tune(args) -> int:
+    from . import tuner as tunermod
+
+    if args.resume:
+        out = Path(args.resume)
+        manifest = json.loads((out / "manifest.json").read_text())
+        spec_text = (out / "spec.yaml").read_text()
+        spec = tunermod.tune_spec_from_dict(yaml.safe_load(spec_text))
+        sim = manifest.get("mode") == "sim"
+        config_path = manifest.get("config_path")
+        rig = (load_rig(config_path) if (config_path and not sim)
+               else RigConfig())
+        battery_cells = manifest.get("battery_cells")
+        resume = True
+    else:
+        if not args.spec:
+            print("error: hwci tune needs --spec (or --resume)", file=sys.stderr)
+            return 2
+        spec_text = Path(args.spec).read_text()
+        spec = tunermod.load_tune_spec(args.spec)
+        sim = _use_sim(args)
+        rig = load_rig(args.config) if args.config else RigConfig()
+        out = Path(args.out) if args.out else _default_out(
+            f"tune-{spec.name}", sim)
+        config_path = args.config
+        battery_cells = args.battery_cells
+        resume = False
+
+    backend = (tunermod.SimTuneBackend(rig) if sim
+               else tunermod.HwTuneBackend(rig))
+    try:
+        tuner = tunermod.Tuner(
+            spec, backend, out, spec_text=spec_text,
+            battery_cells=battery_cells, no_prompt=args.no_prompt,
+            resume=resume, config_path=config_path)
+        result = tuner.run()
+    except tunermod.TunePaused as e:
+        print(f"PAUSED: {e}", file=sys.stderr)
+        return 3
+    finally:
+        backend.close()
+    print(f"report: {out / 'report.md'}\n"
+          f"best settings: {out / 'best_settings.bin'} "
+          f"({'winner' if result['confirmed'] else 'default kept'})")
+    return 0
+
+
+# Persistent in-process simulated settings page for `hwci settings --sim`,
+# so read/write/diff round-trip within one process (tests, demos).
+_SIM_SETTINGS_DEVICE = None
+
+
+def _sim_settings_device():
+    from .debugger.base import MockDebugger
+    from .settings import DEFAULT_EEPROM_ADDRESS, default_blob
+
+    class _Device(MockDebugger):
+        def flash(self, bin_path: str, load_addr: int) -> None:
+            super().flash(bin_path, load_addr)
+            self.poke(load_addr, Path(bin_path).read_bytes())
+
+    global _SIM_SETTINGS_DEVICE
+    if _SIM_SETTINGS_DEVICE is None:
+        _SIM_SETTINGS_DEVICE = _Device(base=DEFAULT_EEPROM_ADDRESS, size=192)
+        _SIM_SETTINGS_DEVICE.poke(DEFAULT_EEPROM_ADDRESS, default_blob())
+    return _SIM_SETTINGS_DEVICE, DEFAULT_EEPROM_ADDRESS
+
+
+def cmd_settings(args) -> int:
+    from . import settings as st
+
+    sim = _use_sim(args)
+    if sim:
+        dbg, addr = _sim_settings_device()
+        closer = lambda: None  # noqa: E731 - kept alive across invocations
+        flash = dbg.flash
+    else:
+        from .debugger.openocd import OpenOcdDebugger
+        rig = load_rig(args.config)
+        elf = rig.resolved_elf()
+        if elf is None:
+            print(f"error: no ELF for target {rig.target}; the live "
+                  "eeprom_address is resolved from the flashed ELF",
+                  file=sys.stderr)
+            return 2
+        make = lambda: OpenOcdDebugger(  # noqa: E731
+            rig.openocd_configs, openocd_bin=rig.openocd_bin,
+            search_dirs=rig.openocd_search_dirs)
+        dbg = make().open()
+        closer = dbg.close
+        addr = st.resolve_eeprom_address(dbg, str(elf))
+
+        def flash(bin_path: str, load_addr: int) -> None:
+            # One-shot flash must not race the open Tcl-RPC session on the
+            # same ST-Link: close, program+reset, reopen to verify.
+            nonlocal dbg, closer
+            dbg.close()
+            make().flash(bin_path, load_addr)
+            dbg = make().open()
+            closer = dbg.close
+
+    try:
+        current = st.Settings.from_device(dbg, addr)
+        if args.action == "read":
+            print(f"eeprom @ 0x{addr:08x}  sha256 {current.sha256()[:16]}")
+            for name, value in current.describe().items():
+                print(f"  {name:16s} = {value:3d}   "
+                      f"({st.EEPROM_FIELDS[name].description})")
+            if args.bin:
+                current.to_bin(args.bin)
+                print(f"saved page to {args.bin}")
+            return 0
+        if not args.bin:
+            print(f"error: hwci settings {args.action} needs --bin",
+                  file=sys.stderr)
+            return 2
+        other = st.Settings.from_bin(args.bin)
+        if args.action == "diff":
+            diff = current.diff(other)
+            for name, a, b in diff:
+                print(f"  {name:16s} device={a:3d}  {args.bin}={b:3d}")
+            print(f"{len(diff)} byte(s) differ" if diff
+                  else "no differences")
+            return 1 if diff else 0
+        # write
+        flash(str(Path(args.bin)), addr)
+        readback = st.Settings.from_device(dbg, addr)
+        if readback != other:
+            print("ERROR: readback after write does not match the file",
+                  file=sys.stderr)
+            return 1
+        print(f"wrote {args.bin} to eeprom @ 0x{addr:08x} (verified)")
+        return 0
+    finally:
+        closer()
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="hwci", description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -344,6 +483,33 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--baseline")
     sp.add_argument("--no-plots", action="store_true")
     sp.set_defaults(func=cmd_report)
+
+    sp = sub.add_parser(
+        "tune", help="auto-tune AM32 EEPROM settings for the motor/prop")
+    add_common(sp)
+    sp.add_argument("--spec", help="tune spec YAML (see hwci/tunes/example.yaml)")
+    sp.add_argument("--out", help="session directory (default: runs/tune-...)")
+    sp.add_argument("--sim", action="store_true", help="force the simulator")
+    sp.add_argument("--battery-cells", type=int, metavar="N",
+                    help="LiPo cell count; gates every trial on resting pack "
+                         "voltage (overrides the spec's battery_cells)")
+    sp.add_argument("--no-prompt", action="store_true",
+                    help="never wait for input: checkpoint and exit cleanly "
+                         "(exit code 3) instead of prompting for a pack swap")
+    sp.add_argument("--resume", metavar="DIR",
+                    help="resume a checkpointed session from its directory "
+                         "(spec/config/mode are reloaded from the session)")
+    sp.set_defaults(func=cmd_tune)
+
+    sp = sub.add_parser(
+        "settings", help="read/write/diff the AM32 EEPROM settings page")
+    sp.add_argument("action", choices=["read", "write", "diff"])
+    add_common(sp)
+    sp.add_argument("--bin", help="192-byte settings blob (read: save to; "
+                                  "write/diff: source)")
+    sp.add_argument("--sim", action="store_true",
+                    help="in-process simulated page (offline)")
+    sp.set_defaults(func=cmd_settings)
 
     sp = sub.add_parser("ci", help="build+flash+run+analyze+gate (full pipeline)")
     add_common(sp)

--- a/hwci/hwci/cli.py
+++ b/hwci/hwci/cli.py
@@ -317,8 +317,10 @@ def cmd_tune(args) -> int:
         return 3
     finally:
         backend.close()
-    print(f"report: {out / 'report.md'}\n"
-          f"best settings: {out / 'best_settings.bin'} "
+    pdf = out / "tune_report.pdf"
+    print(f"report: {out / 'report.md'}"
+          + (f"\nPDF report: {pdf}" if pdf.exists() else "")
+          + f"\nbest settings: {out / 'best_settings.bin'} "
           f"({'winner' if result['confirmed'] else 'default kept'})")
     return 0
 

--- a/hwci/hwci/elf.py
+++ b/hwci/hwci/elf.py
@@ -101,19 +101,89 @@ def struct_layout(elf_path: str, type_name: str) -> list[Member]:
         f"struct {type_name!r} not found in DWARF of {elf_path}")
 
 
+def union_layout(elf_path: str, type_name: str) -> list[Member]:
+    """Read the flattened member layout of ``union <type_name>`` from DWARF.
+
+    Unlike :func:`struct_layout` this RECURSES into struct-typed members:
+    AM32's ``EEprom_u`` wraps all named settings in an anonymous first struct
+    member (and nests ``version``/``servo``/``limits``/``can`` sub-structs),
+    so a plain child walk would only see the anonymous member and ``buffer``.
+    Nested named structs contribute dotted names (``version.major``); the
+    anonymous wrapper contributes no prefix. Returns members in offset order.
+    """
+    _require_elftools()
+    with open(elf_path, "rb") as fh:
+        elf = ELFFile(fh)
+        if not elf.has_dwarf_info():
+            raise ElfError(f"{elf_path}: no DWARF info")
+        dwarf = elf.get_dwarf_info()
+        for cu in dwarf.iter_CUs():
+            for die in cu.iter_DIEs():
+                if die.tag != "DW_TAG_union_type":
+                    continue
+                name_attr = die.attributes.get("DW_AT_name")
+                if name_attr is None:
+                    continue
+                if name_attr.value.decode("utf-8", "replace") != type_name:
+                    continue
+                members = _flatten_members(die, cu, base=0, prefix="")
+                members.sort(key=lambda m: m.offset)
+                return members
+    raise StructNotFoundError(
+        f"union {type_name!r} not found in DWARF of {elf_path}")
+
+
+def _member_offset(member_die) -> int:
+    offset = member_die.attributes.get("DW_AT_data_member_location")
+    offset_val = offset.value if offset is not None else 0
+    if isinstance(offset_val, list):  # location expression form
+        # DW_OP_plus_uconst <n> => [0x23, n]
+        offset_val = offset_val[1] if len(offset_val) > 1 else 0
+    return offset_val
+
+
+def _strip_typedefs(die, cu):
+    """Walk through typedef/const/volatile DIEs to the underlying type."""
+    while die is not None and die.tag in (
+            "DW_TAG_typedef", "DW_TAG_const_type", "DW_TAG_volatile_type"):
+        nxt = die.attributes.get("DW_AT_type")
+        if nxt is None:
+            return None
+        die = cu.get_DIE_from_refaddr(nxt.value + cu.cu_offset)
+    return die
+
+
+def _flatten_members(agg_die, cu, base: int, prefix: str) -> list[Member]:
+    members: list[Member] = []
+    for child in agg_die.iter_children():
+        if child.tag != "DW_TAG_member":
+            continue
+        name_attr = child.attributes.get("DW_AT_name")
+        name = (name_attr.value.decode("utf-8", "replace")
+                if name_attr is not None else None)
+        offset = base + _member_offset(child)
+        type_ref = child.attributes.get("DW_AT_type")
+        tdie = (_strip_typedefs(
+                    cu.get_DIE_from_refaddr(type_ref.value + cu.cu_offset), cu)
+                if type_ref is not None else None)
+        if tdie is not None and tdie.tag == "DW_TAG_structure_type":
+            sub_prefix = f"{prefix}{name}." if name else prefix
+            members += _flatten_members(tdie, cu, offset, sub_prefix)
+            continue
+        size, signed = _base_type(child, cu)
+        members.append(Member(name=prefix + (name or f"anon@{offset}"),
+                              offset=offset, size=size, signed=signed))
+    return members
+
+
 def _members_of(struct_die, cu) -> list[Member]:
     members: list[Member] = []
     for child in struct_die.iter_children():
         if child.tag != "DW_TAG_member":
             continue
         name = child.attributes["DW_AT_name"].value.decode("utf-8", "replace")
-        offset = child.attributes.get("DW_AT_data_member_location")
-        offset_val = offset.value if offset is not None else 0
-        if isinstance(offset_val, list):  # location expression form
-            # DW_OP_plus_uconst <n> => [0x23, n]
-            offset_val = offset_val[1] if len(offset_val) > 1 else 0
         size, signed = _base_type(child, cu)
-        members.append(Member(name=name, offset=offset_val,
+        members.append(Member(name=name, offset=_member_offset(child),
                               size=size, signed=signed))
     members.sort(key=lambda m: m.offset)
     return members

--- a/hwci/hwci/flightstand/simulator.py
+++ b/hwci/hwci/flightstand/simulator.py
@@ -8,10 +8,12 @@ and perf-struct sources so all three channels stay consistent (see
 from __future__ import annotations
 
 import time
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
-from ..sim import MotorParams, RigSimulator
 from .base import SafetyLimits, StandSafetyTripped, StandSample, ThrustStand
+
+if TYPE_CHECKING:  # runtime import is lazy: hwci.sim itself imports
+    from ..sim import MotorParams, RigSimulator   # this package (StandSample)
 
 __all__ = ["SimulatedStand", "StandSafetyTripped"]
 
@@ -19,12 +21,16 @@ __all__ = ["SimulatedStand", "StandSafetyTripped"]
 class SimulatedStand(ThrustStand):
     def __init__(
         self,
-        rig: RigSimulator | None = None,
+        rig: "RigSimulator | None" = None,
         *,
         clock: Callable[[], float] = time.monotonic,
         fixed_dt: float | None = None,
-        params: MotorParams | None = None,
+        params: "MotorParams | None" = None,
     ):
+        # Imported here, not at module top: hwci.sim imports this package for
+        # StandSample, so a top-level import is a cycle that makes
+        # `import hwci.sim` fail whenever it happens to run first.
+        from ..sim import MotorParams, RigSimulator
         self.rig = rig or RigSimulator(params=params or MotorParams())
         self._clock = clock
         self._fixed_dt = fixed_dt

--- a/hwci/hwci/profiles/tune_probe.yaml
+++ b/hwci/hwci/profiles/tune_probe.yaml
@@ -1,0 +1,30 @@
+name: tune_probe
+description: >
+  Short efficiency probe for the auto settings tuner: idle, a two-step
+  low-throttle warmup, then four steady points long enough for a meaningful
+  tail window, then ramp down (~28 s). Points below ~20 W electrical are
+  measurement noise on the bench (see Thresholds.efficiency_min_power_w in
+  hwci/baseline.py), so the probe spends its dwell where the objective
+  actually scores. The warmup mirrors the efficiency_sweep staircase: the
+  motor must already be spinning before commanded throttle crosses the demag
+  detector's 0.2 "running" threshold, or the spool-up's long commutation
+  intervals read as spike events. A tune spec can override the points, dwell
+  and safety limits (probe: block) without editing this file.
+sample_rate_hz: 100
+arm_settle_s: 2.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 40.0
+  max_thrust_n: 16.0
+  max_rpm: 32000
+
+segments:
+  - {label: idle,   throttle: 0.00, duration_s: 2.0}
+  - {label: w10,    throttle: 0.10, duration_s: 1.5, ramp: true}
+  - {label: w20,    throttle: 0.20, duration_s: 1.5}
+  - {label: t30,    throttle: 0.30, duration_s: 6.0, steady: true}
+  - {label: t50,    throttle: 0.50, duration_s: 6.0, steady: true}
+  - {label: t70,    throttle: 0.70, duration_s: 6.0, steady: true}
+  - {label: t90,    throttle: 0.90, duration_s: 6.0, steady: true}
+  - {label: rampdn, throttle: 0.00, duration_s: 2.0, ramp: true}

--- a/hwci/hwci/profiles/tune_probe.yaml
+++ b/hwci/hwci/profiles/tune_probe.yaml
@@ -2,7 +2,7 @@ name: tune_probe
 description: >
   Short efficiency probe for the auto settings tuner: idle, a two-step
   low-throttle warmup, then four steady points long enough for a meaningful
-  tail window, then ramp down (~28 s). Points below ~20 W electrical are
+  tail window, then ramp down (~31 s). Points below ~20 W electrical are
   measurement noise on the bench (see Thresholds.efficiency_min_power_w in
   hwci/baseline.py), so the probe spends its dwell where the objective
   actually scores. The warmup mirrors the efficiency_sweep staircase: the
@@ -19,12 +19,18 @@ safety:
   max_thrust_n: 16.0
   max_rpm: 32000
 
+# Ramp segments between measured points: a 0.5->0.7 snap drew a 43-75 A
+# one-sample transient on the 6S bench (harness abort at 40 A); unramped
+# 10% steps (w20->t30, efficiency_sweep's staircase) are proven safe.
 segments:
   - {label: idle,   throttle: 0.00, duration_s: 2.0}
   - {label: w10,    throttle: 0.10, duration_s: 1.5, ramp: true}
   - {label: w20,    throttle: 0.20, duration_s: 1.5}
   - {label: t30,    throttle: 0.30, duration_s: 6.0, steady: true}
+  - {label: r_t50,  throttle: 0.50, duration_s: 1.0, ramp: true}
   - {label: t50,    throttle: 0.50, duration_s: 6.0, steady: true}
+  - {label: r_t70,  throttle: 0.70, duration_s: 1.0, ramp: true}
   - {label: t70,    throttle: 0.70, duration_s: 6.0, steady: true}
+  - {label: r_t90,  throttle: 0.90, duration_s: 1.0, ramp: true}
   - {label: t90,    throttle: 0.90, duration_s: 6.0, steady: true}
   - {label: rampdn, throttle: 0.00, duration_s: 2.0, ramp: true}

--- a/hwci/hwci/report.py
+++ b/hwci/hwci/report.py
@@ -99,6 +99,251 @@ def write_report(run_dir: str | Path, metrics: dict,
     return report_path
 
 
+# --------------------------------------------------------------------------
+# Auto-tune PDF report
+# --------------------------------------------------------------------------
+def write_tune_pdf(out_dir: str | Path, manifest: dict, result: dict,
+                   diff_rows: list | None = None, *,
+                   log=None) -> Path | None:
+    """Render one auto-tune session to a multi-page PDF (``tune_report.pdf``).
+
+    Best-effort: uses matplotlib's ``PdfPages`` so it needs nothing beyond the
+    existing optional ``plot`` extra. Returns the PDF path on success, or
+    ``None`` if matplotlib is unavailable / rendering fails (the Markdown
+    report is written by the caller regardless).
+
+    ``diff_rows`` is the ``Settings.diff`` output ``[(name, default, best)]``.
+    """
+    def _log(msg: str) -> None:
+        if log is not None:
+            log(msg)
+
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from matplotlib.backends.backend_pdf import PdfPages
+    except Exception as e:  # matplotlib not installed -> skip, don't fail tune
+        _log(f"PDF report skipped (matplotlib unavailable: {e}); "
+             "install the 'plot' extra to enable it")
+        return None
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = out_dir / "tune_report.pdf"
+    try:
+        with PdfPages(pdf_path) as pdf:
+            _pdf_cover_page(plt, pdf, manifest, result, diff_rows or [])
+            _pdf_progress_page(plt, pdf, manifest, result)
+            _pdf_tables_pages(plt, pdf, manifest)
+    except Exception as e:
+        _log(f"PDF report failed to render: {e}")
+        try:
+            pdf_path.unlink()
+        except OSError:
+            pass
+        return None
+    return pdf_path
+
+
+_PAGE = (8.27, 11.69)   # A4 portrait, inches
+_CONFIRMED_GREEN = "#1a7f37"
+_DEFAULT_GRAY = "#57606a"
+
+
+def _pdf_cover_page(plt, pdf, manifest: dict, result: dict, diff_rows: list):
+    fig = plt.figure(figsize=_PAGE)
+    fig.text(0.06, 0.955, "AM32 Auto-Tune Report", fontsize=22,
+             fontweight="bold", va="top")
+    fig.text(0.06, 0.925, str(manifest.get("spec_name", "")), fontsize=13,
+             color=_DEFAULT_GRAY, va="top")
+
+    # -- metadata block --
+    addr = manifest.get("eeprom_address")
+    meta_lines = [
+        ("mode", manifest.get("mode")),
+        ("git_sha", manifest.get("git_sha")),
+        ("eeprom_address",
+         f"0x{addr:08x}" if isinstance(addr, int) else addr),
+        ("battery_cells", manifest.get("battery_cells")),
+        ("jitter reference (default)",
+         f"{manifest.get('jitter_reference')} %"),
+        ("pack swaps", len(manifest.get("pack_events", []))),
+        ("trials run", len(manifest.get("trials", []))),
+    ]
+    y = 0.885
+    for k, v in meta_lines:
+        fig.text(0.06, y, f"{k}", fontsize=10, color=_DEFAULT_GRAY, va="top")
+        fig.text(0.42, y, _fmt(v), fontsize=10, va="top")
+        y -= 0.024
+
+    # -- verdict banner --
+    confirmed = bool(result.get("confirmed"))
+    banner_color = _CONFIRMED_GREEN if confirmed else _DEFAULT_GRAY
+    verdict = ("WINNER CONFIRMED" if confirmed
+               else "DEFAULT SETTINGS KEPT")
+    ax = fig.add_axes([0.06, 0.60, 0.88, 0.09])
+    ax.axis("off")
+    ax.add_patch(plt.Rectangle((0, 0), 1, 1, transform=ax.transAxes,
+                               facecolor=banner_color, alpha=0.14,
+                               edgecolor=banner_color, linewidth=1.5))
+    ax.text(0.5, 0.5, verdict, transform=ax.transAxes, ha="center",
+            va="center", fontsize=20, fontweight="bold", color=banner_color)
+
+    ov = result.get("winner_overrides") or {}
+    detail = [
+        f"winner overrides: {ov or '{} (default)'}",
+        (f"median paired delta: {_fmt(result.get('median_paired_delta'))} g/W "
+         f"over {len(result.get('paired_deltas') or [])} ABBA pairs"),
+        f"winner constraint failures: {result.get('winner_constraint_failures', 0)}",
+    ]
+    st = result.get("startup")
+    if st is not None:
+        detail.append(f"startup: {st.get('failed')}/{st.get('cycles')} failed")
+    y = 0.565
+    for line in detail:
+        fig.text(0.06, y, line, fontsize=11, va="top")
+        y -= 0.026
+
+    # -- settings diff table --
+    fig.text(0.06, 0.46, "Settings diff (default → best)", fontsize=13,
+             fontweight="bold", va="top")
+    if diff_rows:
+        rows = [[name, _fmt(a), _fmt(b)] for name, a, b in diff_rows]
+    else:
+        rows = [["(no change — default settings won)", "", ""]]
+    ax_t = fig.add_axes([0.06, 0.08, 0.88, 0.35])
+    ax_t.axis("off")
+    tbl = ax_t.table(cellText=rows,
+                     colLabels=["setting", "default", "best"],
+                     colLoc="left", cellLoc="left", loc="upper left")
+    _style_table(tbl, header_cols=3)
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _pdf_progress_page(plt, pdf, manifest: dict, result: dict):
+    trials = [t for t in manifest.get("trials", []) if not t.get("discarded")]
+    fig, (ax_prog, ax_abba) = plt.subplots(2, 1, figsize=_PAGE)
+    fig.suptitle("Tuning progress", fontsize=18, fontweight="bold", x=0.06,
+                 ha="left", y=0.97)
+
+    # scored trials: raw + normalized g/W vs trial index
+    idx_raw = [(t["index"], t["score_raw"]) for t in trials
+               if t.get("score_raw") is not None]
+    idx_norm = [(t["index"], t["score_norm"]) for t in trials
+                if t.get("score_norm") is not None]
+    dq = [t["index"] for t in trials if t.get("disqualified")]
+
+    if idx_raw:
+        xs, ys = zip(*idx_raw)
+        ax_prog.plot(xs, ys, "o-", color="#0969da", label="raw g/W", ms=4)
+    if idx_norm:
+        xs, ys = zip(*idx_norm)
+        ax_prog.plot(xs, ys, "s--", color="#bf8700",
+                     label="drift-normalized g/W", ms=4)
+    if dq:
+        ymin = min([y for _, y in idx_raw], default=0)
+        ax_prog.plot(dq, [ymin] * len(dq), "x", color="#cf222e", ms=8,
+                     label="disqualified")
+    ax_prog.set(xlabel="trial index", ylabel="objective (g/W)",
+                title="Objective per trial")
+    if idx_raw or idx_norm or dq:
+        ax_prog.legend(loc="best", fontsize=8)
+    ax_prog.grid(True, alpha=0.3)
+
+    # ABBA paired deltas (winner - default), median line
+    deltas = result.get("paired_deltas") or []
+    if deltas:
+        colors = ["#1a7f37" if d > 0 else "#cf222e" for d in deltas]
+        ax_abba.bar(range(1, len(deltas) + 1), deltas, color=colors,
+                    alpha=0.8)
+        med = result.get("median_paired_delta")
+        if med is not None:
+            ax_abba.axhline(med, ls="--", color="#0969da",
+                            label=f"median {med:g} g/W")
+        ax_abba.axhline(0, color="#57606a", lw=0.8)
+        ax_abba.legend(loc="best", fontsize=8)
+    else:
+        ax_abba.text(0.5, 0.5, "no ABBA paired deltas", ha="center",
+                     va="center", transform=ax_abba.transAxes,
+                     color=_DEFAULT_GRAY)
+    ax_abba.set(xlabel="ABBA pair", ylabel="winner − default (g/W)",
+                title="Finals: interleaved paired deltas")
+    ax_abba.grid(True, alpha=0.3)
+
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _fmt_ov(ov) -> str:
+    """Compact one-line overrides: {'a': 1, 'b': 2} -> 'a=1, b=2'."""
+    if not ov:
+        return "default"
+    if isinstance(ov, dict):
+        return ", ".join(f"{k}={v}" for k, v in ov.items())
+    return str(ov)
+
+
+def _pdf_tables_pages(plt, pdf, manifest: dict):
+    # stages table
+    stages = manifest.get("stages", {})
+    stage_rows = [[name, _fmt_ov(s.get("winner")), _fmt(s.get("winner_score"))]
+                  for name, s in stages.items()]
+    _table_page(plt, pdf, "Stage winners", stage_rows,
+                ["stage", "winner", "score (g/W, norm)"])
+
+    # trials table (paginated)
+    trial_rows = []
+    for e in manifest.get("trials", []):
+        dq = "; ".join(e["disqualified"]) if e.get("disqualified") else ""
+        if e.get("discarded"):
+            dq = (dq + " " if dq else "") + "(discarded: pack swap)"
+        trial_rows.append([
+            _fmt(e.get("index")), _fmt(e.get("stage")), _fmt(e.get("kind")),
+            _fmt_ov(e.get("overrides")), _fmt(e.get("score_raw")),
+            _fmt(e.get("score_norm")), dq])
+    cols = ["#", "stage", "kind", "overrides", "raw g/W", "norm g/W",
+            "disqualified"]
+    per_page = 26
+    if not trial_rows:
+        _table_page(plt, pdf, "Trials", [], cols)
+        return
+    for i in range(0, len(trial_rows), per_page):
+        chunk = trial_rows[i:i + per_page]
+        title = "Trials" if i == 0 else f"Trials (cont. {i // per_page + 1})"
+        _table_page(plt, pdf, title, chunk, cols)
+
+
+def _table_page(plt, pdf, title: str, rows: list, cols: list):
+    fig = plt.figure(figsize=_PAGE)
+    fig.text(0.06, 0.955, title, fontsize=18, fontweight="bold", va="top")
+    ax = fig.add_axes([0.04, 0.04, 0.92, 0.86])
+    ax.axis("off")
+    if not rows:
+        ax.text(0.5, 0.5, "(none)", ha="center", va="center",
+                transform=ax.transAxes, color=_DEFAULT_GRAY)
+    else:
+        tbl = ax.table(cellText=rows, colLabels=cols, cellLoc="left",
+                       colLoc="left", loc="upper center")
+        _style_table(tbl, header_cols=len(cols))
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _style_table(tbl, *, header_cols: int) -> None:
+    tbl.auto_set_font_size(False)
+    tbl.set_fontsize(8)
+    tbl.auto_set_column_width(list(range(header_cols)))
+    tbl.scale(1, 1.4)
+    for (r, _c), cell in tbl.get_celld().items():
+        cell.set_edgecolor("#d0d7de")
+        if r == 0:
+            cell.set_facecolor("#f6f8fa")
+            cell.set_text_props(fontweight="bold")
+
+
 def _write_plots(run_dir: Path, metrics: dict) -> None:
     import matplotlib
     matplotlib.use("Agg")

--- a/hwci/hwci/report.py
+++ b/hwci/hwci/report.py
@@ -1,6 +1,7 @@
 """Render run metrics + regression comparison to Markdown (and optional plots)."""
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 
@@ -146,9 +147,45 @@ def write_tune_pdf(out_dir: str | Path, manifest: dict, result: dict,
     return pdf_path
 
 
-_PAGE = (8.27, 11.69)   # A4 portrait, inches
+_PAGE = (8.27, 11.69)        # A4 portrait, inches
+_PAGE_LS = (11.69, 8.27)     # A4 landscape (wide tables)
 _CONFIRMED_GREEN = "#1a7f37"
 _DEFAULT_GRAY = "#57606a"
+_BORDER_GRAY = "#d0d7de"
+_HEADER_BG = "#f6f8fa"
+
+
+def _wrap(v, width: int) -> str:
+    s = _fmt(v) if not isinstance(v, str) else v
+    return "\n".join(textwrap.wrap(s, width)) if len(s) > width else s
+
+
+def _place_table(ax, rows: list, cols: list, widths: list,
+                 fontsize: float = 8.0, line_h: float = 0.032) -> None:
+    """Left-aligned table pinned to the top of ``ax`` with EXPLICIT column
+    width fractions (auto_set_column_width lets wide tables overflow the
+    page and clip - seen on real trial tables). Cell text may contain
+    newlines (pre-wrapped); row heights follow the tallest cell."""
+    ax.axis("off")
+    if not rows:
+        ax.text(0.5, 0.5, "(none)", ha="center", va="center",
+                transform=ax.transAxes, color=_DEFAULT_GRAY)
+        return
+    tbl = ax.table(cellText=rows, colLabels=cols, cellLoc="left",
+                   colLoc="left", loc="upper left", colWidths=widths)
+    tbl.auto_set_font_size(False)
+    tbl.set_fontsize(fontsize)
+    lines_in_row: dict[int, int] = {}
+    for (r, _c), cell in tbl.get_celld().items():
+        n = cell.get_text().get_text().count("\n") + 1
+        lines_in_row[r] = max(lines_in_row.get(r, 1), n)
+    for (r, _c), cell in tbl.get_celld().items():
+        cell.set_height(line_h * (lines_in_row[r] + 0.6))
+        cell.set_edgecolor(_BORDER_GRAY)
+        cell.PAD = 0.02
+        if r == 0:
+            cell.set_facecolor(_HEADER_BG)
+            cell.set_text_props(fontweight="bold")
 
 
 def _pdf_cover_page(plt, pdf, manifest: dict, result: dict, diff_rows: list):
@@ -192,7 +229,7 @@ def _pdf_cover_page(plt, pdf, manifest: dict, result: dict, diff_rows: list):
 
     ov = result.get("winner_overrides") or {}
     detail = [
-        f"winner overrides: {ov or '{} (default)'}",
+        f"winner overrides: {_fmt_ov(ov)}",
         (f"median paired delta: {_fmt(result.get('median_paired_delta'))} g/W "
          f"over {len(result.get('paired_deltas') or [])} ABBA pairs"),
         f"winner constraint failures: {result.get('winner_constraint_failures', 0)}",
@@ -212,27 +249,41 @@ def _pdf_cover_page(plt, pdf, manifest: dict, result: dict, diff_rows: list):
         rows = [[name, _fmt(a), _fmt(b)] for name, a, b in diff_rows]
     else:
         rows = [["(no change — default settings won)", "", ""]]
-    ax_t = fig.add_axes([0.06, 0.08, 0.88, 0.35])
-    ax_t.axis("off")
-    tbl = ax_t.table(cellText=rows,
-                     colLabels=["setting", "default", "best"],
-                     colLoc="left", cellLoc="left", loc="upper left")
-    _style_table(tbl, header_cols=3)
+    _place_table(fig.add_axes([0.06, 0.29, 0.60, 0.15]), rows,
+                 ["setting", "default", "best"], [0.50, 0.25, 0.25],
+                 line_h=0.10)
+
+    # -- stage winners (was its own near-empty page) --
+    fig.text(0.06, 0.25, "Stage winners", fontsize=13,
+             fontweight="bold", va="top")
+    stage_rows = [[name, _wrap(_fmt_ov(s.get("winner")), 58),
+                   _fmt(s.get("winner_score"))]
+                  for name, s in manifest.get("stages", {}).items()]
+    _place_table(fig.add_axes([0.06, 0.05, 0.88, 0.18]), stage_rows,
+                 ["stage", "winner", "score (g/W, norm)"],
+                 [0.15, 0.62, 0.23], line_h=0.085)
     pdf.savefig(fig)
     plt.close(fig)
 
 
 def _pdf_progress_page(plt, pdf, manifest: dict, result: dict):
+    from matplotlib.ticker import MaxNLocator
+    from matplotlib.transforms import blended_transform_factory
+
     trials = [t for t in manifest.get("trials", []) if not t.get("discarded")]
     fig, (ax_prog, ax_abba) = plt.subplots(2, 1, figsize=_PAGE)
     fig.suptitle("Tuning progress", fontsize=18, fontweight="bold", x=0.06,
                  ha="left", y=0.97)
 
-    # scored trials: raw + normalized g/W vs trial index
+    # scored trials: raw + normalized g/W vs trial index; anchors (incumbent
+    # re-runs) marked distinctly so drift is readable at a glance
     idx_raw = [(t["index"], t["score_raw"]) for t in trials
                if t.get("score_raw") is not None]
     idx_norm = [(t["index"], t["score_norm"]) for t in trials
                 if t.get("score_norm") is not None]
+    anchors = [(t["index"], t["score_raw"]) for t in trials
+               if t.get("kind") == "anchor"
+               and t.get("score_raw") is not None]
     dq = [t["index"] for t in trials if t.get("disqualified")]
 
     if idx_raw:
@@ -242,12 +293,38 @@ def _pdf_progress_page(plt, pdf, manifest: dict, result: dict):
         xs, ys = zip(*idx_norm)
         ax_prog.plot(xs, ys, "s--", color="#bf8700",
                      label="drift-normalized g/W", ms=4)
+    if anchors:
+        xs, ys = zip(*anchors)
+        ax_prog.plot(xs, ys, "o", mfc="white", mec="#0969da", ms=8,
+                     ls="none", label="anchor (incumbent re-run)")
     if dq:
-        ymin = min([y for _, y in idx_raw], default=0)
-        ax_prog.plot(dq, [ymin] * len(dq), "x", color="#cf222e", ms=8,
-                     label="disqualified")
-    ax_prog.set(xlabel="trial index", ylabel="objective (g/W)",
-                title="Objective per trial")
+        # park DQ markers in their own band under the data instead of on
+        # top of the minimum score (they have no score of their own)
+        ys = [y for _, y in idx_raw + idx_norm]
+        lo, hi = (min(ys), max(ys)) if ys else (0.0, 1.0)
+        band = lo - 0.08 * (hi - lo or 1.0)
+        ax_prog.plot(dq, [band] * len(dq), "x", color="#cf222e", ms=8,
+                     mew=2, ls="none", label="disqualified (no score)")
+
+    # stage bands: alternating background + label per contiguous stage
+    trans = blended_transform_factory(ax_prog.transData, ax_prog.transAxes)
+    spans: list[tuple[str, int, int]] = []
+    for t in sorted(trials, key=lambda t: t["index"]):
+        if spans and spans[-1][0] == t["stage"]:
+            spans[-1] = (t["stage"], spans[-1][1], t["index"])
+        else:
+            spans.append((t["stage"], t["index"], t["index"]))
+    for i, (name, a, b) in enumerate(spans):
+        if i % 2:
+            ax_prog.axvspan(a - 0.5, b + 0.5, color="#afb8c1", alpha=0.15,
+                            lw=0)
+        ax_prog.text((a + b) / 2.0, 1.015, name, transform=trans,
+                     ha="center", va="bottom", fontsize=8,
+                     color=_DEFAULT_GRAY)
+
+    ax_prog.set(xlabel="trial index", ylabel="objective (g/W)")
+    ax_prog.set_title("Objective per trial", pad=22)
+    ax_prog.xaxis.set_major_locator(MaxNLocator(integer=True))
     if idx_raw or idx_norm or dq:
         ax_prog.legend(loc="best", fontsize=8)
     ax_prog.grid(True, alpha=0.3)
@@ -257,12 +334,13 @@ def _pdf_progress_page(plt, pdf, manifest: dict, result: dict):
     if deltas:
         colors = ["#1a7f37" if d > 0 else "#cf222e" for d in deltas]
         ax_abba.bar(range(1, len(deltas) + 1), deltas, color=colors,
-                    alpha=0.8)
+                    alpha=0.8, width=0.5)
         med = result.get("median_paired_delta")
         if med is not None:
             ax_abba.axhline(med, ls="--", color="#0969da",
                             label=f"median {med:g} g/W")
         ax_abba.axhline(0, color="#57606a", lw=0.8)
+        ax_abba.set_xticks(list(range(1, len(deltas) + 1)))
         ax_abba.legend(loc="best", fontsize=8)
     else:
         ax_abba.text(0.5, 0.5, "no ABBA paired deltas", ha="center",
@@ -286,15 +364,15 @@ def _fmt_ov(ov) -> str:
     return str(ov)
 
 
-def _pdf_tables_pages(plt, pdf, manifest: dict):
-    # stages table
-    stages = manifest.get("stages", {})
-    stage_rows = [[name, _fmt_ov(s.get("winner")), _fmt(s.get("winner_score"))]
-                  for name, s in stages.items()]
-    _table_page(plt, pdf, "Stage winners", stage_rows,
-                ["stage", "winner", "score (g/W, norm)"])
+_TRIAL_COLS = ["#", "stage", "kind", "overrides", "raw g/W", "norm g/W",
+               "disqualified"]
+_TRIAL_WIDTHS = [0.04, 0.09, 0.11, 0.40, 0.075, 0.075, 0.21]
 
-    # trials table (paginated)
+
+def _pdf_tables_pages(plt, pdf, manifest: dict):
+    # trials table: landscape + explicit widths + wrapped text (a portrait
+    # auto-width table clipped both edges on real sessions), paginated on a
+    # LINE budget so wrapped disqualification reasons don't overflow a page
     trial_rows = []
     for e in manifest.get("trials", []):
         dq = "; ".join(e["disqualified"]) if e.get("disqualified") else ""
@@ -302,46 +380,27 @@ def _pdf_tables_pages(plt, pdf, manifest: dict):
             dq = (dq + " " if dq else "") + "(discarded: pack swap)"
         trial_rows.append([
             _fmt(e.get("index")), _fmt(e.get("stage")), _fmt(e.get("kind")),
-            _fmt_ov(e.get("overrides")), _fmt(e.get("score_raw")),
-            _fmt(e.get("score_norm")), dq])
-    cols = ["#", "stage", "kind", "overrides", "raw g/W", "norm g/W",
-            "disqualified"]
-    per_page = 26
-    if not trial_rows:
-        _table_page(plt, pdf, "Trials", [], cols)
-        return
-    for i in range(0, len(trial_rows), per_page):
-        chunk = trial_rows[i:i + per_page]
-        title = "Trials" if i == 0 else f"Trials (cont. {i // per_page + 1})"
-        _table_page(plt, pdf, title, chunk, cols)
+            _wrap(_fmt_ov(e.get("overrides")), 62), _fmt(e.get("score_raw")),
+            _fmt(e.get("score_norm")), _wrap(dq, 38)])
 
+    pages: list[list[list[str]]] = [[]]
+    lines = 0
+    for row in trial_rows:
+        n = max(cell.count("\n") + 1 for cell in row)
+        if pages[-1] and lines + n > 30:
+            pages.append([])
+            lines = 0
+        pages[-1].append(row)
+        lines += n
 
-def _table_page(plt, pdf, title: str, rows: list, cols: list):
-    fig = plt.figure(figsize=_PAGE)
-    fig.text(0.06, 0.955, title, fontsize=18, fontweight="bold", va="top")
-    ax = fig.add_axes([0.04, 0.04, 0.92, 0.86])
-    ax.axis("off")
-    if not rows:
-        ax.text(0.5, 0.5, "(none)", ha="center", va="center",
-                transform=ax.transAxes, color=_DEFAULT_GRAY)
-    else:
-        tbl = ax.table(cellText=rows, colLabels=cols, cellLoc="left",
-                       colLoc="left", loc="upper center")
-        _style_table(tbl, header_cols=len(cols))
-    pdf.savefig(fig)
-    plt.close(fig)
-
-
-def _style_table(tbl, *, header_cols: int) -> None:
-    tbl.auto_set_font_size(False)
-    tbl.set_fontsize(8)
-    tbl.auto_set_column_width(list(range(header_cols)))
-    tbl.scale(1, 1.4)
-    for (r, _c), cell in tbl.get_celld().items():
-        cell.set_edgecolor("#d0d7de")
-        if r == 0:
-            cell.set_facecolor("#f6f8fa")
-            cell.set_text_props(fontweight="bold")
+    for i, chunk in enumerate(pages):
+        fig = plt.figure(figsize=_PAGE_LS)
+        title = "Trials" if i == 0 else f"Trials (cont. {i + 1})"
+        fig.text(0.04, 0.94, title, fontsize=18, fontweight="bold", va="top")
+        _place_table(fig.add_axes([0.04, 0.05, 0.92, 0.80]), chunk,
+                     _TRIAL_COLS, _TRIAL_WIDTHS, line_h=0.026)
+        pdf.savefig(fig)
+        plt.close(fig)
 
 
 def _write_plots(run_dir: Path, metrics: dict) -> None:

--- a/hwci/hwci/runner.py
+++ b/hwci/hwci/runner.py
@@ -325,15 +325,26 @@ def _safe(fn):
 # Source builders
 # --------------------------------------------------------------------------
 def build_sim_sources(rig: RigConfig, profile: Profile, *,
-                      demag_prone: bool = True) -> Sources:
-    """All three channels fed by one RigSimulator (deterministic, no hardware)."""
+                      demag_prone: bool = True,
+                      sim=None, settings_blob: bytes | None = None) -> Sources:
+    """All three channels fed by one RigSimulator (deterministic, no hardware).
+
+    ``sim`` optionally supplies an existing :class:`~hwci.sim.RigSimulator` so
+    one simulator (pack state, temperature, RNG) persists across multiple
+    runs - the auto-tuner's trials share a rig exactly like hardware does.
+    ``settings_blob`` installs a 192-byte AM32 settings page on it (decoded by
+    :class:`~hwci.sim.SimSettings`, the sim's analogue of flash+reset).
+    """
     from .flightstand.simulator import SimulatedStand
-    from .sim import MotorParams, RigSimulator
+    from .sim import MotorParams, RigSimulator, SimSettings
     from .throttle.flightstand_src import FlightStandThrottle
 
     period = 1.0 / profile.sample_rate_hz
-    sim = RigSimulator(params=MotorParams(pole_pairs=rig.pole_pairs,
-                                          demag_prone=demag_prone))
+    if sim is None:
+        sim = RigSimulator(params=MotorParams(pole_pairs=rig.pole_pairs,
+                                              demag_prone=demag_prone))
+    if settings_blob is not None:
+        sim.set_settings(SimSettings.from_blob(settings_blob))
     stand = SimulatedStand(sim, fixed_dt=period).open()
     stand.set_safety_limits(profile.safety)
     throttle = FlightStandThrottle(stand, arm_settle_s=0.0)

--- a/hwci/hwci/settings.py
+++ b/hwci/hwci/settings.py
@@ -1,0 +1,283 @@
+"""AM32 EEPROM settings: read, mutate and write the 192-byte settings page.
+
+AM32 keeps its settings in a 192-byte ``EEprom_t`` union (Inc/eeprom.h) stored
+in a dedicated 1 KB flash page and read ONCE at boot (``loadEEpromSettings`` in
+Src/main.c). Changing a setting therefore never needs a rebuild: write the page
+over SWD with the debugger's one-shot ``program ... verify reset exit`` flow
+(:meth:`hwci.debugger.openocd.OpenOcdDebugger.flash`) and the reset boots the
+firmware into the new settings.
+
+Two safety properties are load-bearing here:
+
+* **Validation refuses out-of-range writes.** The firmware silently falls back
+  to defaults on bad values (e.g. ``pwm_frequency`` outside 8..144 keeps the
+  compile-time ARR, main.c ``loadEEpromSettings``), so an out-of-range "trial"
+  would run the DEFAULT setting while the tuner records it as the trial value -
+  a lie in the data. Rejecting the write is the only honest behaviour.
+* **Trial blobs are seeded from the device's current page**, mutating only the
+  tuned bytes. That preserves the version/identity bytes (offsets 1, 3, 4),
+  motor_kv, input_type and servo calibration - so the boot-time
+  version-mismatch rewrite in main.c (which saves the page back when
+  VERSION_MAJOR/MINOR or EEPROM_VERSION differ) never fires mid-tune, and rig
+  calibration is never clobbered.
+
+The live settings address is the firmware global ``eeprom_address``
+(Src/main.c): it starts at the target's ``EEPROM_START_ADD`` but the bootloader
+devinfo check may rewrite it at boot (0x1f -> 0x08007c00, 0x35 -> 0x0800f800,
+0x2b -> 0x0801f800). :func:`resolve_eeprom_address` reads the global off the
+running target (flash is memory-mapped, same read path as the perf struct) and
+sanity-checks it against the known values.
+"""
+from __future__ import annotations
+
+import hashlib
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import elf
+from .debugger.base import Debugger
+
+EEPROM_SIZE = 192
+UNION_TAG = "EEprom_u"
+EEPROM_ADDRESS_SYMBOL = "eeprom_address"
+
+# F051 EEPROM_START_ADD (Inc/targets.h) - the ARK 4IN1 value.
+DEFAULT_EEPROM_ADDRESS = 0x08007C00
+# Every value the firmware's eeprom_address global can legally hold: the
+# per-target EEPROM_START_ADD values, which are also exactly the values the
+# bootloader-devinfo rewrite in Src/main.c can install.
+KNOWN_EEPROM_ADDRESSES = frozenset({0x08007C00, 0x0800F800, 0x0801F800})
+
+
+class SettingsError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Field:
+    """One tunable byte of the EEprom_t settings struct."""
+    name: str
+    offset: int
+    lo: int          # inclusive firmware-valid range
+    hi: int
+    description: str
+    size: int = 1
+
+
+# Tunable settings, offsets/ranges from Inc/eeprom.h comments and the
+# validation code in Src/main.c loadEEpromSettings(). ``lo``/``hi`` are the
+# FIRMWARE-accepted ranges; a tune spec may (and should) sweep a narrower
+# window - e.g. pwm_frequency is valid 8..144 but sensibly tuned 8..48.
+EEPROM_FIELDS: dict[str, Field] = {f.name: f for f in [
+    Field("max_ramp", 5, 1, 255,
+          "throttle ramp limit, 0.1%/ms steps up to 25%/ms (default 160)"),
+    Field("variable_pwm", 21, 0, 2,
+          "0=fixed PWM, 1=RPM-scaled within pwm_frequency range, 2=auto range"),
+    Field("advance_level", 23, 10, 42,
+          "timing advance, value-10 degrees*(48/32) (16 = firmware fallback)"),
+    Field("pwm_frequency", 24, 8, 144,
+          "PWM frequency in kHz; firmware accepts 8..144, tune 8..48"),
+    Field("startup_power", 25, 50, 150,
+          "startup duty boost; firmware accepts 50..150"),
+    Field("auto_advance", 47, 0, 1,
+          "1 = firmware maps advance from duty cycle, ignoring advance_level"),
+]}
+
+# Identity/version bytes that a settings write must NEVER change: a mismatch
+# against the running firmware's VERSION_MAJOR/MINOR or EEPROM_VERSION makes
+# boot rewrite the whole page (main.c), invalidating the trial blob.
+READ_ONLY_OFFSETS: dict[int, str] = {
+    1: "eeprom_version",
+    3: "version.major",
+    4: "version.minor",
+}
+
+_OFFSET_TO_NAME: dict[int, str] = {
+    **{f.offset: f.name for f in EEPROM_FIELDS.values()},
+    **READ_ONLY_OFFSETS,
+}
+
+
+def resolve_field(name: str, offset: int | None = None) -> Field:
+    """Resolve a tune parameter to a :class:`Field`.
+
+    Known names come from :data:`EEPROM_FIELDS`. An explicit ``offset`` (for
+    settings this module doesn't know yet - forward-compat with newer
+    firmware) yields an ad-hoc full-range byte field, but never one of the
+    read-only identity offsets.
+    """
+    if name in EEPROM_FIELDS:
+        f = EEPROM_FIELDS[name]
+        if offset is not None and offset != f.offset:
+            raise SettingsError(
+                f"parameter {name!r}: explicit offset {offset} contradicts "
+                f"the known offset {f.offset}")
+        return f
+    if offset is None:
+        raise SettingsError(
+            f"unknown setting {name!r} and no explicit offset given; known: "
+            f"{sorted(EEPROM_FIELDS)}")
+    if not 0 <= offset < EEPROM_SIZE:
+        raise SettingsError(f"parameter {name!r}: offset {offset} outside "
+                            f"the {EEPROM_SIZE}-byte settings page")
+    if offset in READ_ONLY_OFFSETS:
+        raise SettingsError(
+            f"parameter {name!r}: offset {offset} is the read-only identity "
+            f"byte {READ_ONLY_OFFSETS[offset]!r}")
+    return Field(name, offset, 0, 255, "explicit-offset parameter")
+
+
+class Settings:
+    """A 192-byte EEprom page image. Immutable-style: ``apply`` returns a copy."""
+
+    def __init__(self, data: bytes | bytearray):
+        if len(data) != EEPROM_SIZE:
+            raise SettingsError(
+                f"settings blob must be {EEPROM_SIZE} bytes, got {len(data)}")
+        self._data = bytearray(data)
+
+    @classmethod
+    def from_device(cls, dbg: Debugger, addr: int) -> "Settings":
+        """Read the current page off the target (flash is memory-mapped)."""
+        return cls(dbg.read_memory(addr, EEPROM_SIZE))
+
+    @classmethod
+    def from_bin(cls, path: str | Path) -> "Settings":
+        return cls(Path(path).read_bytes())
+
+    def get(self, name: str, offset: int | None = None) -> int:
+        return self._data[resolve_field(name, offset).offset]
+
+    def apply(self, overrides: dict[str, int],
+              offsets: dict[str, int] | None = None) -> "Settings":
+        """Return a copy with ``overrides`` applied, validating every value.
+
+        ``offsets`` optionally maps names to explicit byte offsets (see
+        :func:`resolve_field`). Out-of-range values are refused, never
+        clamped: the firmware would silently fall back to its default and
+        the "trial" would not test what it claims to.
+        """
+        out = Settings(self._data)
+        for name, value in overrides.items():
+            f = resolve_field(name, (offsets or {}).get(name))
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise SettingsError(f"{name}: value {value!r} is not an int")
+            if not f.lo <= value <= f.hi:
+                raise SettingsError(
+                    f"{name}: {value} outside firmware-valid range "
+                    f"[{f.lo}, {f.hi}] ({f.description}); the firmware would "
+                    "silently ignore it, so the write is refused")
+            out._data[f.offset] = value
+        return out
+
+    def to_bytes(self) -> bytes:
+        return bytes(self._data)
+
+    def to_bin(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(self.to_bytes())
+        return path
+
+    def sha256(self) -> str:
+        return hashlib.sha256(self._data).hexdigest()
+
+    def hex(self) -> str:
+        return self._data.hex()
+
+    def diff(self, other: "Settings") -> list[tuple[str, int, int]]:
+        """Byte-level diff -> [(name, self_value, other_value)]; bytes with no
+        known field name are reported as ``offset:N``."""
+        out = []
+        for i, (a, b) in enumerate(zip(self._data, other._data)):
+            if a != b:
+                out.append((_OFFSET_TO_NAME.get(i, f"offset:{i}"), a, b))
+        return out
+
+    def describe(self) -> dict[str, int]:
+        """Values of every known tunable field (for reports/CLI)."""
+        return {name: self._data[f.offset]
+                for name, f in sorted(EEPROM_FIELDS.items(),
+                                      key=lambda kv: kv[1].offset)}
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Settings) and self._data == other._data
+
+
+def default_blob() -> bytes:
+    """A plausible AM32 default settings page for the OFFLINE simulator.
+
+    Field values follow the firmware defaults in ``loadEEpromSettings`` /
+    the configurator defaults; identity bytes are non-zero so the tuner's
+    "seed from device, mutate only tuned bytes" flow is exercised for real.
+    Never used on hardware - there the page is always read off the device.
+    """
+    d = bytearray(EEPROM_SIZE)
+    d[0] = 0x01    # reserved/boot byte
+    d[1] = 2       # eeprom_version
+    d[3] = 2       # version.major
+    d[4] = 18      # version.minor
+    d[5] = 160     # max_ramp (25%/ms)
+    d[6] = 1       # minimum_duty_cycle
+    d[8] = 10      # absolute_voltage_cutoff
+    d[9] = 100     # current_P
+    d[11] = 100    # current_D
+    d[20] = 1      # comp_pwm
+    d[21] = 1      # variable_pwm
+    d[22] = 1      # stuck_rotor_protection
+    d[23] = 26     # advance_level (16 degrees)
+    d[24] = 24     # pwm_frequency kHz
+    d[25] = 100    # startup_power
+    d[26] = 55     # motor_kv -> (55*40)+20 = 2220
+    d[27] = 14     # motor_poles
+    d[30] = 5      # beep_volume
+    d[32], d[33], d[34], d[35] = 128, 128, 128, 50   # servo cal
+    d[37] = 30     # low_cell_volt_cutoff (3.0v)
+    d[43], d[44] = 141, 102   # limits (off)
+    d[45] = 5      # sine_mode_power
+    d[46] = 1      # input_type
+    return bytes(d)
+
+
+def resolve_eeprom_address(dbg: Debugger, elf_path: str) -> int:
+    """Read the live ``eeprom_address`` global off the running target.
+
+    The global's RAM address comes from the ELF symbol table; its VALUE is
+    what boot-time devinfo handling left there. Sanity-checked against the
+    known per-target page addresses - a garbage value here would make the
+    tuner "program" an arbitrary flash sector.
+    """
+    sym = elf.find_symbol(elf_path, EEPROM_ADDRESS_SYMBOL)
+    addr = int.from_bytes(dbg.read_memory(sym.address, 4), "little")
+    if addr not in KNOWN_EEPROM_ADDRESSES:
+        raise SettingsError(
+            f"live eeprom_address reads 0x{addr:08x}, not one of the known "
+            f"settings pages {sorted(f'0x{a:08x}' for a in KNOWN_EEPROM_ADDRESSES)}; "
+            "refusing to write settings anywhere else")
+    return addr
+
+
+def check_eeprom_layout(elf_path: str) -> None:
+    """Cross-check :data:`EEPROM_FIELDS` offsets against the ELF's DWARF.
+
+    Mirrors ``PerfReader._check_layout``: missing DWARF only warns (the
+    canonical offsets in this module still apply), but DWARF that lacks the
+    ``EEprom_u`` union entirely, or disagrees on an offset, fails hard -
+    that is exactly the firmware/host drift this check exists to catch.
+    """
+    try:
+        members = {m.name: m for m in elf.union_layout(elf_path, UNION_TAG)}
+    except elf.StructNotFoundError as e:
+        raise SettingsError(f"cannot cross-check EEprom layout: {e}") from e
+    except elf.ElfError as e:
+        warnings.warn(f"EEprom layout cross-check skipped ({e}); relying on "
+                      "the canonical offsets in hwci/hwci/settings.py")
+        return
+    for f in EEPROM_FIELDS.values():
+        m = members.get(f.name)
+        if m is None or m.offset != f.offset or m.size != f.size:
+            raise SettingsError(
+                f"firmware/host EEprom layout mismatch at {f.name!r}: "
+                f"ELF={m} canonical(off={f.offset},size={f.size}); "
+                "update EEPROM_FIELDS in hwci/hwci/settings.py")

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -218,7 +218,14 @@ class RigSimulator:
             frac = 0.05 if self.desync_remaining > 0 else 0.005
             if self.settings is not None and self.settings.variable_pwm:
                 frac *= p.variable_pwm_jitter_mult
-            dev = max(1, int(interval * frac * self._rng.uniform(0.3, 1.7)))
+            # Stochastic rounding: the true deviation is often sub-tick
+            # (0.5% of a ~150-tick interval), and plain int()+floor-at-1
+            # quantizes every configuration to the same "1 tick" - hiding
+            # e.g. variable_pwm's jitter penalty from the accumulated mean.
+            raw_dev = interval * frac * self._rng.uniform(0.3, 1.7)
+            dev = int(raw_dev)
+            if self._rng.random() < (raw_dev - dev):
+                dev += 1
             self.zc_count = (self.zc_count + n_comm) & 0xFFFFFFFF
             self.zc_jitter_sum = (self.zc_jitter_sum + dev * n_comm) & 0xFFFFFFFF
             self.zc_interval_sum = (self.zc_interval_sum + interval * n_comm) & 0xFFFFFFFF

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -20,6 +20,30 @@ from dataclasses import dataclass, field
 from . import perf
 from .esc_telem.kiss import encode_frame
 from .flightstand.base import StandSample
+from .settings import Settings
+
+
+@dataclass(frozen=True)
+class SimSettings:
+    """The AM32 settings the simulator responds to, decoded from the SAME
+    192-byte blob :mod:`hwci.settings` writes to hardware - one decoder for
+    both paths, so a tuner bug in blob encoding shows up offline too."""
+    advance_level: int = 26
+    pwm_frequency: int = 24
+    variable_pwm: int = 1
+    auto_advance: int = 0
+    startup_power: int = 100
+    max_ramp: int = 160
+
+    @classmethod
+    def from_blob(cls, blob: bytes) -> "SimSettings":
+        s = Settings(blob)
+        return cls(advance_level=s.get("advance_level"),
+                   pwm_frequency=s.get("pwm_frequency"),
+                   variable_pwm=s.get("variable_pwm"),
+                   auto_advance=s.get("auto_advance"),
+                   startup_power=s.get("startup_power"),
+                   max_ramp=s.get("max_ramp"))
 
 
 @dataclass
@@ -40,6 +64,25 @@ class MotorParams:
     demag_step_threshold: float = 0.35   # throttle jump that can desync
     demag_current_a: float = 18.0        # current above which a jump desyncs
     desync_ticks: int = 8
+    # --- settings response (active only when RigSimulator.settings is set) --
+    # Phenomenological, tuner-testable shapes: efficiency has an interior
+    # maximum in timing advance (gaussian) and in log2 PWM frequency; the
+    # optima are injectable so tests can move the "truth" and check the tuner
+    # finds it.
+    advance_optimum: float = 26.0        # eeprom advance_level units (10..42)
+    advance_sigma: float = 8.0
+    advance_eff_depth: float = 0.10      # efficiency lost far from optimum
+    auto_advance_equiv: float = 18.0     # auto_advance scores as this advance
+    pwm_optimum_khz: float = 24.0
+    pwm_sigma_log2: float = 1.0
+    pwm_eff_depth: float = 0.05
+    variable_pwm_low_bonus: float = 0.015   # small efficiency bonus...
+    variable_pwm_low_throttle: float = 0.45  # ...below this throttle
+    variable_pwm_jitter_mult: float = 1.4    # ...at a small ZC-jitter cost
+    # start attempts fail with probability (fail_ref - startup_power)/scale
+    # (clipped to [0, 0.9]): 50 -> 0.5, 100 -> ~0.12, 150 -> 0.
+    startup_fail_ref: float = 115.0
+    startup_fail_scale: float = 130.0
 
 
 @dataclass
@@ -47,9 +90,13 @@ class RigSimulator:
     params: MotorParams = field(default_factory=MotorParams)
     seed: int = 1234
     noise: float = 0.01  # fractional measurement noise
+    # AM32 settings under test; None = legacy behaviour (no settings model),
+    # which stays bit-identical so settings-less runs are unaffected.
+    settings: SimSettings | None = None
 
     def __post_init__(self):
         self._rng = random.Random(self.seed)
+        self._start_blocked = False
         self.rpm = 0.0
         self.throttle = 0.0
         self._prev_cmd = 0.0
@@ -75,9 +122,43 @@ class RigSimulator:
         self._phase_rr = 0
 
     # --- model -------------------------------------------------------
+    def set_settings(self, settings: SimSettings | None) -> None:
+        """Install the AM32 settings under test (the sim's "reboot into new
+        settings"); also clears any blocked-start latch from the previous
+        trial, like the real MCU reset would."""
+        self.settings = settings
+        self._start_blocked = False
+
     def _rpm_max(self) -> float:
         p = self.params
         return p.kv * p.batt_voltage * p.throttle_rpm_fraction
+
+    def _settings_eff_factor(self) -> float:
+        """Efficiency multiplier (<= 1 + small bonus) from the settings model."""
+        s = self.settings
+        if s is None:
+            return 1.0
+        p = self.params
+        adv = p.auto_advance_equiv if s.auto_advance else float(s.advance_level)
+        g_adv = math.exp(-((adv - p.advance_optimum) ** 2)
+                         / (2.0 * p.advance_sigma ** 2))
+        g_pwm = math.exp(-(math.log2(max(s.pwm_frequency, 1) / p.pwm_optimum_khz) ** 2)
+                         / (2.0 * p.pwm_sigma_log2 ** 2))
+        factor = ((1.0 - p.advance_eff_depth * (1.0 - g_adv))
+                  * (1.0 - p.pwm_eff_depth * (1.0 - g_pwm)))
+        if s.variable_pwm and self.throttle < p.variable_pwm_low_throttle:
+            factor *= 1.0 + p.variable_pwm_low_bonus
+        return factor
+
+    def _demag_step_threshold(self) -> float:
+        """Effective throttle-jump threshold for a desync: a low max_ramp
+        slew-limits the duty step the firmware actually applies, so the jump
+        needed to shed sync scales up as max_ramp comes down (deterministic
+        realization of "low max_ramp reduces desync probability")."""
+        p = self.params
+        if self.settings is None or self.settings.max_ramp <= 0:
+            return p.demag_step_threshold
+        return p.demag_step_threshold * (160.0 / self.settings.max_ramp)
 
     def step(self, dt: float, throttle: float) -> None:
         p = self.params
@@ -87,9 +168,28 @@ class RigSimulator:
         # Detect a demag/desync trigger: a big, fast throttle increase into a
         # high-current regime on a demag-prone motor.
         target_rpm = throttle * self._rpm_max()
+
+        # Startup reliability model (settings runs only): each stopped->spin
+        # transition is a start attempt that fails with a probability set by
+        # startup_power; a failed start leaves the rotor twitching at ~zero
+        # RPM until the throttle is dropped and a new attempt begins.
+        if self.settings is not None:
+            if self._start_blocked:
+                if throttle <= 0.02:
+                    self._start_blocked = False
+                target_rpm = 0.0
+            elif (throttle > 0.02 and self._prev_cmd <= 0.02
+                    and self.rpm < 200.0):
+                p_fail = max(0.0, min(0.9, (p.startup_fail_ref
+                                            - self.settings.startup_power)
+                                     / p.startup_fail_scale))
+                if self._rng.random() < p_fail:
+                    self._start_blocked = True
+                    target_rpm = 0.0
+
         provisional_current = self._current_for_rpm(target_rpm, p.batt_voltage)
         if (p.demag_prone and self.desync_remaining == 0
-                and cmd_jump > p.demag_step_threshold
+                and cmd_jump > self._demag_step_threshold()
                 and provisional_current > p.demag_current_a):
             self.desync_remaining = p.desync_ticks
             self.desync_count += 1
@@ -116,6 +216,8 @@ class RigSimulator:
         if n_comm > 0 and self.zero_cross_count >= 100:
             interval = int((1.0 / (erev_per_s * 6.0)) / 0.5e-6)
             frac = 0.05 if self.desync_remaining > 0 else 0.005
+            if self.settings is not None and self.settings.variable_pwm:
+                frac *= p.variable_pwm_jitter_mult
             dev = max(1, int(interval * frac * self._rng.uniform(0.3, 1.7)))
             self.zc_count = (self.zc_count + n_comm) & 0xFFFFFFFF
             self.zc_jitter_sum = (self.zc_jitter_sum + dev * n_comm) & 0xFFFFFFFF
@@ -153,7 +255,8 @@ class RigSimulator:
         torque = p.cq * rpm * rpm
         omega = rpm * 2.0 * math.pi / 60.0
         mech = torque * omega
-        elec = mech / p.motor_efficiency + p.idle_power_w
+        elec = mech / (p.motor_efficiency * self._settings_eff_factor()) \
+            + p.idle_power_w
         return elec / max(v, 1.0)
 
     # --- derived measurements ---------------------------------------

--- a/hwci/hwci/tuner.py
+++ b/hwci/hwci/tuner.py
@@ -50,6 +50,7 @@ import numpy as np
 import yaml
 
 from . import metrics as metricsmod
+from . import report as reportmod
 from .config import (PROFILES_DIR, Profile, RigConfig, load_profile,
                      profile_from_dict, profile_to_dict)
 from .debugger.base import MockDebugger
@@ -1230,6 +1231,11 @@ class Tuner:
         best.to_bin(self.out / "best_settings.bin")
         (self.out / "settings_diff.md").write_text(self._diff_md(best))
         (self.out / "report.md").write_text(self._report_md(result))
+        pdf = reportmod.write_tune_pdf(
+            self.out, self.manifest, result, self.base.diff(best),
+            log=self.log)
+        if pdf is not None:
+            self.log(f"PDF report: {pdf}")
         self.log(f"winner {result['winner_overrides'] or '{}'} "
                  f"{'CONFIRMED' if result['confirmed'] else 'NOT confirmed'} "
                  f"(median paired delta: {result['median_paired_delta']})")

--- a/hwci/hwci/tuner.py
+++ b/hwci/hwci/tuner.py
@@ -1,0 +1,1313 @@
+"""Auto settings tuner: find the best AM32 EEPROM settings for a motor/prop.
+
+Given a motor/prop on the rig, ``hwci tune`` searches the AM32 settings space
+(advance_level, pwm_frequency, variable_pwm, auto_advance, max_ramp, ...) for
+the combination that maximizes efficiency (g/W) subject to hard constraints:
+no demag/desync/bemf timeouts, zero-cross jitter not regressed vs the default
+settings, temperatures bounded, and reliable startup.
+
+Settings trials need NO rebuild: AM32 reads its 192-byte EEprom page once at
+boot, so each trial writes the page over SWD (one-shot flash + reset, see
+:mod:`hwci.settings`) and runs a short probe profile.
+
+Search shape (dictated by the bench's noise reality - same-firmware efficiency
+spread is up to 9.8 % at >= 20 W, and the pack drifts within a session, see
+hwci/baseline.py):
+
+* **Coordinate sweeps**, one parameter at a time with the others held at the
+  incumbent: advance_level (coarse grid, then refine +/- one step around the
+  argmax), then pwm_frequency (variable_pwm forced 0), then a **mode A/B
+  stage** on top of the winners ({} incumbent, variable_pwm 1, variable_pwm 2,
+  auto_advance 1) with interleaved repeats, then max_ramp as a
+  **constraint-only** stage on a step-stress profile.
+* **Anchor runs**: the incumbent settings are re-run every ``anchors_every``
+  trials; every candidate score is reported raw AND normalized to the linear
+  interpolation between surrounding anchors, which cancels pack drift.
+* **Finals**: winner vs default, interleaved ABBA blocks on the full
+  efficiency sweep plus a startup-reliability check. The winner is confirmed
+  only with a positive median paired delta and zero constraint failures.
+
+Every trial is checkpointed to ``manifest.json`` (atomic rewrite), so a
+session interrupted by a pack swap, crash, or Ctrl-C resumes exactly where it
+left off with ``hwci tune --resume <dir>``.
+"""
+from __future__ import annotations
+
+import abc
+import dataclasses
+import hashlib
+import json
+import math
+import os
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+import yaml
+
+from . import metrics as metricsmod
+from .config import (PROFILES_DIR, Profile, RigConfig, load_profile,
+                     profile_from_dict, profile_to_dict)
+from .debugger.base import MockDebugger
+from .model import RunResult
+from .runner import (DEFAULT_MIN_CELL_VOLTAGE, BatteryTooLowError,
+                     build_live_sources, build_sim_sources, check_battery,
+                     run_profile)
+from .settings import (DEFAULT_EEPROM_ADDRESS, EEPROM_SIZE, Settings,
+                       check_eeprom_layout, default_blob, resolve_eeprom_address,
+                       resolve_field)
+
+MANIFEST_VERSION = 1
+
+
+class TuneSpecError(ValueError):
+    """A tune spec failed strict validation (unknown key, bad value)."""
+
+
+class TunePaused(RuntimeError):
+    """The session checkpointed and stopped cleanly (e.g. pack too low with
+    --no-prompt); resume later with ``hwci tune --resume <dir>``."""
+
+
+# ==========================================================================
+# Tune spec (strict YAML schema)
+# ==========================================================================
+def _strict(d: dict | None, ctx: str, known: dict) -> dict:
+    """Return d after refusing unknown keys - a typo'd key must never
+    silently become 'use the default' (mirrors load_rig strictness)."""
+    d = d or {}
+    if not isinstance(d, dict):
+        raise TuneSpecError(f"tune spec: {ctx} must be a mapping, got {d!r}")
+    unknown = sorted(set(d) - set(known))
+    if unknown:
+        raise TuneSpecError(
+            f"tune spec: unknown key(s) {unknown} in {ctx}; "
+            f"valid keys: {sorted(known)}")
+    return d
+
+
+@dataclass
+class PackSpec:
+    min_resting_cell_v: float = 3.5
+    prompt_on_swap: bool = True
+
+
+@dataclass
+class ThermalSpec:
+    max_start_fet_temp_c: float | None = None
+    cool_timeout_s: float = 600.0
+
+
+@dataclass
+class ProbeSpec:
+    points: dict[str, float] | None = None   # label -> throttle, ordered
+    dwell_s: float = 6.0
+    safety: dict = field(default_factory=dict)
+
+
+@dataclass
+class ObjectiveSpec:
+    weights: dict[str, float] = field(default_factory=lambda: {
+        "t30": 1.0, "t50": 2.0, "t70": 1.0, "t90": 0.5})
+    min_power_w: float = 20.0
+    noise_floor_pct: float = 3.0
+
+
+@dataclass
+class StartupSpec:
+    cycles: int = 5
+    max_failed: int = 0
+    spin_throttle: float = 0.15
+    min_rpm: float = 1000.0
+
+
+@dataclass
+class ConstraintsSpec:
+    max_demag_events: int = 0
+    max_bemf_timeout_samples: int = 0
+    jitter_max_regression_pct: float = 25.0
+    max_fet_temp_c: float | None = None
+    max_motor_temp_c: float | None = None
+    startup: StartupSpec = field(default_factory=StartupSpec)
+
+
+@dataclass
+class ParamSpec:
+    name: str
+    values: list[int]
+    refine_step: int | None = None
+    offset: int | None = None      # explicit byte offset (forward-compat)
+
+
+@dataclass
+class StageSpec:
+    name: str
+    sweep: str | None = None                    # parameter name to grid-sweep
+    ab_candidates: list[dict] | None = None     # override dicts to A/B
+    fixed: dict = field(default_factory=dict)   # forced during this stage only
+    repeats: int = 1
+    profile: str | None = None                  # None -> tune probe
+    constraint_only: bool = False
+
+
+@dataclass
+class FinalsSpec:
+    profile: str = "efficiency_sweep"
+    pattern: str = "ABBA"
+    repeats: int = 2
+    startup_check: bool = True
+
+
+@dataclass
+class TuneSpec:
+    name: str
+    description: str = ""
+    battery_cells: int | None = None
+    pack: PackSpec = field(default_factory=PackSpec)
+    thermal: ThermalSpec = field(default_factory=ThermalSpec)
+    probe: ProbeSpec = field(default_factory=ProbeSpec)
+    objective: ObjectiveSpec = field(default_factory=ObjectiveSpec)
+    constraints: ConstraintsSpec = field(default_factory=ConstraintsSpec)
+    anchors_every: int = 5
+    parameters: dict[str, ParamSpec] = field(default_factory=dict)
+    stages: list[StageSpec] = field(default_factory=list)
+    finals: FinalsSpec = field(default_factory=FinalsSpec)
+
+    def param_offsets(self) -> dict[str, int]:
+        return {p.name: p.offset for p in self.parameters.values()
+                if p.offset is not None}
+
+
+def _build(cls, d: dict | None, ctx: str, nested: dict | None = None):
+    known = {f.name: f for f in dataclasses.fields(cls)}
+    d = dict(_strict(d, ctx, known))
+    for key, sub in (nested or {}).items():
+        if key in d:
+            d[key] = sub(d[key])
+    return cls(**d)
+
+
+def tune_spec_from_dict(data: dict) -> TuneSpec:
+    known = {f.name: f for f in dataclasses.fields(TuneSpec)}
+    data = dict(_strict(data, "top level", known))
+    if "name" not in data:
+        raise TuneSpecError("tune spec: 'name' is required")
+
+    data["pack"] = _build(PackSpec, data.get("pack"), "pack")
+    data["thermal"] = _build(ThermalSpec, data.get("thermal"), "thermal")
+    data["probe"] = _build(ProbeSpec, data.get("probe"), "probe")
+    data["objective"] = _build(ObjectiveSpec, data.get("objective"), "objective")
+    data["constraints"] = _build(
+        ConstraintsSpec, data.get("constraints"), "constraints",
+        nested={"startup": lambda d: _build(StartupSpec, d,
+                                            "constraints.startup")})
+    data["finals"] = _build(FinalsSpec, data.get("finals"), "finals")
+
+    params: dict[str, ParamSpec] = {}
+    for name, pd in (data.get("parameters") or {}).items():
+        pd = _strict(pd, f"parameters.{name}",
+                     {"values": None, "refine_step": None, "offset": None})
+        if not pd.get("values"):
+            raise TuneSpecError(f"tune spec: parameters.{name} needs 'values'")
+        p = ParamSpec(name=name, values=[int(v) for v in pd["values"]],
+                      refine_step=pd.get("refine_step"),
+                      offset=pd.get("offset"))
+        f = resolve_field(name, p.offset)   # raises on unknown/read-only
+        for v in p.values:
+            if not f.lo <= v <= f.hi:
+                raise TuneSpecError(
+                    f"tune spec: parameters.{name} value {v} outside "
+                    f"firmware-valid range [{f.lo}, {f.hi}]")
+        params[name] = p
+    data["parameters"] = params
+
+    stages: list[StageSpec] = []
+    seen = set()
+    for sd in data.get("stages") or []:
+        s = _build(StageSpec, sd, "stages[]")
+        if s.name in seen:
+            raise TuneSpecError(f"tune spec: duplicate stage name {s.name!r}")
+        seen.add(s.name)
+        if bool(s.sweep) == bool(s.ab_candidates):
+            raise TuneSpecError(
+                f"tune spec: stage {s.name!r} needs exactly one of "
+                "'sweep' or 'ab_candidates'")
+        if s.sweep and s.sweep not in params:
+            raise TuneSpecError(
+                f"tune spec: stage {s.name!r} sweeps unknown parameter "
+                f"{s.sweep!r}; declare it under parameters:")
+        for ov in (s.ab_candidates or []) + [s.fixed]:
+            _validate_overrides(ov, params, f"stage {s.name!r}")
+        stages.append(s)
+    data["stages"] = stages
+
+    if data["finals"].pattern != "ABBA":
+        raise TuneSpecError(
+            f"tune spec: finals.pattern {data['finals'].pattern!r} is not "
+            "supported (only 'ABBA')")
+    return TuneSpec(**data)
+
+
+def _validate_overrides(ov: dict, params: dict[str, ParamSpec], ctx: str):
+    if not isinstance(ov, dict):
+        raise TuneSpecError(f"tune spec: {ctx}: overrides must be a mapping")
+    for name, value in ov.items():
+        offset = params[name].offset if name in params else None
+        f = resolve_field(name, offset)
+        if not f.lo <= int(value) <= f.hi:
+            raise TuneSpecError(
+                f"tune spec: {ctx}: {name}={value} outside firmware-valid "
+                f"range [{f.lo}, {f.hi}]")
+
+
+def load_tune_spec(path: str | Path) -> TuneSpec:
+    data = yaml.safe_load(Path(path).read_text())
+    if not isinstance(data, dict):
+        raise TuneSpecError(f"tune spec {path}: not a YAML mapping")
+    try:
+        return tune_spec_from_dict(data)
+    except TuneSpecError as e:
+        raise TuneSpecError(f"{path}: {e}") from e
+
+
+# ==========================================================================
+# Profiles: probe + inline startup-reliability check
+# ==========================================================================
+def probe_profile(spec: TuneSpec) -> Profile:
+    """The tuner's inner probe (~28 s): tune_probe.yaml with the spec's
+    points/dwell/safety overrides applied."""
+    d = yaml.safe_load((PROFILES_DIR / "tune_probe.yaml").read_text())
+    if spec.probe.points:
+        # Keep the low-throttle warmup staircase (see the profile YAML for
+        # why it must exist) and rebuild only the measured points.
+        segs = [
+            {"label": "idle", "throttle": 0.0, "duration_s": 2.0},
+            {"label": "w10", "throttle": 0.10, "duration_s": 1.5, "ramp": True},
+            {"label": "w20", "throttle": 0.20, "duration_s": 1.5},
+        ]
+        for label, thr in spec.probe.points.items():
+            segs.append({"label": label, "throttle": float(thr),
+                         "duration_s": spec.probe.dwell_s, "steady": True})
+        segs.append({"label": "rampdn", "throttle": 0.0, "duration_s": 2.0,
+                     "ramp": True})
+        d["segments"] = segs
+    else:
+        for seg in d["segments"]:
+            if seg.get("steady"):
+                seg["duration_s"] = spec.probe.dwell_s
+    if spec.probe.safety:
+        d["safety"] = {**(d.get("safety") or {}), **spec.probe.safety}
+    return profile_from_dict(d)
+
+
+def startup_profile(spec: TuneSpec) -> Profile:
+    """Inline minimal startup-reliability profile: N cycles of
+    {spin low for 1.5 s -> stop 2.5 s}.
+
+    TODO: PR #22's startup_reliability profile/metric is not on this branch;
+    delegate to it (profile + its richer per-cycle metric) once merged.
+    """
+    st = spec.constraints.startup
+    segs = [{"label": "idle", "throttle": 0.0, "duration_s": 1.0}]
+    for i in range(st.cycles):
+        segs.append({"label": f"spin{i}", "throttle": st.spin_throttle,
+                     "duration_s": 1.5})
+        segs.append({"label": f"stop{i}", "throttle": 0.0, "duration_s": 2.5})
+    return profile_from_dict({
+        "name": "tune_startup",
+        "description": "inline startup-reliability check (auto-tuner)",
+        "sample_rate_hz": 100.0,
+        "segments": segs,
+        "safety": spec.probe.safety or None,
+    })
+
+
+def step_profile(spec: TuneSpec) -> Profile:
+    """Step-stress profile for the max_ramp constraint stage: aggressive
+    snaps into a high-current regime FROM A SPINNING STATE (0.30 hold).
+
+    Snapping from a stop (as demag_step_stress does) makes the host demag
+    detector read the spool-up's long commutation intervals as spike events
+    even when nothing desynced; stepping from 0.30 keeps the detector's
+    median-interval reference honest, so only a real loss of sync (bemf
+    timeouts, interval blow-up, RPM collapse) disqualifies a max_ramp value.
+    """
+    return profile_from_dict({
+        "name": "tune_step",
+        "description": "inline step-stress for the max_ramp stage (auto-tuner)",
+        "sample_rate_hz": 100.0,
+        "segments": [
+            {"label": "idle", "throttle": 0.0, "duration_s": 2.0},
+            {"label": "spool", "throttle": 0.30, "duration_s": 2.0, "ramp": True},
+            {"label": "hold30a", "throttle": 0.30, "duration_s": 2.0},
+            {"label": "snap95a", "throttle": 0.95, "duration_s": 1.5},
+            {"label": "hold30b", "throttle": 0.30, "duration_s": 2.0},
+            {"label": "snap95b", "throttle": 0.95, "duration_s": 1.5},
+            {"label": "hold30c", "throttle": 0.30, "duration_s": 2.0},
+            {"label": "rampdn", "throttle": 0.0, "duration_s": 1.5, "ramp": True},
+        ],
+        "safety": spec.probe.safety or None,
+    })
+
+
+def startup_stats(result: RunResult, profile: Profile,
+                  min_rpm: float = 1000.0) -> dict:
+    """Count failed starts in a :func:`startup_profile` run.
+
+    A cycle failed if by the END of its spin segment neither the stand RPM
+    nor the perf eRPM/pole_pairs exceeded ``min_rpm``.
+
+    TODO: replace with PR #22's startup_reliability metric when merged.
+    """
+    rows = result.rows
+    seg = np.array([r.get("segment") for r in rows], dtype=object)
+    stand_rpm = metricsmod._col(rows, "stand_rpm")
+    e_rpm = metricsmod._col(rows, "perf_e_rpm")
+    pp = int(result.meta.get("pole_pairs") or profile.pole_pairs)
+    cycles = 0
+    failed: list[str] = []
+    for s in profile.segments:
+        if not s.label.startswith("spin"):
+            continue
+        cycles += 1
+        idx = np.where(seg == s.label)[0]
+        if idx.size == 0:
+            failed.append(s.label)
+            continue
+        tail = idx[-max(1, idx.size // 4):]     # end of the spin segment
+        vals = np.concatenate([stand_rpm[tail],
+                               e_rpm[tail] / pp])   # column is true eRPM
+        vals = vals[~np.isnan(vals)]
+        if not (vals.size and float(vals.max()) >= min_rpm):
+            failed.append(s.label)
+    return {"cycles": cycles, "failed": len(failed),
+            "failed_segments": failed, "min_rpm": min_rpm}
+
+
+# ==========================================================================
+# Objective + constraints
+# ==========================================================================
+def objective_score(m: dict, objective: ObjectiveSpec) -> float | None:
+    """Weighted mean of eff_gf_per_w over steady points at meaningful power.
+
+    Points below ``min_power_w`` are excluded entirely - on the bench they
+    are the ratio of two small noisy numbers (a 2.3 W point swung -73 %
+    run-to-run on unchanged firmware, see hwci/baseline.py). Labels missing
+    from ``weights`` get weight 1.0. None if no point qualifies.
+    """
+    num = den = 0.0
+    for p in m.get("steady_points", []):
+        eff, pw = p.get("eff_gf_per_w"), p.get("elec_power_w")
+        if eff is None or pw is None or eff != eff or pw != pw:
+            continue
+        if pw < objective.min_power_w:
+            continue
+        w = float(objective.weights.get(p["segment"], 1.0))
+        num += w * eff
+        den += w
+    return num / den if den > 0 else None
+
+
+def check_constraints(m: dict, meta: dict, cons: ConstraintsSpec, *,
+                      jitter_reference: float | None,
+                      settings_verified: bool,
+                      startup: dict | None = None,
+                      min_start_rpm: float | None = None) -> list[str]:
+    """Hard-constraint check -> list of failure strings (empty = pass).
+
+    A failing trial is DISQUALIFIED, never scored: a desyncing run can post a
+    great g/W (undriven windmilling draws no power), so scoring it at all
+    would reward exactly the behaviour the tuner must avoid.
+    """
+    fails: list[str] = []
+    if meta.get("aborted"):
+        fails.append(f"run aborted: {meta['aborted']}")
+    if not settings_verified:
+        fails.append("settings readback mismatch (page on device != intended)")
+    d = m.get("demag", {})
+    if d.get("event_count", 0) > cons.max_demag_events:
+        fails.append(f"demag events {d.get('event_count')} > "
+                     f"{cons.max_demag_events}")
+    if d.get("bemf_timeout_samples", 0) > cons.max_bemf_timeout_samples:
+        fails.append(f"bemf timeout samples {d.get('bemf_timeout_samples')} > "
+                     f"{cons.max_bemf_timeout_samples}")
+    s = m.get("summary", {})
+    for key, bound in (("max_fet_temp_c", cons.max_fet_temp_c),
+                       ("max_motor_temp_c", cons.max_motor_temp_c)):
+        v = s.get(key)
+        if bound is not None and v is not None and v == v and v > bound:
+            fails.append(f"{key} {v:.1f} > {bound:.1f}")
+    j = s.get("worst_zc_jitter_pct")
+    if (jitter_reference is not None and j is not None
+            and j > jitter_reference
+            * (1.0 + cons.jitter_max_regression_pct / 100.0)):
+        fails.append(
+            f"zc jitter {j:.2f}% regressed > {cons.jitter_max_regression_pct}% "
+            f"vs default-settings anchor ({jitter_reference:.2f}%)")
+    if startup is not None:
+        if startup["failed"] > cons.startup.max_failed:
+            fails.append(f"failed starts {startup['failed']}/"
+                         f"{startup['cycles']} > {cons.startup.max_failed}")
+    elif min_start_rpm is not None:
+        pts = m.get("steady_points", [])
+        rpms = [p.get("rpm") for p in pts
+                if p.get("rpm") is not None and p.get("rpm") == p.get("rpm")]
+        if pts and (not rpms or max(rpms) < min_start_rpm):
+            fails.append("failed start: no steady point reached "
+                         f"{min_start_rpm:.0f} rpm")
+    return fails
+
+
+# ==========================================================================
+# Backends: how a trial reaches an ESC (simulated or real)
+# ==========================================================================
+class TuneBackend(abc.ABC):
+    """Writes settings pages and runs profiles against one ESC + rig."""
+
+    eeprom_address: int
+    mode: str                    # "sim" | "hw"
+
+    @abc.abstractmethod
+    def read_page(self) -> bytes:
+        """Current 192-byte settings page on the device."""
+
+    @abc.abstractmethod
+    def program(self, blob: bytes, bin_path: Path) -> None:
+        """Write ``blob`` as the settings page and reset into it."""
+
+    @abc.abstractmethod
+    def run_trial(self, blob: bytes, profile: Profile, bin_path: Path,
+                  meta: dict, *, battery_cells: int | None,
+                  min_cell_voltage: float) -> tuple[RunResult, dict]:
+        """Program ``blob``, run ``profile``, return (result, extra) where
+        extra carries ``settings_verified`` and ``resting_v``. Raises
+        :class:`BatteryTooLowError` BEFORE arming if the pack is too low."""
+
+    def wait_for_cool(self, max_temp_c: float, timeout_s: float) -> None:
+        """Optionally block until the FET temp is below ``max_temp_c``."""
+
+    def close(self) -> None:
+        pass
+
+
+class _SimEepromDevice(MockDebugger):
+    """MockDebugger whose flash() actually lands: the blob becomes the
+    readable page AND is decoded into the shared RigSimulator - the sim's
+    equivalent of 'program page, reset, firmware loads settings at boot'."""
+
+    def __init__(self, sim, eeprom_address: int):
+        super().__init__(base=eeprom_address, size=EEPROM_SIZE)
+        self._sim = sim
+
+    def flash(self, bin_path: str, load_addr: int) -> None:
+        from .sim import SimSettings
+        super().flash(bin_path, load_addr)
+        blob = Path(bin_path).read_bytes()
+        self.poke(load_addr, blob)
+        self._sim.set_settings(SimSettings.from_blob(blob))
+
+
+class SimTuneBackend(TuneBackend):
+    """One persistent RigSimulator across all trials (pack state, temperature
+    and RNG carry over, exactly like a physical rig would)."""
+
+    mode = "sim"
+
+    def __init__(self, rig: RigConfig | None = None, *,
+                 motor_params=None, seed: int = 1234, noise: float = 0.01,
+                 base_blob: bytes | None = None):
+        from .sim import MotorParams, RigSimulator
+        self.rig = rig or RigConfig()
+        params = motor_params or MotorParams(
+            pole_pairs=self.rig.pole_pairs, demag_prone=True,
+            # default sim tunes shouldn't randomly fail startup at the stock
+            # startup_power of 100; tests inject a harsher fail_ref
+            startup_fail_ref=100.0)
+        self.sim = RigSimulator(params=params, seed=seed, noise=noise)
+        self.eeprom_address = DEFAULT_EEPROM_ADDRESS
+        self.dbg = _SimEepromDevice(self.sim, self.eeprom_address)
+        self.dbg.poke(self.eeprom_address, base_blob or default_blob())
+        # test hook: report a different resting pack voltage (e.g. fake a
+        # drained pack to exercise the swap path)
+        self.voltage_fn: Callable[[], float] | None = None
+
+    def read_page(self) -> bytes:
+        return self.dbg.read_memory(self.eeprom_address, EEPROM_SIZE)
+
+    def program(self, blob: bytes, bin_path: Path) -> None:
+        bin_path.parent.mkdir(parents=True, exist_ok=True)
+        bin_path.write_bytes(blob)
+        self.dbg.flash(str(bin_path), self.eeprom_address)
+
+    def _resting_voltage(self) -> float:
+        return self.voltage_fn() if self.voltage_fn else self.sim.voltage
+
+    def run_trial(self, blob: bytes, profile: Profile, bin_path: Path,
+                  meta: dict, *, battery_cells: int | None,
+                  min_cell_voltage: float) -> tuple[RunResult, dict]:
+        resting_v = self._resting_voltage()
+        if battery_cells:
+            check_battery(resting_v, battery_cells, min_cell_voltage)
+        self.program(blob, bin_path)
+        verified = self.read_page() == blob
+        sources = build_sim_sources(self.rig, profile, sim=self.sim)
+        try:
+            result = run_profile(profile, sources, realtime=False, meta=meta)
+        finally:
+            sources.close()
+        return result, {"settings_verified": verified,
+                        "resting_v": round(resting_v, 3)}
+
+    def wait_for_cool(self, max_temp_c: float, timeout_s: float) -> None:
+        waited = 0.0
+        while self.sim.temp_c > max_temp_c and waited < timeout_s:
+            self.sim.step(1.0, 0.0)   # cool at zero throttle, sim time
+            waited += 1.0
+
+
+class HwTuneBackend(TuneBackend):
+    """Real rig: one-shot OpenOCD flash of the settings page, then the
+    standard live sources (mirrors cmd_ci's flash-then-open flow)."""
+
+    mode = "hw"
+
+    def __init__(self, rig: RigConfig, *, tare: bool = True):
+        from .debugger.openocd import OpenOcdDebugger
+        self.rig = rig
+        self.tare = tare
+        elf = rig.resolved_elf()
+        if elf is None:
+            raise FileNotFoundError(
+                f"no ELF for target {rig.target} in {rig.resolved_obj_dir()}; "
+                "build + flash firmware (HWCI_PERF=1) before tuning")
+        self.elf_path = str(elf)
+        # Layout drift between this module's EEPROM_FIELDS and the flashed
+        # firmware is caught HERE, before any page is written.
+        check_eeprom_layout(self.elf_path)
+        self._make_dbg = lambda: OpenOcdDebugger(
+            rig.openocd_configs, openocd_bin=rig.openocd_bin,
+            search_dirs=rig.openocd_search_dirs)
+        dbg = self._make_dbg().open()
+        try:
+            self.eeprom_address = resolve_eeprom_address(dbg, self.elf_path)
+        finally:
+            dbg.close()
+
+    def read_page(self) -> bytes:
+        dbg = self._make_dbg().open()
+        try:
+            return dbg.read_memory(self.eeprom_address, EEPROM_SIZE)
+        finally:
+            dbg.close()
+
+    def program(self, blob: bytes, bin_path: Path) -> None:
+        bin_path.parent.mkdir(parents=True, exist_ok=True)
+        bin_path.write_bytes(blob)
+        # One-shot program of the 1KB settings sector + verify + reset; the
+        # firmware reloads settings on the way back up.
+        self._make_dbg().flash(str(bin_path), self.eeprom_address)
+
+    def run_trial(self, blob: bytes, profile: Profile, bin_path: Path,
+                  meta: dict, *, battery_cells: int | None,
+                  min_cell_voltage: float) -> tuple[RunResult, dict]:
+        from .runner import _live_voltage
+        self.program(blob, bin_path)
+        sources = build_live_sources(
+            self.rig, profile, battery_cells=battery_cells,
+            min_cell_voltage=min_cell_voltage, tare=self.tare)
+        try:
+            verified = False
+            if sources.perf_reader is not None:
+                readback = sources.perf_reader.dbg.read_memory(
+                    self.eeprom_address, EEPROM_SIZE)
+                verified = readback == blob
+            resting_v = _live_voltage(sources.stand, sources.perf_source)
+            result = run_profile(profile, sources, realtime=True, meta=meta)
+        finally:
+            sources.close()
+        return result, {
+            "settings_verified": verified,
+            "resting_v": round(resting_v, 3) if resting_v is not None else None}
+
+    def wait_for_cool(self, max_temp_c: float, timeout_s: float) -> None:
+        # Best-effort: poll the ESC's own temperature over a short live
+        # session until it cools (the stand's FET probe needs open sources,
+        # which would hold the throttle line - keep it simple).
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            page_dbg = self._make_dbg().open()
+            try:
+                from .perf_reader import PerfReader
+                reader = PerfReader(page_dbg, self.elf_path,
+                                    check_layout=False)
+                temp = reader.read().raw.get("temperature_c")
+            except Exception:
+                temp = None
+            finally:
+                page_dbg.close()
+            if temp is None or temp <= max_temp_c:
+                return
+            time.sleep(10.0)
+
+
+# ==========================================================================
+# Session state (manifest + trial ledger, atomic checkpointing, resume)
+# ==========================================================================
+def _atomic_write_json(path: Path, data: dict) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True))
+    os.replace(tmp, path)
+
+
+def _git_sha(repo_root: str) -> str | None:
+    try:
+        out = subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                             cwd=repo_root, capture_output=True, text=True)
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def _slug(overrides: dict, kind: str) -> str:
+    if kind != "trial":
+        base = kind.replace("_", "-")
+    elif overrides:
+        base = "-".join(f"{k}_{v}" for k, v in sorted(overrides.items()))
+    else:
+        base = "incumbent"
+    return base[:60]
+
+
+@dataclass
+class TrialPlan:
+    stage: str
+    kind: str                    # trial|anchor|baseline|final_winner|...
+    overrides: dict[str, int]    # relative to the BASE page
+    profile: Profile
+    repeat: int = 0
+
+    def signature(self) -> dict:
+        return {"stage": self.stage, "kind": self.kind,
+                "overrides": self.overrides, "repeat": self.repeat,
+                "profile": self.profile.name}
+
+
+class Tuner:
+    """Runs (or resumes) one tune session against a backend."""
+
+    def __init__(self, spec: TuneSpec, backend: TuneBackend,
+                 out_dir: str | Path, *,
+                 spec_text: str | None = None,
+                 battery_cells: int | None = None,
+                 no_prompt: bool = False,
+                 resume: bool = False,
+                 config_path: str | None = None,
+                 prompt_fn: Callable[[str], str] = input,
+                 before_trial: Callable[[int, TrialPlan], None] | None = None,
+                 log: Callable[[str], None] = print):
+        self.spec = spec
+        self.backend = backend
+        self.out = Path(out_dir)
+        self.no_prompt = no_prompt
+        self.prompt_fn = prompt_fn
+        self.before_trial = before_trial
+        self.log = log
+        self.battery_cells = (battery_cells if battery_cells is not None
+                              else spec.battery_cells)
+        self._offsets = spec.param_offsets()
+        self._cursor = 0            # next ledger entry to try to reuse
+        self.executed = 0           # trials actually run this session
+
+        if resume:
+            self.manifest = json.loads((self.out / "manifest.json").read_text())
+            if self.manifest.get("format_version") != MANIFEST_VERSION:
+                raise TunePaused(
+                    f"manifest format {self.manifest.get('format_version')} "
+                    f"!= {MANIFEST_VERSION}; cannot resume")
+            self.base = Settings(bytes.fromhex(self.manifest["base_blob_hex"]))
+            # A crash may have left ANY trial's settings flashed; put the
+            # device back on the current incumbent before continuing.
+            blob = self.base.apply(self.manifest.get("incumbent") or {},
+                                   self._offsets)
+            self.backend.program(blob.to_bytes(),
+                                 self.out / "resume_settings.bin")
+        else:
+            self.out.mkdir(parents=True, exist_ok=True)
+            if spec_text is not None:
+                (self.out / "spec.yaml").write_text(spec_text)
+            self.base = Settings(self.backend.read_page())
+            self.base.to_bin(self.out / "base_settings.bin")
+            self.manifest = {
+                "format_version": MANIFEST_VERSION,
+                "spec_name": spec.name,
+                "spec_sha256": hashlib.sha256(
+                    (spec_text or "").encode()).hexdigest(),
+                "git_sha": _git_sha(getattr(backend, "rig", RigConfig()).repo_root),
+                "mode": backend.mode,
+                "config_path": config_path,
+                "battery_cells": self.battery_cells,
+                "eeprom_address": backend.eeprom_address,
+                "base_blob_hex": self.base.hex(),
+                "jitter_reference": None,
+                "incumbent": {},
+                "stages": {},
+                "trials": [],
+                "pack_events": [],
+                "result": None,
+            }
+            self._save()
+
+    # -- persistence ----------------------------------------------------
+    def _save(self) -> None:
+        _atomic_write_json(self.out / "manifest.json", self.manifest)
+
+    @property
+    def ledger(self) -> list[dict]:
+        return self.manifest["trials"]
+
+    @property
+    def incumbent(self) -> dict[str, int]:
+        return dict(self.manifest["incumbent"])
+
+    # -- battery / thermal gates -----------------------------------------
+    def _min_cell_voltage(self) -> float:
+        return max(DEFAULT_MIN_CELL_VOLTAGE, self.spec.pack.min_resting_cell_v)
+
+    def _handle_low_battery(self, err: BatteryTooLowError, index: int) -> None:
+        self._save()   # checkpoint before anything else
+        if self.no_prompt or not self.spec.pack.prompt_on_swap:
+            raise TunePaused(
+                f"pack too low before trial T{index:03d} ({err}); manifest "
+                f"checkpointed - swap the pack and resume with "
+                f"'hwci tune --resume {self.out}'")
+        self.prompt_fn(
+            f"\nPack too low before trial T{index:03d}: {err}\n"
+            "Swap/charge the pack, then press Enter to continue... ")
+        self.manifest["pack_events"].append({
+            "trial_index": index, "event": "pack_swap",
+            "reason": str(err), "time": time.time()})
+        self._save()
+
+    def _swap_count(self) -> int:
+        return len(self.manifest["pack_events"])
+
+    # -- one trial (with replay/reuse) -----------------------------------
+    def _trial(self, plan: TrialPlan) -> dict:
+        # Replay: skip discarded entries, reuse a completed matching entry.
+        while (self._cursor < len(self.ledger)
+                and self.ledger[self._cursor].get("discarded")):
+            self._cursor += 1
+        if self._cursor < len(self.ledger):
+            entry = self.ledger[self._cursor]
+            sig_match = all(entry.get(k) == v
+                            for k, v in plan.signature().items())
+            trial_dir = self.out / entry.get("dir", "")
+            complete = ((trial_dir / "trial.json").exists()
+                        and (trial_dir / "metrics.json").exists())
+            if sig_match and complete:
+                self._cursor += 1
+                return entry
+            # Diverged or incomplete: quarantine this and everything after.
+            self._quarantine_from(self._cursor)
+        return self._execute(plan)
+
+    def _quarantine_from(self, idx: int) -> None:
+        for entry in self.ledger[idx:]:
+            d = self.out / entry.get("dir", "")
+            if d.exists():
+                self._quarantine_dir(d)
+        del self.ledger[idx:]
+        self._save()
+
+    @staticmethod
+    def _quarantine_dir(d: Path) -> None:
+        target = d.with_name(d.name + ".incomplete")
+        n = 1
+        while target.exists():
+            target = d.with_name(f"{d.name}.incomplete{n}")
+            n += 1
+        d.rename(target)
+
+    def _execute(self, plan: TrialPlan) -> dict:
+        index = len(self.ledger)
+        if self.before_trial is not None:
+            self.before_trial(index, plan)
+        thermal = self.spec.thermal
+        if thermal.max_start_fet_temp_c is not None:
+            self.backend.wait_for_cool(thermal.max_start_fet_temp_c,
+                                       thermal.cool_timeout_s)
+        blob = self.base.apply(plan.overrides, self._offsets)
+        rel_dir = f"trials/T{index:03d}-{_slug(plan.overrides, plan.kind)}"
+        trial_dir = self.out / rel_dir
+        # Quarantine leftovers from a crash mid-trial: any dir claiming this
+        # trial index (whatever its slug) that never completed.
+        for stale in sorted(self.out.glob(f"trials/T{index:03d}-*")):
+            if stale.is_dir() and ".incomplete" not in stale.name:
+                self._quarantine_dir(stale)
+
+        rig = getattr(self.backend, "rig", RigConfig())
+        meta = {
+            "target": rig.target, "mode": self.backend.mode,
+            "profile": plan.profile.name,
+            "profile_def": profile_to_dict(plan.profile),
+            "pole_pairs": rig.pole_pairs,
+            "motor": rig.motor_name, "prop": rig.prop,
+            "tune_stage": plan.stage, "tune_kind": plan.kind,
+            "tune_overrides": plan.overrides,
+            "settings_blob_sha256": blob.sha256(),
+        }
+        while True:
+            try:
+                result, extra = self.backend.run_trial(
+                    blob.to_bytes(), plan.profile,
+                    trial_dir / "settings.bin", meta,
+                    battery_cells=self.battery_cells,
+                    min_cell_voltage=self._min_cell_voltage())
+                break
+            except BatteryTooLowError as e:
+                self._handle_low_battery(e, index)
+
+        result.meta.update(extra)
+        result.save(trial_dir)
+        m = metricsmod.compute(result, plan.profile)
+        (trial_dir / "metrics.json").write_text(json.dumps(m, indent=2))
+
+        is_startup = plan.profile.name == "tune_startup"
+        st = (startup_stats(result, plan.profile,
+                            self.spec.constraints.startup.min_rpm)
+              if is_startup else None)
+        fails = check_constraints(
+            m, result.meta, self.spec.constraints,
+            jitter_reference=self.manifest["jitter_reference"],
+            settings_verified=bool(extra.get("settings_verified")),
+            startup=st,
+            min_start_rpm=(None if is_startup
+                           else self.spec.constraints.startup.min_rpm))
+        score = objective_score(m, self.spec.objective) if not fails else None
+        summary = m.get("summary", {})
+
+        entry = {
+            **plan.signature(),
+            "index": index,
+            "dir": rel_dir,
+            "blob_sha256": blob.sha256(),
+            "settings_verified": bool(extra.get("settings_verified")),
+            "resting_v": extra.get("resting_v"),
+            "score_raw": None if score is None else round(score, 5),
+            "score_norm": None,
+            "disqualified": fails or None,
+            "startup": st,
+            "jitter_pct": summary.get("worst_zc_jitter_pct"),
+            "fet_temp_c": _none_if_nan(summary.get("max_fet_temp_c")),
+            "discarded": False,
+        }
+        (trial_dir / "trial.json").write_text(
+            json.dumps(entry, indent=2, sort_keys=True))
+        self.ledger.append(entry)
+        self._cursor = len(self.ledger)
+        self.executed += 1
+        self._save()
+        if fails:
+            verdict = f"DISQUALIFIED ({'; '.join(fails)})"
+        elif score is not None:
+            verdict = f"score {score:.3f} g/W"
+        else:
+            verdict = "ok (no scored points)"
+        self.log(f"  T{index:03d} {plan.stage}/{plan.kind} "
+                 f"{plan.overrides or '{}'} -> {verdict}")
+        return entry
+
+    # -- anchor-normalized scoring ---------------------------------------
+    @staticmethod
+    def _normalize(entries: list[dict], anchors: list[tuple[int, float]],
+                   positions: dict[int, int]) -> None:
+        """Set score_norm on each entry: raw scaled by the first anchor over
+        the linear interpolation between surrounding anchors (cancels pack
+        drift). No/one usable anchor -> raw is kept as-is."""
+        usable = [(p, s) for p, s in anchors if s is not None and s > 0]
+        for e in entries:
+            raw = e.get("score_raw")
+            if raw is None:
+                continue
+            pos = positions[e["index"]]
+            e["score_norm"] = round(raw * Tuner._drift_factor(usable, pos), 5)
+
+    @staticmethod
+    def _drift_factor(anchors: list[tuple[int, float]], pos: int) -> float:
+        if not anchors:
+            return 1.0
+        ref = anchors[0][1]
+        if pos <= anchors[0][0]:
+            interp = anchors[0][1]
+        elif pos >= anchors[-1][0]:
+            interp = anchors[-1][1]
+        else:
+            interp = anchors[0][1]
+            for (p0, s0), (p1, s1) in zip(anchors, anchors[1:]):
+                if p0 <= pos <= p1:
+                    frac = (pos - p0) / max(1, (p1 - p0))
+                    interp = s0 + (s1 - s0) * frac
+                    break
+        return ref / interp if interp > 0 else 1.0
+
+    # -- candidate scoring / winner picking --------------------------------
+    def _distance_to_default(self, overrides: dict[str, int]) -> float:
+        dist = 0.0
+        for name, v in overrides.items():
+            f = resolve_field(name, self._offsets.get(name))
+            span = max(1, f.hi - f.lo)
+            dist += abs(int(v) - self.base.get(name, self._offsets.get(name))) \
+                / span
+        return dist
+
+    def _pick_winner(self, cands: list[dict]) -> dict | None:
+        """cands: [{overrides, entries, order}] -> winner cand or None.
+
+        Disqualified candidates never win. Within ``noise_floor_pct`` of the
+        best score the tie breaks toward lower jitter, then lower FET temp,
+        then the settings closest to default.
+        """
+        scored = []
+        for c in cands:
+            if any(e.get("disqualified") for e in c["entries"]):
+                c["score"] = None
+                continue
+            vals = [e.get("score_norm") if e.get("score_norm") is not None
+                    else e.get("score_raw") for e in c["entries"]]
+            vals = [v for v in vals if v is not None]
+            if not vals:
+                c["score"] = None
+                continue
+            c["score"] = statistics.median(vals)
+            c["jitter"] = _median_of(c["entries"], "jitter_pct")
+            c["fet"] = _median_of(c["entries"], "fet_temp_c")
+            scored.append(c)
+        if not scored:
+            return None
+        best = max(c["score"] for c in scored)
+        floor = best * (1.0 - self.spec.objective.noise_floor_pct / 100.0)
+        tied = [c for c in scored if c["score"] >= floor]
+        tied.sort(key=lambda c: (
+            c["jitter"] if c.get("jitter") is not None else math.inf,
+            c["fet"] if c.get("fet") is not None else math.inf,
+            self._distance_to_default(c["overrides"]),
+            c["order"]))
+        return tied[0]
+
+    # -- stages ------------------------------------------------------------
+    def _merged(self, stage: StageSpec, overrides: dict) -> dict:
+        return {**self.incumbent, **stage.fixed, **overrides}
+
+    def _stage_profile(self, stage: StageSpec) -> Profile:
+        return self._profile_by_name(stage.profile)
+
+    def _profile_by_name(self, name: str | None) -> Profile:
+        if name in (None, "tune_probe", "probe"):
+            return probe_profile(self.spec)
+        if name == "tune_startup":
+            return startup_profile(self.spec)
+        if name == "tune_step":
+            return step_profile(self.spec)
+        return load_profile(name)
+
+    def _run_scored_stage(self, stage: StageSpec) -> None:
+        profile = self._stage_profile(stage)
+        anchors: list[tuple[int, float]] = []
+        positions: dict[int, int] = {}
+        entries_all: list[dict] = []
+        pos = 0
+        since_anchor = [0]
+
+        def run_one(kind: str, overrides: dict, repeat: int = 0) -> dict:
+            nonlocal pos
+            e = self._trial(TrialPlan(stage=stage.name, kind=kind,
+                                      overrides=overrides, profile=profile,
+                                      repeat=repeat))
+            positions[e["index"]] = pos
+            entries_all.append(e)
+            pos += 1
+            return e
+
+        def anchor() -> None:
+            e = run_one("anchor", self.incumbent)
+            anchors.append((positions[e["index"]], e.get("score_raw")))
+            since_anchor[0] = 0
+
+        def candidate(overrides: dict, repeat: int = 0) -> dict:
+            if since_anchor[0] >= self.spec.anchors_every:
+                anchor()
+            e = run_one("trial", overrides, repeat)
+            since_anchor[0] += 1
+            return e
+
+        anchor()
+        cands: list[dict] = []
+        if stage.sweep:
+            param = self.spec.parameters[stage.sweep]
+            f = resolve_field(param.name, param.offset)
+            values = list(dict.fromkeys(param.values))
+            inc_val = self.base.apply(self.incumbent, self._offsets).get(
+                param.name, param.offset)
+            if inc_val not in values:
+                values.append(inc_val)
+            for order, v in enumerate(values):
+                ent = [candidate(self._merged(stage, {param.name: v}), r)
+                       for r in range(stage.repeats)]
+                cands.append({"overrides": self._merged(stage, {param.name: v}),
+                              "value": v, "entries": ent, "order": order})
+            if param.refine_step:
+                # Refine around the raw ARGMAX (not the tie-break winner: the
+                # tie set spans the whole noise floor and would wander).
+                # Raw scores: anchors are not complete yet, but refinement
+                # only needs a neighborhood, not a drift-corrected ranking.
+                center = _argmax_value(cands)
+                if center is not None:
+                    for dv in (-param.refine_step, param.refine_step):
+                        v = center + dv
+                        if v in values or not f.lo <= v <= f.hi:
+                            continue
+                        values.append(v)
+                        ent = [candidate(
+                                   self._merged(stage, {param.name: v}), r)
+                               for r in range(stage.repeats)]
+                        cands.append({
+                            "overrides": self._merged(stage, {param.name: v}),
+                            "value": v, "entries": ent,
+                            "order": len(cands)})
+        else:
+            candidates = stage.ab_candidates or []
+            ents: list[list[dict]] = [[] for _ in candidates]
+            for r in range(stage.repeats):      # interleaved: c0 c1 c2 | c0..
+                for i, ov in enumerate(candidates):
+                    ents[i].append(candidate(self._merged(stage, ov), r))
+            cands = [{"overrides": self._merged(stage, ov), "raw_ov": ov,
+                      "entries": ents[i], "order": i}
+                     for i, ov in enumerate(candidates)]
+        anchor()
+
+        self._normalize(entries_all, anchors, positions)
+        self._save()
+        winner = self._pick_winner(cands)
+        if winner is not None:
+            self.manifest["incumbent"] = dict(winner["overrides"])
+        self.manifest["stages"][stage.name] = {
+            "winner": None if winner is None else winner["overrides"],
+            "winner_score": None if winner is None else round(winner["score"], 5),
+            "trials": [e["index"] for e in entries_all],
+        }
+        self._save()
+        self.log(f"stage {stage.name}: winner "
+                 f"{None if winner is None else winner['overrides']}")
+
+    def _run_constraint_stage(self, stage: StageSpec) -> None:
+        """Constraint-only sweep (e.g. max_ramp on a step profile): values are
+        tried in listed order (list them best-first); the first value with
+        ZERO constraint failures wins and the stage stops there."""
+        profile = self._stage_profile(stage)
+        param = self.spec.parameters[stage.sweep]
+        indices, winner_val = [], None
+        for v in param.values:
+            e = self._trial(TrialPlan(
+                stage=stage.name, kind="trial",
+                overrides=self._merged(stage, {param.name: v}),
+                profile=profile))
+            indices.append(e["index"])
+            if not e.get("disqualified"):
+                winner_val = v
+                break
+        if winner_val is not None:
+            self.manifest["incumbent"] = self._merged(
+                stage, {param.name: winner_val})
+        self.manifest["stages"][stage.name] = {
+            "winner": (None if winner_val is None
+                       else {param.name: winner_val}),
+            "winner_score": None,
+            "trials": indices,
+        }
+        self._save()
+        self.log(f"stage {stage.name}: winner "
+                 f"{None if winner_val is None else {param.name: winner_val}}")
+
+    # -- finals -------------------------------------------------------------
+    def _run_finals(self) -> dict:
+        finals = self.spec.finals
+        profile = self._profile_by_name(finals.profile)
+        winner_ov = self.incumbent
+        deltas: list[float] = []
+        winner_fails = 0
+        indices: list[int] = []
+        pattern = [("final_winner", winner_ov), ("final_default", {}),
+                   ("final_default", {}), ("final_winner", winner_ov)]
+        for rep in range(finals.repeats):
+            while True:     # a pack swap mid-block restarts the whole block
+                swaps_before = self._swap_count()
+                block: list[dict] = []
+                for kind, ov in pattern:
+                    e = self._trial(TrialPlan(stage="finals", kind=kind,
+                                              overrides=ov, profile=profile,
+                                              repeat=rep))
+                    block.append(e)
+                    if self._swap_count() != swaps_before and len(block) > 1:
+                        break   # block straddled a swap - restart it
+                if self._swap_count() == swaps_before or len(block) == 1:
+                    break
+                for e in block:     # discard the straddling partial block
+                    e["discarded"] = True
+                self._save()
+                self.log(f"finals block {rep}: pack swap mid-block - "
+                         "restarting the block")
+            indices += [e["index"] for e in block]
+            w = [e for e in block if e["kind"] == "final_winner"]
+            d = [e for e in block if e["kind"] == "final_default"]
+            winner_fails += sum(1 for e in w if e.get("disqualified"))
+            for we, de in zip(w, d):
+                if (we.get("score_raw") is not None
+                        and de.get("score_raw") is not None):
+                    deltas.append(we["score_raw"] - de["score_raw"])
+
+        startup_ok = True
+        st = None
+        if finals.startup_check:
+            sp = startup_profile(self.spec)
+            e = self._trial(TrialPlan(stage="finals", kind="final_startup",
+                                      overrides=winner_ov, profile=sp))
+            indices.append(e["index"])
+            st = e.get("startup")
+            startup_ok = not e.get("disqualified")
+
+        median_delta = statistics.median(deltas) if deltas else None
+        confirmed = (bool(winner_ov) and winner_fails == 0 and startup_ok
+                     and median_delta is not None and median_delta > 0)
+        result = {
+            "winner_overrides": winner_ov,
+            "median_paired_delta": (None if median_delta is None
+                                    else round(median_delta, 5)),
+            "paired_deltas": [round(x, 5) for x in deltas],
+            "winner_constraint_failures": winner_fails,
+            "startup": st,
+            "confirmed": confirmed,
+            "trials": indices,
+        }
+        self.manifest["result"] = result
+        self._save()
+        return result
+
+    # -- top level -----------------------------------------------------------
+    def run(self) -> dict:
+        spec = self.spec
+        self.log(f"tune session {spec.name!r} -> {self.out} "
+                 f"({self.backend.mode}, eeprom @ "
+                 f"0x{self.backend.eeprom_address:08x})")
+        # The incumbent is REPLAYED, not loaded: the manifest holds its
+        # latest value, but deterministic planning must see it evolve stage
+        # by stage exactly as the original session did (anchors run "the
+        # incumbent as of that trial", and their signatures must match).
+        self.manifest["incumbent"] = {}
+        # Session baseline: the DEFAULT (base-page) settings. Its jitter is
+        # the reference every trial's jitter-regression constraint compares
+        # against, and its score anchors the whole session.
+        e = self._trial(TrialPlan(stage="baseline", kind="baseline",
+                                  overrides={}, profile=probe_profile(spec)))
+        if self.manifest["jitter_reference"] is None:
+            self.manifest["jitter_reference"] = e.get("jitter_pct")
+            self._save()
+        if e.get("disqualified"):
+            self.log(f"WARNING: baseline run disqualified: {e['disqualified']}")
+
+        for stage in spec.stages:
+            if stage.constraint_only:
+                self._run_constraint_stage(stage)
+            else:
+                self._run_scored_stage(stage)
+
+        result = self._run_finals()
+        best = (self.base.apply(result["winner_overrides"], self._offsets)
+                if result["confirmed"] else self.base)
+        best.to_bin(self.out / "best_settings.bin")
+        (self.out / "settings_diff.md").write_text(self._diff_md(best))
+        (self.out / "report.md").write_text(self._report_md(result))
+        self.log(f"winner {result['winner_overrides'] or '{}'} "
+                 f"{'CONFIRMED' if result['confirmed'] else 'NOT confirmed'} "
+                 f"(median paired delta: {result['median_paired_delta']})")
+        return result
+
+    # -- reporting -----------------------------------------------------------
+    def _diff_md(self, best: Settings) -> str:
+        out = ["# Settings diff: default -> best\n",
+               "| setting | default | best |", "|---|---|---|"]
+        diff = self.base.diff(best)
+        if not diff:
+            out.append("| (no change - default settings won) | | |")
+        for name, a, b in diff:
+            out.append(f"| {name} | {a} | {b} |")
+        out.append("")
+        return "\n".join(out)
+
+    def _report_md(self, result: dict) -> str:
+        m = self.manifest
+        out = [f"# AM32 auto-tune report: {m['spec_name']}\n"]
+        out.append(f"- **mode**: {m['mode']}")
+        out.append(f"- **git_sha**: {m['git_sha']}")
+        out.append(f"- **eeprom_address**: 0x{m['eeprom_address']:08x}")
+        out.append(f"- **battery_cells**: {m['battery_cells']}")
+        out.append(f"- **jitter reference (default)**: "
+                   f"{m['jitter_reference']} %")
+        out.append(f"- **pack swaps**: {len(m['pack_events'])}")
+        out.append("")
+        out.append("## Verdict\n")
+        out.append(f"- winner: `{result['winner_overrides'] or '{} (default)'}`")
+        out.append(f"- confirmed: **{result['confirmed']}** "
+                   f"(median paired delta {result['median_paired_delta']} g/W "
+                   f"over {len(result['paired_deltas'])} ABBA pairs, "
+                   f"{result['winner_constraint_failures']} winner "
+                   "constraint failures)")
+        if result.get("startup") is not None:
+            st = result["startup"]
+            out.append(f"- startup: {st['failed']}/{st['cycles']} failed")
+        out.append("\n## Stages\n")
+        out.append("| stage | winner | score (g/W, normalized) |")
+        out.append("|---|---|---|")
+        for name, s in m["stages"].items():
+            out.append(f"| {name} | `{s['winner']}` | {s['winner_score']} |")
+        out.append("\n## Trials\n")
+        out.append("| # | stage | kind | overrides | raw g/W | norm g/W "
+                   "| disqualified |")
+        out.append("|---|---|---|---|---|---|---|")
+        for e in m["trials"]:
+            dq = "; ".join(e["disqualified"]) if e.get("disqualified") else ""
+            if e.get("discarded"):
+                dq = (dq + " " if dq else "") + "(discarded: pack swap)"
+            out.append(f"| {e['index']} | {e['stage']} | {e['kind']} | "
+                       f"`{e['overrides']}` | {e['score_raw']} | "
+                       f"{e['score_norm']} | {dq} |")
+        out.append("")
+        return "\n".join(out)
+
+
+def _argmax_value(cands: list[dict]) -> Optional[int]:
+    """Value of the best-scoring qualified sweep candidate (median raw)."""
+    best_v, best_s = None, None
+    for c in cands:
+        if any(e.get("disqualified") for e in c["entries"]):
+            continue
+        vals = [e["score_raw"] for e in c["entries"]
+                if e.get("score_raw") is not None]
+        if not vals:
+            continue
+        s = statistics.median(vals)
+        if best_s is None or s > best_s:
+            best_v, best_s = c["value"], s
+    return best_v
+
+
+def _none_if_nan(v):
+    return None if (isinstance(v, float) and math.isnan(v)) else v
+
+
+def _median_of(entries: list[dict], key: str) -> Optional[float]:
+    vals = [e[key] for e in entries if e.get(key) is not None]
+    return statistics.median(vals) if vals else None

--- a/hwci/hwci/tuner.py
+++ b/hwci/hwci/tuner.py
@@ -290,9 +290,20 @@ def probe_profile(spec: TuneSpec) -> Profile:
             {"label": "w10", "throttle": 0.10, "duration_s": 1.5, "ramp": True},
             {"label": "w20", "throttle": 0.20, "duration_s": 1.5},
         ]
+        prev = 0.20
         for label, thr in spec.probe.points.items():
-            segs.append({"label": label, "throttle": float(thr),
+            thr = float(thr)
+            # Steps > 10% throttle get a ramp segment: a 0.5->0.7 snap drew a
+            # 43-75 A one-sample transient on the 6S bench (harness abort at
+            # 40 A), while efficiency_sweep's unramped 10% staircase is
+            # bench-proven safe. The dwell stays constant-throttle so the
+            # steady tail is unaffected.
+            if abs(thr - prev) > 0.10 + 1e-9:
+                segs.append({"label": f"r_{label}", "throttle": thr,
+                             "duration_s": 1.0, "ramp": True})
+            segs.append({"label": label, "throttle": thr,
                          "duration_s": spec.probe.dwell_s, "steady": True})
+            prev = thr
         segs.append({"label": "rampdn", "throttle": 0.0, "duration_s": 2.0,
                      "ramp": True})
         d["segments"] = segs
@@ -351,7 +362,16 @@ def step_profile(spec: TuneSpec) -> Profile:
             {"label": "hold30c", "throttle": 0.30, "duration_s": 2.0},
             {"label": "rampdn", "throttle": 0.0, "duration_s": 1.5, "ramp": True},
         ],
-        "safety": spec.probe.safety or None,
+        # The snaps are the point of this profile, and a legitimate
+        # 0.3->0.95 snap transient peaks near 50 A on the 6S bench (see
+        # demag_step_stress.yaml's 55 A precedent). Probe-level current
+        # limits would abort every candidate on that transient before demag
+        # is even assessed, so give the current limit snap headroom; all
+        # other probe safety limits apply unchanged.
+        "safety": {**(spec.probe.safety or {}),
+                   "max_current_a": max(
+                       (spec.probe.safety or {}).get("max_current_a") or 0.0,
+                       55.0)},
     })
 
 
@@ -551,7 +571,11 @@ class SimTuneBackend(TuneBackend):
                   meta: dict, *, battery_cells: int | None,
                   min_cell_voltage: float) -> tuple[RunResult, dict]:
         resting_v = self._resting_voltage()
-        if battery_cells:
+        # Gate only on an injected voltage_fn (pack-drain tests): the sim's
+        # nominal battery doesn't represent a real cell count, same reason
+        # `hwci run`/`ci` ignore --battery-cells under --sim. A hardware
+        # spec's battery_cells must not stop a sim dry-run of the same spec.
+        if battery_cells and self.voltage_fn is not None:
             check_battery(resting_v, battery_cells, min_cell_voltage)
         self.program(blob, bin_path)
         verified = self.read_page() == blob
@@ -1228,7 +1252,10 @@ class Tuner:
         result = self._run_finals()
         best = (self.base.apply(result["winner_overrides"], self._offsets)
                 if result["confirmed"] else self.base)
-        best.to_bin(self.out / "best_settings.bin")
+        # Leave the DEVICE on the session's verdict too: the last finals
+        # trial flashed the unconfirmed winner, which would silently stay
+        # active while the report says "default kept".
+        self.backend.program(best.to_bytes(), self.out / "best_settings.bin")
         (self.out / "settings_diff.md").write_text(self._diff_md(best))
         (self.out / "report.md").write_text(self._report_md(result))
         pdf = reportmod.write_tune_pdf(

--- a/hwci/hwci/tuner.py
+++ b/hwci/hwci/tuner.py
@@ -1296,11 +1296,29 @@ class Tuner:
         # against, and its score anchors the whole session.
         e = self._trial(TrialPlan(stage="baseline", kind="baseline",
                                   overrides={}, profile=probe_profile(spec)))
+        if e.get("disqualified"):
+            self.log(f"WARNING: baseline run disqualified: "
+                     f"{e['disqualified']}; retrying once")
+            e = self._trial(TrialPlan(stage="baseline", kind="baseline",
+                                      overrides={},
+                                      profile=probe_profile(spec), repeat=1))
+        if e.get("disqualified"):
+            # Everything downstream leans on this run: the jitter gate's
+            # reference, drift normalization, and the finals' default legs.
+            # Bench experience: a session run past a broken baseline burns
+            # every trial and ends unconfirmable. Quarantine the baseline
+            # entries so a resume re-runs them fresh after the fix.
+            self._quarantine_from(0)
+            raise TunePaused(
+                "baseline (default settings) disqualified twice: "
+                f"{e['disqualified']} - fix the rig or spec limits, then "
+                f"resume with 'hwci tune --resume {self.out}'")
         if self.manifest["jitter_reference"] is None:
             self.manifest["jitter_reference"] = e.get("jitter_pct")
+            if e.get("jitter_pct") is None:
+                self.log("WARNING: baseline has no zc-jitter data; the "
+                         "jitter regression gate is OFF for this session")
             self._save()
-        if e.get("disqualified"):
-            self.log(f"WARNING: baseline run disqualified: {e['disqualified']}")
 
         for stage in spec.stages:
             if stage.constraint_only:

--- a/hwci/hwci/tuner.py
+++ b/hwci/hwci/tuner.py
@@ -157,6 +157,11 @@ class StageSpec:
     # list from the incumbent (valid for unimodal responses like advance or
     # pwm frequency - typically halves the trial count of a wide grid).
     search: str = "grid"
+    # "ramp_rate": measure the powertrain (mech time constant + transient
+    # current per % of duty lead) with one instrumented step run, COMPUTE
+    # max_ramp from the physics, then verify it on the step-stress profile.
+    measure: str | None = None
+    margin: float = 0.8       # fraction of the physics-derived rate to keep
 
 
 @dataclass
@@ -237,10 +242,22 @@ def tune_spec_from_dict(data: dict) -> TuneSpec:
         if s.name in seen:
             raise TuneSpecError(f"tune spec: duplicate stage name {s.name!r}")
         seen.add(s.name)
-        if bool(s.sweep) == bool(s.ab_candidates):
+        if sum(map(bool, (s.sweep, s.ab_candidates, s.measure))) != 1:
             raise TuneSpecError(
                 f"tune spec: stage {s.name!r} needs exactly one of "
-                "'sweep' or 'ab_candidates'")
+                "'sweep', 'ab_candidates' or 'measure'")
+        if s.measure is not None and s.measure != "ramp_rate":
+            raise TuneSpecError(
+                f"tune spec: stage {s.name!r} measure {s.measure!r} is not "
+                "'ramp_rate'")
+        if s.measure and s.constraint_only:
+            raise TuneSpecError(
+                f"tune spec: stage {s.name!r}: 'measure' and "
+                "'constraint_only' are mutually exclusive")
+        if not 0.1 <= s.margin <= 2.0:
+            raise TuneSpecError(
+                f"tune spec: stage {s.name!r} margin {s.margin} outside "
+                "[0.1, 2.0]")
         if s.search not in ("grid", "climb"):
             raise TuneSpecError(
                 f"tune spec: stage {s.name!r} search {s.search!r} is not "
@@ -385,6 +402,130 @@ def step_profile(spec: TuneSpec) -> Profile:
                        (spec.probe.safety or {}).get("max_current_a") or 0.0,
                        55.0)},
     })
+
+
+def ramp_measure_profile(spec: TuneSpec) -> Profile:
+    """Measurement profile for the mech-ramp stage: two moderate snap steps
+    from a spinning state (0.20 -> 0.55), sampled at 200 Hz.
+
+    The trial runs with max_ramp at the field maximum so firmware duty slew
+    is not the limiter: the eRPM rise time is then the POWERTRAIN's (rotor
+    inertia + prop aero load), and the current overshoot measures how much
+    a leading duty costs. Two reps -> median estimates. The step tops out
+    at 0.55 to stay clear of high-RPM sync margins (this bench desyncs
+    arriving at fresh-pack t70)."""
+    safety = dict(spec.probe.safety or {})
+    # deliberate snaps: same transient headroom rationale as step_profile
+    safety["max_current_a"] = max(safety.get("max_current_a") or 0.0, 55.0)
+    return profile_from_dict({
+        "name": "tune_ramp_measure",
+        "description": "inline powertrain step-response measurement "
+                       "(auto-tuner mech-ramp stage)",
+        "sample_rate_hz": 200.0,
+        "segments": [
+            {"label": "idle",     "throttle": 0.00, "duration_s": 2.0},
+            {"label": "spool",    "throttle": 0.20, "duration_s": 2.0,
+             "ramp": True},
+            {"label": "hold_lo",  "throttle": 0.20, "duration_s": 1.5},
+            {"label": "step_up",  "throttle": 0.55, "duration_s": 2.5},
+            {"label": "drop",     "throttle": 0.20, "duration_s": 2.0},
+            {"label": "step_up2", "throttle": 0.55, "duration_s": 2.5},
+            {"label": "rampdn",   "throttle": 0.00, "duration_s": 1.5,
+             "ramp": True},
+        ],
+        "safety": safety,
+    })
+
+
+def mech_ramp_stats(rows: list[dict]) -> Optional[dict]:
+    """Powertrain step-response estimates from a ``tune_ramp_measure`` run.
+
+    Per step: first-order time constant ``tau_ms`` (63.2% eRPM crossing),
+    mechanical slew (step height / tau) and the transient-current slope
+    ``k_a_per_pct`` (peak current overshoot per % of commanded duty step -
+    an upper bound on A per % of duty-lead, since the lead at the current
+    peak is at most the full step). Median across steps; None if no usable
+    step was found.
+    """
+    def fget(r, key):
+        v = r.get(key)
+        try:
+            return float(v) if v not in (None, "") else None
+        except (TypeError, ValueError):
+            return None
+
+    segs: dict[str, list[dict]] = {}
+    for r in rows:
+        segs.setdefault(str(r.get("segment")), []).append(r)
+
+    ests = []
+    for lbl, prev_lbl in (("step_up", "hold_lo"), ("step_up2", "drop")):
+        step, prev = segs.get(lbl), segs.get(prev_lbl)
+        if not step or not prev:
+            continue
+        tail = prev[-max(1, len(prev) // 5):]
+        base_rpm = statistics.median(
+            [v for r in tail if (v := fget(r, "perf_e_rpm")) is not None]
+            or [float("nan")])
+        base_i = statistics.median(
+            [v for r in tail if (v := fget(r, "stand_current_a")) is not None]
+            or [0.0])
+        plat = step[-max(1, len(step) // 3):]
+        hi_rpm = statistics.median(
+            [v for r in plat if (v := fget(r, "perf_e_rpm")) is not None]
+            or [float("nan")])
+        hi_i = statistics.median(
+            [v for r in plat if (v := fget(r, "stand_current_a")) is not None]
+            or [0.0])
+        if not (base_rpm == base_rpm and hi_rpm == hi_rpm):   # NaN guard
+            continue
+        rise = hi_rpm - base_rpm
+        if rise < 1000.0:            # no real step -> nothing to measure
+            continue
+        t0 = fget(step[0], "t")
+        thr0 = fget(prev[-1], "throttle_cmd") or 0.0
+        thr1 = fget(step[-1], "throttle_cmd") or 0.0
+        step_pct = abs(thr1 - thr0) * 100.0
+        if t0 is None or step_pct < 5.0:
+            continue
+        target = base_rpm + 0.632 * rise
+        t63 = next((t for r in step
+                    if (v := fget(r, "perf_e_rpm")) is not None
+                    and v >= target and (t := fget(r, "t")) is not None), None)
+        if t63 is None:
+            continue
+        tau_ms = max((t63 - t0) * 1000.0, 5.0)   # floor at sampling grain
+        i_pk = max([v for r in step
+                    if (t := fget(r, "t")) is not None and t <= t0 + 0.5
+                    and (v := fget(r, "stand_current_a")) is not None]
+                   or [base_i])
+        ests.append({
+            "tau_ms": tau_ms,
+            "slew_erpm_per_s": rise / (tau_ms / 1000.0),
+            "k_a_per_pct": max(i_pk - base_i, 0.1) / step_pct,
+            "i_peak_a": i_pk,
+            "i_hi_a": hi_i,
+            "rpm_lo": base_rpm,
+            "rpm_hi": hi_rpm,
+        })
+    if not ests:
+        return None
+    return {k: statistics.median([e[k] for e in ests]) for k in ests[0]}
+
+
+def compute_max_ramp(stats: dict, *, current_budget_a: float,
+                     lo: int, hi: int, margin: float = 0.8) -> int:
+    """max_ramp (0.1 %/ms units) from step-response physics.
+
+    During a duty ramp at rate r the duty leads the mechanical state by
+    ~r*tau once quasi-steady, and the transient current is ~k * lead. The
+    fastest ramp whose worst-case transient stays inside the budget is
+    r = budget / (k * tau); margin keeps a fraction of it.
+    """
+    lead_pct = current_budget_a / max(stats["k_a_per_pct"], 1e-3)
+    rate_pct_per_ms = lead_pct / max(stats["tau_ms"], 1.0)
+    setting = int(round(rate_pct_per_ms * 10.0 * margin))
+    return max(lo, min(hi, setting))
 
 
 def startup_stats(result: RunResult, profile: Profile,
@@ -1187,6 +1328,79 @@ class Tuner:
             if moved:
                 break   # went uphill one way; the other side is downhill
 
+    def _trial_rows(self, entry: dict) -> list[dict]:
+        import csv
+        path = self.out / entry.get("dir", "") / "samples.csv"
+        with open(path, newline="") as f:
+            return list(csv.DictReader(f))
+
+    def _run_measure_stage(self, stage: StageSpec) -> None:
+        """Physics-based max_ramp: measure the powertrain's step response
+        once (firmware slew unrestricted), compute the fastest ramp whose
+        worst-case transient stays inside the current budget, then VERIFY
+        it on the step-stress profile (backing off 0.7x on failure)."""
+        f = resolve_field("max_ramp", None)
+        e = self._trial(TrialPlan(
+            stage=stage.name, kind="measure",
+            overrides=self._merged(stage, {"max_ramp": f.hi}),
+            profile=ramp_measure_profile(self.spec)))
+        indices = [e["index"]]
+        stats = None
+        if e.get("disqualified"):
+            self.log(f"stage {stage.name}: measurement run disqualified "
+                     f"({e['disqualified']}); keeping incumbent max_ramp")
+        else:
+            stats = mech_ramp_stats(self._trial_rows(e))
+            if stats is None:
+                self.log(f"stage {stage.name}: no usable step response in "
+                         "the measurement run; keeping incumbent max_ramp")
+
+        winner_val = None
+        computed = None
+        if stats is not None:
+            limit = ramp_measure_profile(self.spec).safety.max_current_a
+            budget = max(0.75 * (limit or 55.0) - stats["i_hi_a"], 5.0)
+            computed = compute_max_ramp(stats, current_budget_a=budget,
+                                        lo=f.lo, hi=f.hi,
+                                        margin=stage.margin)
+            self.log(
+                f"stage {stage.name}: tau {stats['tau_ms']:.0f} ms, slew "
+                f"{stats['slew_erpm_per_s']:.0f} eRPM/s, "
+                f"k {stats['k_a_per_pct']:.2f} A/%, budget {budget:.1f} A "
+                f"-> max_ramp {computed}")
+            v = computed
+            while True:
+                ev = self._trial(TrialPlan(
+                    stage=stage.name, kind="verify",
+                    overrides=self._merged(stage, {"max_ramp": v}),
+                    profile=step_profile(self.spec)))
+                indices.append(ev["index"])
+                if not ev.get("disqualified"):
+                    winner_val = v
+                    break
+                nxt = max(f.lo, int(v * 0.7))
+                if nxt == v:
+                    break               # already at the floor: no winner
+                self.log(f"stage {stage.name}: verify failed at max_ramp "
+                         f"{v}; backing off to {nxt}")
+                v = nxt
+
+        if winner_val is not None:
+            self.manifest["incumbent"] = self._merged(
+                stage, {"max_ramp": winner_val})
+        self.manifest["stages"][stage.name] = {
+            "winner": (None if winner_val is None
+                       else {"max_ramp": winner_val}),
+            "winner_score": None,
+            "measured": (None if stats is None
+                         else {k: round(v, 3) for k, v in stats.items()}),
+            "computed_max_ramp": computed,
+            "trials": indices,
+        }
+        self._save()
+        self.log(f"stage {stage.name}: winner "
+                 f"{None if winner_val is None else {'max_ramp': winner_val}}")
+
     def _run_constraint_stage(self, stage: StageSpec) -> None:
         """Constraint-only sweep (e.g. max_ramp on a step profile): values are
         tried in listed order (list them best-first); the first value with
@@ -1321,7 +1535,9 @@ class Tuner:
             self._save()
 
         for stage in spec.stages:
-            if stage.constraint_only:
+            if stage.measure:
+                self._run_measure_stage(stage)
+            elif stage.constraint_only:
                 self._run_constraint_stage(stage)
             else:
                 self._run_scored_stage(stage)

--- a/hwci/hwci/tuner.py
+++ b/hwci/hwci/tuner.py
@@ -153,6 +153,10 @@ class StageSpec:
     repeats: int = 1
     profile: str | None = None                  # None -> tune probe
     constraint_only: bool = False
+    # "grid" tests every listed value; "climb" hill-climbs the sorted value
+    # list from the incumbent (valid for unimodal responses like advance or
+    # pwm frequency - typically halves the trial count of a wide grid).
+    search: str = "grid"
 
 
 @dataclass
@@ -237,6 +241,14 @@ def tune_spec_from_dict(data: dict) -> TuneSpec:
             raise TuneSpecError(
                 f"tune spec: stage {s.name!r} needs exactly one of "
                 "'sweep' or 'ab_candidates'")
+        if s.search not in ("grid", "climb"):
+            raise TuneSpecError(
+                f"tune spec: stage {s.name!r} search {s.search!r} is not "
+                "'grid' or 'climb'")
+        if s.search == "climb" and (not s.sweep or s.constraint_only):
+            raise TuneSpecError(
+                f"tune spec: stage {s.name!r}: 'climb' only applies to "
+                "scored sweep stages")
         if s.sweep and s.sweep not in params:
             raise TuneSpecError(
                 f"tune spec: stage {s.name!r} sweeps unknown parameter "
@@ -1079,11 +1091,20 @@ class Tuner:
                 param.name, param.offset)
             if inc_val not in values:
                 values.append(inc_val)
-            for order, v in enumerate(values):
+
+            def test_value(v: int) -> dict:
                 ent = [candidate(self._merged(stage, {param.name: v}), r)
                        for r in range(stage.repeats)]
-                cands.append({"overrides": self._merged(stage, {param.name: v}),
-                              "value": v, "entries": ent, "order": order})
+                c = {"overrides": self._merged(stage, {param.name: v}),
+                     "value": v, "entries": ent, "order": len(cands)}
+                cands.append(c)
+                return c
+
+            if stage.search == "climb":
+                self._climb(sorted(values), inc_val, test_value)
+            else:
+                for v in values:
+                    test_value(v)
             if param.refine_step:
                 # Refine around the raw ARGMAX (not the tie-break winner: the
                 # tie set spans the whole noise floor and would wander).
@@ -1127,6 +1148,44 @@ class Tuner:
         self._save()
         self.log(f"stage {stage.name}: winner "
                  f"{None if winner is None else winner['overrides']}")
+
+    @staticmethod
+    def _climb(ordered: list[int], start_val: int,
+               test_value: Callable[[int], dict]) -> None:
+        """Hill-climb a sorted value list from the value nearest ``start_val``.
+
+        Valid for unimodal responses (advance, pwm frequency): walk in the
+        first improving direction and stop at the first non-improvement -
+        for a wide grid this typically tests 3-4 values instead of all of
+        them. Raw single-value scores are compared (same basis the grid
+        sweep's refine step uses); a disqualified value reads as worse than
+        any qualified one, so the climb walks away from constraint
+        violations instead of stopping on them.
+        """
+        def raw(c: dict) -> Optional[float]:
+            if any(e.get("disqualified") for e in c["entries"]):
+                return None
+            vals = [e["score_raw"] for e in c["entries"]
+                    if e.get("score_raw") is not None]
+            return statistics.median(vals) if vals else None
+
+        def better(a: dict, b: dict) -> bool:
+            ra, rb = raw(a), raw(b)
+            return rb is not None and (ra is None or rb > ra)
+
+        i = min(range(len(ordered)), key=lambda k: abs(ordered[k] - start_val))
+        cur = test_value(ordered[i])
+        moved = False
+        for direction in (1, -1):
+            j = i + direction
+            while 0 <= j < len(ordered):
+                nxt = test_value(ordered[j])
+                if not better(cur, nxt):
+                    break
+                cur, moved = nxt, True
+                j += direction
+            if moved:
+                break   # went uphill one way; the other side is downhill
 
     def _run_constraint_stage(self, stage: StageSpec) -> None:
         """Constraint-only sweep (e.g. max_ramp on a step profile): values are

--- a/hwci/pyproject.toml
+++ b/hwci/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-plot = ["matplotlib>=3.7"]            # report plots
+plot = ["matplotlib>=3.7"]            # report plots + tune PDF report
 flightstand = ["grpcio>=1.51"]        # real Flight Stand gRPC client
-dev = ["pytest>=7.0", "grpcio-tools>=1.51"]
+dev = ["pytest>=7.0", "grpcio-tools>=1.51", "matplotlib>=3.7"]
 
 [project.scripts]
 hwci = "hwci.cli:main"

--- a/hwci/tests/conftest.py
+++ b/hwci/tests/conftest.py
@@ -123,3 +123,36 @@ _PROBE_V3_C = _PROBE_V2_C.replace(
 @pytest.fixture(scope="session")
 def host_perf_elf_v3(tmp_path_factory):
     return _compile_probe(tmp_path_factory, "perf_elf_v3", _PROBE_V3_C)
+
+
+# EEprom settings probe: compiles the REAL Inc/eeprom.h on the host so the
+# DWARF union-walk cross-check in hwci.settings is tested against the actual
+# firmware layout. eeprom.h starts with `#include "main.h"` (an MCU-specific
+# header), so the header is copied next to a stub main.h that only provides
+# <stdint.h> - all EEprom_t needs. Members are uint8_t, so host and Cortex-M0
+# layouts are identical.
+_PROBE_EEPROM_C = """\
+#include "eeprom.h"
+EEprom_t eepromBuffer;
+void read_flash_bin(uint8_t* data, uint32_t add, int out_buff_len) {(void)data;(void)add;(void)out_buff_len;}
+void save_flash_nolib(uint8_t* data, int length, uint32_t add) {(void)data;(void)length;(void)add;}
+int main(void){ return (int)sizeof(EEprom_t); }
+"""
+
+
+@pytest.fixture(scope="session")
+def host_eeprom_elf(tmp_path_factory):
+    if not (HEADER_DIR / "eeprom.h").exists():
+        pytest.skip("Inc/eeprom.h not found")
+    pytest.importorskip("elftools")
+    if _CC is None:
+        pytest.skip("no host C compiler available")
+    d = tmp_path_factory.mktemp("eeprom_elf")
+    (d / "main.h").write_text("#include <stdint.h>\n")
+    (d / "eeprom.h").write_text((HEADER_DIR / "eeprom.h").read_text())
+    src = d / "probe.c"
+    src.write_text(_PROBE_EEPROM_C)
+    out = d / "probe.elf"
+    subprocess.run([_CC, "-g", "-O0", f"-I{d}", str(src), "-o", str(out)],
+                   check=True, capture_output=True)
+    return str(out)

--- a/hwci/tests/test_cli.py
+++ b/hwci/tests/test_cli.py
@@ -80,3 +80,69 @@ def test_battery_check_does_not_apply_in_sim_mode():
     result = cli._execute(rig, profile, sim=True, battery_cells=6)
     assert result.meta["aborted"] is None
     assert result.meta["battery_cells"] == 6  # still recorded for the record
+
+
+# --------------------------------------------------------------------------
+# hwci tune / hwci settings
+# --------------------------------------------------------------------------
+def test_tune_sim_end_to_end(tmp_path, capsys):
+    import yaml
+    spec = tmp_path / "spec.yaml"
+    spec.write_text(yaml.safe_dump({
+        "name": "cli-e2e",
+        "probe": {"dwell_s": 1.0},
+        "objective": {"min_power_w": 5.0},
+        "parameters": {"advance_level": {"values": [22, 26, 30]}},
+        "stages": [{"name": "advance", "sweep": "advance_level"}],
+        "finals": {"profile": "tune_probe", "repeats": 1,
+                   "startup_check": False},
+    }))
+    out = tmp_path / "tune"
+    rc = cli.main(["tune", "--sim", "--spec", str(spec), "--out", str(out),
+                   "--no-prompt"])
+    assert rc == 0
+    assert (out / "report.md").exists()
+    assert (out / "best_settings.bin").exists()
+    assert len((out / "best_settings.bin").read_bytes()) == 192
+    assert (out / "manifest.json").exists()
+    assert (out / "spec.yaml").exists()
+
+
+def test_tune_requires_spec_or_resume(capsys):
+    rc = cli.main(["tune", "--sim", "--no-prompt"])
+    assert rc == 2
+    assert "--spec" in capsys.readouterr().err
+
+
+def test_settings_round_trip_against_mock_device(tmp_path, capsys, monkeypatch):
+    from hwci.settings import Settings
+    # fresh in-process simulated page for this test
+    monkeypatch.setattr(cli, "_SIM_SETTINGS_DEVICE", None)
+
+    # read: prints fields and saves the page
+    page = tmp_path / "page.bin"
+    assert cli.main(["settings", "read", "--sim", "--bin", str(page)]) == 0
+    assert "advance_level" in capsys.readouterr().out
+    assert len(page.read_bytes()) == 192
+
+    # diff against a modified blob reports the difference (exit 1)
+    modified = tmp_path / "mod.bin"
+    Settings.from_bin(page).apply({"advance_level": 30}).to_bin(modified)
+    assert cli.main(["settings", "diff", "--sim", "--bin", str(modified)]) == 1
+    assert "advance_level" in capsys.readouterr().out
+
+    # write flashes the blob (MockDebugger records the flash), then verify
+    assert cli.main(["settings", "write", "--sim", "--bin", str(modified)]) == 0
+    assert cli._SIM_SETTINGS_DEVICE.flashed  # flash path actually used
+    assert "verified" in capsys.readouterr().out
+
+    # device now matches: diff is clean and read shows the new value
+    assert cli.main(["settings", "diff", "--sim", "--bin", str(modified)]) == 0
+    cli.main(["settings", "read", "--sim"])
+    assert "advance_level    =  30" in capsys.readouterr().out
+
+
+def test_settings_write_requires_bin(capsys):
+    rc = cli.main(["settings", "write", "--sim"])
+    assert rc == 2
+    assert "--bin" in capsys.readouterr().err

--- a/hwci/tests/test_report.py
+++ b/hwci/tests/test_report.py
@@ -1,0 +1,98 @@
+"""Auto-tune PDF report rendering (report.write_tune_pdf)."""
+import sys
+
+import pytest
+
+from hwci import report
+
+# The whole PDF path is a best-effort matplotlib feature; skip when it's not
+# installed (the tune itself never depends on it).
+mpl = pytest.importorskip("matplotlib")
+
+
+def _manifest(**over):
+    m = {
+        "spec_name": "unit", "mode": "sim", "git_sha": "deadbee",
+        "eeprom_address": 0x08007C00, "battery_cells": 6,
+        "jitter_reference": 0.8, "pack_events": [],
+        "stages": {"advance": {"winner": {"advance_level": 30},
+                               "winner_score": 6.30}},
+        "trials": [
+            {"index": 0, "stage": "baseline", "kind": "baseline",
+             "overrides": {}, "score_raw": 5.9, "score_norm": 5.9,
+             "disqualified": None, "discarded": False},
+            {"index": 1, "stage": "advance", "kind": "trial",
+             "overrides": {"advance_level": 30}, "score_raw": 6.3,
+             "score_norm": 6.3, "disqualified": None, "discarded": False},
+            {"index": 2, "stage": "advance", "kind": "trial",
+             "overrides": {"advance_level": 10}, "score_raw": None,
+             "score_norm": None, "disqualified": ["demag"],
+             "discarded": False},
+        ],
+    }
+    m.update(over)
+    return m
+
+
+def _result(**over):
+    r = {"confirmed": True, "winner_overrides": {"advance_level": 30},
+         "median_paired_delta": 0.2, "paired_deltas": [0.1, 0.3, -0.05],
+         "winner_constraint_failures": 0, "startup": {"failed": 0, "cycles": 5}}
+    r.update(over)
+    return r
+
+
+def _is_pdf(path) -> bool:
+    return path is not None and path.read_bytes()[:5] == b"%PDF-"
+
+
+def test_write_tune_pdf_produces_valid_pdf(tmp_path):
+    p = report.write_tune_pdf(tmp_path, _manifest(), _result(),
+                              [("advance_level", 26, 30)])
+    assert p == tmp_path / "tune_report.pdf"
+    assert _is_pdf(p)
+
+
+def test_write_tune_pdf_default_kept_no_deltas(tmp_path):
+    # not confirmed, empty diff, no ABBA deltas, no stages/trials
+    m = _manifest(stages={}, trials=[])
+    r = _result(confirmed=False, winner_overrides={},
+                median_paired_delta=None, paired_deltas=[], startup=None)
+    p = report.write_tune_pdf(tmp_path, m, r, [])
+    assert _is_pdf(p)
+
+
+def test_write_tune_pdf_paginates_many_trials(tmp_path):
+    trials = [{"index": i, "stage": "advance", "kind": "trial",
+               "overrides": {"advance_level": i}, "score_raw": 6.0 + i * 0.01,
+               "score_norm": 6.0 + i * 0.01, "disqualified": None,
+               "discarded": False} for i in range(60)]
+    p = report.write_tune_pdf(tmp_path, _manifest(trials=trials), _result(), [])
+    assert _is_pdf(p)
+
+
+def test_write_tune_pdf_skips_gracefully_without_matplotlib(tmp_path, monkeypatch):
+    # Force `import matplotlib` to fail; the tune must not blow up.
+    monkeypatch.setitem(sys.modules, "matplotlib", None)
+    logs = []
+    p = report.write_tune_pdf(tmp_path, _manifest(), _result(), [],
+                              log=logs.append)
+    assert p is None
+    assert not (tmp_path / "tune_report.pdf").exists()
+    assert any("matplotlib" in m for m in logs)
+
+
+def test_fmt_ov_compact():
+    assert report._fmt_ov({}) == "default"
+    assert report._fmt_ov({"advance_level": 30}) == "advance_level=30"
+    assert report._fmt_ov({"a": 1, "b": 2}) == "a=1, b=2"
+
+
+def test_tune_run_writes_pdf_report(tmp_path):
+    # end-to-end: a real sim tune emits tune_report.pdf alongside report.md
+    from test_tuner import make_backend, run_tune, small_spec
+
+    _, result = run_tune(tmp_path, small_spec(), make_backend(advance_optimum=33.0))
+    pdf = tmp_path / "tune" / "tune_report.pdf"
+    assert (tmp_path / "tune" / "report.md").exists()
+    assert _is_pdf(pdf)

--- a/hwci/tests/test_settings.py
+++ b/hwci/tests/test_settings.py
@@ -1,0 +1,146 @@
+"""AM32 EEPROM settings blob: encode/apply/diff, range refusal, address
+resolution, and the DWARF cross-check against a host-compiled Inc/eeprom.h."""
+import pytest
+
+from hwci import settings as st
+from hwci.debugger.base import MockDebugger
+
+
+def test_default_blob_round_trips_known_fields():
+    s = st.Settings(st.default_blob())
+    assert s.get("advance_level") == 26
+    assert s.get("pwm_frequency") == 24
+    assert s.get("variable_pwm") == 1
+    assert s.get("auto_advance") == 0
+    assert s.get("max_ramp") == 160
+    assert s.get("startup_power") == 100
+
+
+def test_apply_returns_mutated_copy_and_diff_names_fields():
+    base = st.Settings(st.default_blob())
+    trial = base.apply({"advance_level": 30, "auto_advance": 1})
+    # original untouched
+    assert base.get("advance_level") == 26
+    assert trial.get("advance_level") == 30
+    d = base.diff(trial)
+    assert ("advance_level", 26, 30) in d
+    assert ("auto_advance", 0, 1) in d
+    assert len(d) == 2
+    # only the tuned bytes changed - identity/calibration preserved
+    assert trial.to_bytes()[1] == base.to_bytes()[1]
+    assert trial.to_bytes()[3:5] == base.to_bytes()[3:5]
+
+
+def test_bin_round_trip(tmp_path):
+    s = st.Settings(st.default_blob()).apply({"pwm_frequency": 48})
+    p = s.to_bin(tmp_path / "settings.bin")
+    assert p.read_bytes() == s.to_bytes()
+    assert st.Settings.from_bin(p) == s
+
+
+@pytest.mark.parametrize("name,value", [
+    ("advance_level", 9),      # firmware treats <10 as legacy format
+    ("advance_level", 43),     # firmware falls back to 16
+    ("pwm_frequency", 7),      # firmware keeps compile-time ARR
+    ("pwm_frequency", 145),
+    ("startup_power", 49),
+    ("startup_power", 151),
+    ("variable_pwm", 3),
+    ("auto_advance", 2),
+    ("max_ramp", 0),
+    ("max_ramp", 256),
+])
+def test_out_of_range_values_are_refused_not_clamped(name, value):
+    base = st.Settings(st.default_blob())
+    with pytest.raises(st.SettingsError, match="range"):
+        base.apply({name: value})
+
+
+def test_unknown_name_requires_explicit_offset():
+    base = st.Settings(st.default_blob())
+    with pytest.raises(st.SettingsError, match="unknown setting"):
+        base.apply({"warp_drive": 1})
+    # explicit offset addressing (forward-compat with newer firmware fields)
+    out = base.apply({"warp_drive": 7}, offsets={"warp_drive": 60})
+    assert out.to_bytes()[60] == 7
+
+
+def test_explicit_offset_refuses_identity_bytes():
+    with pytest.raises(st.SettingsError, match="read-only"):
+        st.resolve_field("hack", offset=3)
+
+
+def test_explicit_offset_must_match_known_field():
+    with pytest.raises(st.SettingsError, match="contradicts"):
+        st.resolve_field("advance_level", offset=24)
+
+
+def test_wrong_blob_size_rejected():
+    with pytest.raises(st.SettingsError, match="192"):
+        st.Settings(b"\x00" * 191)
+
+
+def test_from_device_reads_page(tmp_path):
+    dbg = MockDebugger(base=st.DEFAULT_EEPROM_ADDRESS, size=1024)
+    dbg.poke(st.DEFAULT_EEPROM_ADDRESS, st.default_blob())
+    s = st.Settings.from_device(dbg, st.DEFAULT_EEPROM_ADDRESS)
+    assert s.get("advance_level") == 26
+
+
+# --------------------------------------------------------------------------
+# live eeprom_address resolution
+# --------------------------------------------------------------------------
+def test_resolve_eeprom_address_sanity_checks(monkeypatch):
+    from hwci import elf as elfmod
+    monkeypatch.setattr(
+        st.elf, "find_symbol",
+        lambda path, name: elfmod.Symbol(name=name, address=0x20000010, size=4))
+    dbg = MockDebugger(base=0x20000000, size=0x100)
+    dbg.poke(0x20000010, (0x08007C00).to_bytes(4, "little"))
+    assert st.resolve_eeprom_address(dbg, "fake.elf") == 0x08007C00
+    dbg.poke(0x20000010, (0x08001234).to_bytes(4, "little"))
+    with pytest.raises(st.SettingsError, match="refusing"):
+        st.resolve_eeprom_address(dbg, "fake.elf")
+
+
+# --------------------------------------------------------------------------
+# DWARF union-walk cross-check vs the real firmware header
+# --------------------------------------------------------------------------
+def test_union_layout_flattens_anonymous_struct(host_eeprom_elf):
+    from hwci import elf
+    members = {m.name: m for m in elf.union_layout(host_eeprom_elf, "EEprom_u")}
+    # direct members of the anonymous first struct
+    assert members["advance_level"].offset == 23
+    assert members["pwm_frequency"].offset == 24
+    assert members["auto_advance"].offset == 47
+    # nested NAMED structs flatten with dotted names
+    assert members["version.major"].offset == 3
+    assert members["version.minor"].offset == 4
+    assert members["servo.dead_band"].offset == 35
+    assert members["can.esc_index"].offset == 177
+    # union's second member overlaps at offset 0
+    assert members["buffer"].offset == 0
+
+
+def test_eeprom_fields_match_firmware_header(host_eeprom_elf):
+    st.check_eeprom_layout(host_eeprom_elf)
+
+
+def test_layout_check_fails_hard_on_missing_union(host_perf_elf):
+    # DWARF is present but has no EEprom_u: exactly the drift the check must
+    # catch loudly (renamed union, stripped types).
+    with pytest.raises(st.SettingsError, match="cross-check"):
+        st.check_eeprom_layout(host_perf_elf)
+
+
+def test_layout_check_soft_skips_without_dwarf(monkeypatch):
+    # Stripped debug info (no DWARF at all) only warns - the canonical
+    # offsets still apply - mirroring PerfReader._check_layout's policy.
+    from hwci import elf
+
+    def no_dwarf(path, name):
+        raise elf.ElfError("no DWARF info")
+
+    monkeypatch.setattr(st.elf, "union_layout", no_dwarf)
+    with pytest.warns(UserWarning, match="cross-check skipped"):
+        st.check_eeprom_layout("whatever.elf")

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -3,7 +3,8 @@ import pytest
 
 from hwci import perf
 from hwci.esc_telem import parse_frame
-from hwci.sim import MotorParams, RigSimulator
+from hwci.settings import Settings, default_blob
+from hwci.sim import MotorParams, RigSimulator, SimSettings
 
 
 def _settle(rig, throttle, n=200, dt=0.005):
@@ -106,3 +107,99 @@ def test_perf_channel_carries_phase_histogram():
     # the sim locks 20% of edges onto the throttle-derived bin
     peak = int(0.7 * 32) & 31
     assert max(range(32), key=delta.__getitem__) == peak
+
+
+# --------------------------------------------------------------------------
+# AM32 settings model (SimSettings)
+# --------------------------------------------------------------------------
+def _sim_with(overrides, **params):
+    blob = Settings(default_blob()).apply(overrides).to_bytes()
+    rig = RigSimulator(params=MotorParams(**params), noise=0.0)
+    rig.set_settings(SimSettings.from_blob(blob))
+    return rig
+
+
+def _steady_efficiency(rig, throttle=0.6, n=400, dt=0.005):
+    _settle(rig, throttle, n=n, dt=dt)
+    s = rig.stand_sample(1.0)
+    return (s.thrust_n * 1000.0 / 9.80665) / (s.voltage_v * s.current_a)
+
+
+def test_simsettings_decodes_the_same_blob_settings_writes():
+    blob = Settings(default_blob()).apply(
+        {"advance_level": 30, "pwm_frequency": 16, "auto_advance": 1}).to_bytes()
+    s = SimSettings.from_blob(blob)
+    assert (s.advance_level, s.pwm_frequency, s.auto_advance) == (30, 16, 1)
+    assert s.max_ramp == 160 and s.startup_power == 100
+
+
+def test_efficiency_has_interior_maximum_in_advance():
+    # optimum injectable: put it at 27 and check 27 beats both grid edges
+    effs = {adv: _steady_efficiency(
+                _sim_with({"advance_level": adv}, advance_optimum=27.0))
+            for adv in (13, 27, 41)}
+    assert effs[27] > effs[13]
+    assert effs[27] > effs[41]
+
+
+def test_efficiency_has_interior_maximum_in_pwm_frequency():
+    effs = {khz: _steady_efficiency(_sim_with({"pwm_frequency": khz}))
+            for khz in (8, 24, 96)}
+    assert effs[24] > effs[8]
+    assert effs[24] > effs[96]
+
+
+def test_auto_advance_scores_as_equivalent_fixed_advance():
+    auto = _steady_efficiency(_sim_with({"auto_advance": 1,
+                                         "advance_level": 40}))
+    fixed18 = _steady_efficiency(_sim_with({"auto_advance": 0,
+                                            "advance_level": 18}))
+    assert auto == pytest.approx(fixed18, rel=1e-6)
+
+
+def test_variable_pwm_adds_jitter_and_low_throttle_bonus():
+    lo_var = _steady_efficiency(_sim_with({"variable_pwm": 1}), throttle=0.3)
+    lo_fix = _steady_efficiency(_sim_with({"variable_pwm": 0}), throttle=0.3)
+    assert lo_var > lo_fix  # small low-throttle efficiency bonus
+    # jitter penalty: compare accumulated mean jitter fraction
+    var, fix = _sim_with({"variable_pwm": 1}), _sim_with({"variable_pwm": 0})
+    _settle(var, 0.6, n=400)
+    _settle(fix, 0.6, n=400)
+    var_pct = var.zc_jitter_sum / var.zc_interval_sum
+    fix_pct = fix.zc_jitter_sum / fix.zc_interval_sum
+    assert var_pct > fix_pct
+
+
+def test_startup_reliability_responds_to_startup_power():
+    def failed_starts(power, attempts=40):
+        rig = _sim_with({"startup_power": power})
+        fails = 0
+        for _ in range(attempts):
+            _settle(rig, 0.0, n=100)    # stop and coast down between attempts
+            _settle(rig, 0.15, n=100)   # spin attempt (0.5 s)
+            if rig.rpm < 500.0:
+                fails += 1
+        return fails
+
+    assert failed_starts(50) > failed_starts(150)
+    assert failed_starts(150) == 0
+
+
+def test_low_max_ramp_prevents_step_desync():
+    fast = _sim_with({"max_ramp": 160}, demag_prone=True)
+    slow = _sim_with({"max_ramp": 40}, demag_prone=True)
+    for rig in (fast, slow):
+        _settle(rig, 0.1, n=50)
+        rig.step(0.005, 1.0)  # violent step into a high-current regime
+    assert fast.desync_count >= 1
+    assert slow.desync_count == 0
+
+
+def test_settings_none_keeps_legacy_behaviour():
+    a = RigSimulator(noise=0.0)
+    b = RigSimulator(noise=0.0)
+    b.set_settings(None)
+    _settle(a, 0.6)
+    _settle(b, 0.6)
+    assert a.rpm == b.rpm
+    assert a.current == b.current

--- a/hwci/tests/test_tune_resume.py
+++ b/hwci/tests/test_tune_resume.py
@@ -1,0 +1,147 @@
+"""Tune session checkpointing: crash -> resume reuses completed trials and
+reaches the identical winner; pack-swap events pause/prompt correctly."""
+import json
+
+import pytest
+import yaml
+
+from hwci.sim import MotorParams
+from hwci.tuner import SimTuneBackend, TunePaused, Tuner, tune_spec_from_dict
+
+
+def spec_dict() -> dict:
+    return {
+        "name": "resume-test",
+        "probe": {"dwell_s": 1.0},
+        # tight noise floor: with noise=0 the winner is decided purely by
+        # deterministic scores, so crash/resume equality is exact
+        "objective": {"min_power_w": 5.0, "noise_floor_pct": 0.1},
+        "anchors_every": 4,
+        "parameters": {
+            "advance_level": {"values": [18, 22, 26, 30, 34],
+                              "refine_step": 2},
+            "pwm_frequency": {"values": [8, 24, 48]},
+        },
+        "stages": [
+            {"name": "advance", "sweep": "advance_level"},
+            {"name": "pwm", "sweep": "pwm_frequency"},
+        ],
+        "finals": {"profile": "tune_probe", "repeats": 1,
+                   "startup_check": False},
+    }
+
+
+def make_backend() -> SimTuneBackend:
+    # noise=0 so a resumed session is bit-deterministic: reused trials carry
+    # their recorded scores and re-executed ones recompute the same values.
+    # The optimum sits OFF the grid midpoints (30.5, not 31) so no two grid
+    # values score exactly equal and the winner never falls to a jitter
+    # tie-break (whose RNG phase differs after a resume).
+    return SimTuneBackend(motor_params=MotorParams(
+        pole_pairs=7, demag_prone=True, advance_optimum=30.5,
+        startup_fail_ref=100.0), noise=0.0)
+
+
+def make_tuner(out, backend, *, resume=False, **kw) -> Tuner:
+    d = spec_dict()
+    return Tuner(tune_spec_from_dict(d), backend, out,
+                 spec_text=yaml.safe_dump(d), no_prompt=True, resume=resume,
+                 log=lambda s: None, **kw)
+
+
+def test_crash_then_resume_reaches_identical_winner(tmp_path):
+    # Reference: uninterrupted run.
+    ref = make_tuner(tmp_path / "ref", make_backend())
+    ref_result = ref.run()
+    total = len(ref.ledger)
+
+    # Crash after K completed trials.
+    K = 7
+
+    def crash(index, plan):
+        if index >= K:
+            raise RuntimeError("injected crash")
+
+    crashing = make_tuner(tmp_path / "crash", make_backend(),
+                          before_trial=crash)
+    with pytest.raises(RuntimeError, match="injected crash"):
+        crashing.run()
+    m = json.loads((tmp_path / "crash" / "manifest.json").read_text())
+    assert len(m["trials"]) == K          # checkpointed up to the crash
+    assert m["result"] is None
+
+    # Simulate a crash that left a partial trial dir behind (no trial.json).
+    stray = tmp_path / "crash" / "trials" / f"T{K:03d}-halfway"
+    stray.mkdir(parents=True)
+    (stray / "samples.csv").write_text("t\n")
+
+    # Resume with a FRESH backend (new process, device state unknown).
+    resumed = make_tuner(tmp_path / "crash", make_backend(), resume=True)
+    result = resumed.run()
+
+    assert result["winner_overrides"] == ref_result["winner_overrides"]
+    assert result["confirmed"] == ref_result["confirmed"]
+    # Completed trials were reused, only the remainder was executed.
+    assert resumed.executed == total - K
+    assert len(resumed.ledger) == total
+    # The stray partial dir was quarantined, not silently reused.
+    incomplete = list((tmp_path / "crash" / "trials").glob("*.incomplete*"))
+    assert incomplete
+    # Resume re-programmed the incumbent blob before continuing (a crash may
+    # have left arbitrary trial settings flashed).
+    assert (tmp_path / "crash" / "resume_settings.bin").exists()
+
+
+def test_resume_of_finished_session_reuses_everything(tmp_path):
+    t1 = make_tuner(tmp_path / "s", make_backend())
+    r1 = t1.run()
+    t2 = make_tuner(tmp_path / "s", make_backend(), resume=True)
+    r2 = t2.run()
+    assert t2.executed == 0
+    assert r2["winner_overrides"] == r1["winner_overrides"]
+
+
+# --------------------------------------------------------------------------
+# pack swap
+# --------------------------------------------------------------------------
+def test_low_pack_prompts_for_swap_and_records_event(tmp_path):
+    backend = make_backend()
+    backend.voltage_fn = lambda: 12.0     # 3.0 V/cell on a 4S: too low
+    prompts = []
+
+    def prompt(msg):
+        prompts.append(msg)
+        backend.voltage_fn = None         # "pack swapped" - healthy again
+        return ""
+
+    d = spec_dict()
+    d["battery_cells"] = 4
+    tuner = Tuner(tune_spec_from_dict(d), backend, tmp_path / "t",
+                  spec_text=yaml.safe_dump(d), prompt_fn=prompt,
+                  log=lambda s: None)
+    result = tuner.run()
+    assert len(prompts) == 1
+    assert "too low" in prompts[0]
+    m = json.loads((tmp_path / "t" / "manifest.json").read_text())
+    assert len(m["pack_events"]) == 1
+    assert m["pack_events"][0]["event"] == "pack_swap"
+    assert result["winner_overrides"]      # the tune still completed
+
+
+def test_low_pack_with_no_prompt_pauses_cleanly_then_resumes(tmp_path):
+    backend = make_backend()
+    backend.voltage_fn = lambda: 12.0
+    d = spec_dict()
+    d["battery_cells"] = 4
+    tuner = Tuner(tune_spec_from_dict(d), backend, tmp_path / "t",
+                  spec_text=yaml.safe_dump(d), no_prompt=True,
+                  log=lambda s: None)
+    with pytest.raises(TunePaused, match="resume"):
+        tuner.run()
+    # manifest was checkpointed before exiting
+    assert (tmp_path / "t" / "manifest.json").exists()
+
+    # after the swap (fresh healthy backend), --resume finishes the session
+    resumed = make_tuner(tmp_path / "t", make_backend(), resume=True)
+    result = resumed.run()
+    assert result["winner_overrides"]

--- a/hwci/tests/test_tune_spec.py
+++ b/hwci/tests/test_tune_spec.py
@@ -1,0 +1,126 @@
+"""Tune spec loading is STRICT: unknown keys/params fail loudly (a typo must
+never silently become 'use the default'), values are validated against the
+firmware-accepted ranges before anything reaches the bench."""
+from pathlib import Path
+
+import pytest
+
+from hwci.settings import SettingsError
+from hwci.tuner import TuneSpecError, load_tune_spec, tune_spec_from_dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _minimal(**extra) -> dict:
+    return {"name": "t", **extra}
+
+
+def test_minimal_spec_gets_documented_defaults():
+    spec = tune_spec_from_dict(_minimal())
+    assert spec.objective.weights == {"t30": 1.0, "t50": 2.0,
+                                      "t70": 1.0, "t90": 0.5}
+    assert spec.objective.min_power_w == 20.0
+    assert spec.objective.noise_floor_pct == 3.0
+    assert spec.anchors_every == 5
+    assert spec.constraints.max_demag_events == 0
+    assert spec.constraints.jitter_max_regression_pct == 25.0
+    assert spec.constraints.startup.cycles == 5
+    assert spec.finals.pattern == "ABBA"
+
+
+def test_example_spec_loads():
+    spec = load_tune_spec(REPO_ROOT / "hwci" / "tunes" / "example.yaml")
+    assert {s.name for s in spec.stages} == {"advance", "pwm", "modes", "ramp"}
+    assert spec.parameters["advance_level"].refine_step == 2
+    assert spec.stages[3].constraint_only
+
+
+def test_name_is_required():
+    with pytest.raises(TuneSpecError, match="'name' is required"):
+        tune_spec_from_dict({})
+
+
+def test_unknown_top_level_key_fails():
+    with pytest.raises(TuneSpecError, match="advnce_level"):
+        tune_spec_from_dict(_minimal(advnce_level=1))
+
+
+@pytest.mark.parametrize("block,bad", [
+    ("objective", {"weights": {}, "min_powr_w": 5}),
+    ("constraints", {"max_demag_evnts": 1}),
+    ("pack", {"min_resting_cel_v": 3.4}),
+    ("probe", {"dwel_s": 3}),
+    ("finals", {"repeat": 3}),
+])
+def test_unknown_nested_key_fails(block, bad):
+    with pytest.raises(TuneSpecError, match="unknown key"):
+        tune_spec_from_dict(_minimal(**{block: bad}))
+
+
+def test_unknown_startup_key_fails():
+    with pytest.raises(TuneSpecError, match="constraints.startup"):
+        tune_spec_from_dict(_minimal(
+            constraints={"startup": {"cycels": 3}}))
+
+
+def test_unknown_parameter_without_offset_fails():
+    with pytest.raises(SettingsError, match="unknown setting"):
+        tune_spec_from_dict(_minimal(
+            parameters={"warp_drive": {"values": [1, 2]}}))
+
+
+def test_unknown_parameter_with_offset_is_forward_compat():
+    spec = tune_spec_from_dict(_minimal(
+        parameters={"future_field": {"values": [1, 2], "offset": 60}}))
+    assert spec.parameters["future_field"].offset == 60
+
+
+def test_parameter_value_outside_firmware_range_fails():
+    with pytest.raises(TuneSpecError, match="firmware-valid range"):
+        tune_spec_from_dict(_minimal(
+            parameters={"advance_level": {"values": [10, 43]}}))
+
+
+def test_stage_sweeping_undeclared_parameter_fails():
+    with pytest.raises(TuneSpecError, match="unknown parameter"):
+        tune_spec_from_dict(_minimal(
+            stages=[{"name": "s", "sweep": "advance_level"}]))
+
+
+def test_stage_needs_exactly_one_of_sweep_or_ab():
+    params = {"advance_level": {"values": [20]}}
+    with pytest.raises(TuneSpecError, match="exactly one"):
+        tune_spec_from_dict(_minimal(
+            parameters=params, stages=[{"name": "s"}]))
+    with pytest.raises(TuneSpecError, match="exactly one"):
+        tune_spec_from_dict(_minimal(
+            parameters=params,
+            stages=[{"name": "s", "sweep": "advance_level",
+                     "ab_candidates": [{}]}]))
+
+
+def test_duplicate_stage_name_fails():
+    params = {"advance_level": {"values": [20]}}
+    with pytest.raises(TuneSpecError, match="duplicate stage"):
+        tune_spec_from_dict(_minimal(
+            parameters=params,
+            stages=[{"name": "s", "sweep": "advance_level"},
+                    {"name": "s", "sweep": "advance_level"}]))
+
+
+def test_ab_candidate_out_of_range_fails():
+    with pytest.raises(TuneSpecError, match="firmware-valid range"):
+        tune_spec_from_dict(_minimal(
+            stages=[{"name": "s", "ab_candidates": [{"variable_pwm": 5}]}]))
+
+
+def test_unsupported_finals_pattern_fails():
+    with pytest.raises(TuneSpecError, match="ABBA"):
+        tune_spec_from_dict(_minimal(finals={"pattern": "AABB"}))
+
+
+def test_non_mapping_spec_fails(tmp_path):
+    p = tmp_path / "spec.yaml"
+    p.write_text("- just\n- a list\n")
+    with pytest.raises(TuneSpecError, match="not a YAML mapping"):
+        load_tune_spec(p)

--- a/hwci/tests/test_tune_spec.py
+++ b/hwci/tests/test_tune_spec.py
@@ -32,7 +32,7 @@ def test_example_spec_loads():
     spec = load_tune_spec(REPO_ROOT / "hwci" / "tunes" / "example.yaml")
     assert {s.name for s in spec.stages} == {"advance", "pwm", "modes", "ramp"}
     assert spec.parameters["advance_level"].refine_step == 2
-    assert spec.stages[3].constraint_only
+    assert spec.stages[3].measure == "ramp_rate"
 
 
 def test_name_is_required():

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -1,0 +1,283 @@
+"""Auto-tuner core: end-to-end sim tunes (injected optimum), objective
+weighting, constraint disqualification, anchor normalization, tie-breaks."""
+import pytest
+import yaml
+
+from hwci.model import RunResult
+from hwci.sim import MotorParams
+from hwci.tuner import (SimTuneBackend, Tuner, objective_score, startup_stats,
+                        startup_profile, tune_spec_from_dict)
+
+
+def small_spec(**extra) -> dict:
+    d = {
+        "name": "test",
+        "probe": {"dwell_s": 1.0},
+        "objective": {"min_power_w": 5.0, "noise_floor_pct": 0.5},
+        "anchors_every": 4,
+        "parameters": {
+            "advance_level": {"values": [14, 18, 22, 26, 30, 34, 38],
+                              "refine_step": 2},
+            "pwm_frequency": {"values": [8, 16, 24, 48]},
+            "variable_pwm": {"values": [0, 1, 2]},
+            "auto_advance": {"values": [0, 1]},
+            "max_ramp": {"values": [160, 80, 40]},
+        },
+        "stages": [
+            {"name": "advance", "sweep": "advance_level"},
+            {"name": "pwm", "sweep": "pwm_frequency",
+             "fixed": {"variable_pwm": 0}},
+        ],
+        "finals": {"profile": "tune_probe", "repeats": 1,
+                   "startup_check": False},
+    }
+    d.update(extra)
+    return d
+
+
+def make_backend(**params) -> SimTuneBackend:
+    defaults = dict(pole_pairs=7, demag_prone=True, startup_fail_ref=100.0)
+    defaults.update(params)
+    return SimTuneBackend(motor_params=MotorParams(**defaults), noise=0.0)
+
+
+def run_tune(tmp_path, spec_d, backend, **kw):
+    spec = tune_spec_from_dict(spec_d)
+    t = Tuner(spec, backend, tmp_path / "tune",
+              spec_text=yaml.safe_dump(spec_d), no_prompt=True,
+              log=lambda s: None, **kw)
+    return t, t.run()
+
+
+# --------------------------------------------------------------------------
+# end-to-end: injected optimum is found
+# --------------------------------------------------------------------------
+def test_e2e_finds_injected_optimum(tmp_path):
+    backend = make_backend(advance_optimum=27.0, pwm_optimum_khz=24.0)
+    _, result = run_tune(tmp_path, small_spec(), backend)
+    winner = result["winner_overrides"]
+    # advance grid is every 4, refine step 2: winner within one refine step
+    assert abs(winner["advance_level"] - 27) <= 2
+    assert winner["pwm_frequency"] == 24
+
+
+def test_e2e_confirms_a_real_improvement_and_writes_outputs(tmp_path):
+    # optimum far from the default (26) so finals see a real paired delta
+    backend = make_backend(advance_optimum=33.0)
+    tuner, result = run_tune(tmp_path, small_spec(), backend)
+    assert result["confirmed"]
+    assert result["median_paired_delta"] > 0
+    out = tmp_path / "tune"
+    assert (out / "report.md").exists()
+    assert (out / "settings_diff.md").exists()
+    assert (out / "base_settings.bin").exists()
+    best = (out / "best_settings.bin").read_bytes()
+    assert best[23] == result["winner_overrides"]["advance_level"]
+    # identity bytes preserved from the base page (never mutated)
+    base = (out / "base_settings.bin").read_bytes()
+    assert best[1] == base[1] and best[3:5] == base[3:5]
+
+
+def test_e2e_default_optimum_keeps_default_settings(tmp_path):
+    # optimum AT the default: winner is within noise of default; finals must
+    # not confirm an improvement, and best_settings.bin stays the base page
+    backend = make_backend(advance_optimum=26.0)
+    _, result = run_tune(tmp_path, small_spec(), backend)
+    out = tmp_path / "tune"
+    if not result["confirmed"]:
+        assert (out / "best_settings.bin").read_bytes() == \
+            (out / "base_settings.bin").read_bytes()
+
+
+# --------------------------------------------------------------------------
+# constraint disqualification
+# --------------------------------------------------------------------------
+def test_constraint_only_stage_disqualifies_desyncing_ramp(tmp_path):
+    spec_d = small_spec(stages=[
+        {"name": "ramp", "sweep": "max_ramp", "constraint_only": True,
+         "profile": "tune_step"},
+    ])
+    _, result = run_tune(tmp_path, spec_d, make_backend())
+    # 160 desyncs on the step profile (disqualified: demag + bemf timeouts);
+    # 80 is the first listed value that passes
+    ledger = (tmp_path / "tune" / "manifest.json").read_text()
+    assert "demag events" in ledger
+    assert result["winner_overrides"]["max_ramp"] == 80
+
+
+def test_disqualified_candidate_never_wins(tmp_path):
+    tuner, _ = run_tune(tmp_path, small_spec(stages=[]), make_backend())
+    cands = [
+        {"overrides": {"advance_level": 30}, "order": 0, "value": 30,
+         "entries": [{"score_raw": 99.0, "score_norm": 99.0,
+                      "disqualified": ["demag events 1 > 0"],
+                      "jitter_pct": 0.1, "fet_temp_c": None}]},
+        {"overrides": {"advance_level": 22}, "order": 1, "value": 22,
+         "entries": [{"score_raw": 5.0, "score_norm": 5.0,
+                      "disqualified": None,
+                      "jitter_pct": 0.5, "fet_temp_c": None}]},
+    ]
+    assert tuner._pick_winner(cands)["overrides"] == {"advance_level": 22}
+
+
+def test_all_disqualified_yields_no_winner(tmp_path):
+    tuner, _ = run_tune(tmp_path, small_spec(stages=[]), make_backend())
+    cands = [{"overrides": {}, "order": 0, "value": 0,
+              "entries": [{"score_raw": None, "score_norm": None,
+                           "disqualified": ["run aborted: x"],
+                           "jitter_pct": None, "fet_temp_c": None}]}]
+    assert tuner._pick_winner(cands) is None
+
+
+# --------------------------------------------------------------------------
+# objective weighting
+# --------------------------------------------------------------------------
+def _metrics(points):
+    return {"steady_points": [
+        {"segment": lbl, "eff_gf_per_w": eff, "elec_power_w": pw}
+        for lbl, eff, pw in points]}
+
+
+def test_objective_weighted_mean():
+    spec = tune_spec_from_dict({
+        "name": "t",
+        "objective": {"weights": {"a": 1.0, "b": 3.0}, "min_power_w": 10.0}})
+    m = _metrics([("a", 4.0, 50.0), ("b", 8.0, 50.0)])
+    assert objective_score(m, spec.objective) == pytest.approx(
+        (1 * 4.0 + 3 * 8.0) / 4)
+
+
+def test_objective_excludes_low_power_points():
+    spec = tune_spec_from_dict({"name": "t"})
+    m = _metrics([("t30", 40.0, 2.3),      # noise point, must not score
+                  ("t50", 6.0, 50.0), ("t70", 5.0, 100.0)])
+    assert objective_score(m, spec.objective) == pytest.approx(
+        (2 * 6.0 + 1 * 5.0) / 3)
+
+
+def test_objective_unlisted_label_gets_weight_one():
+    spec = tune_spec_from_dict(
+        {"name": "t", "objective": {"weights": {}, "min_power_w": 1.0}})
+    m = _metrics([("x", 4.0, 50.0), ("y", 8.0, 50.0)])
+    assert objective_score(m, spec.objective) == pytest.approx(6.0)
+
+
+def test_objective_none_when_no_point_qualifies():
+    spec = tune_spec_from_dict({"name": "t"})
+    assert objective_score(_metrics([("t30", 40.0, 2.0)]),
+                           spec.objective) is None
+
+
+# --------------------------------------------------------------------------
+# anchor normalization
+# --------------------------------------------------------------------------
+def test_drift_factor_interpolates_between_anchors():
+    anchors = [(0, 10.0), (5, 8.0)]
+    assert Tuner._drift_factor(anchors, 0) == pytest.approx(1.0)
+    assert Tuner._drift_factor(anchors, 5) == pytest.approx(10.0 / 8.0)
+    assert Tuner._drift_factor(anchors, 2) == pytest.approx(10.0 / 9.2)
+    assert Tuner._drift_factor(anchors, 9) == pytest.approx(10.0 / 8.0)
+    assert Tuner._drift_factor([], 3) == 1.0
+
+
+def test_e2e_finds_optimum_under_injected_linear_drift(tmp_path):
+    # The rig degrades linearly (sagging pack modeled as falling motor
+    # efficiency): raw scores of later trials read lower. Anchor
+    # normalization must cancel it so the argmax stays at the optimum.
+    backend = make_backend(advance_optimum=27.0)
+
+    def drift(index, plan):
+        backend.sim.params.motor_efficiency = 0.82 * (1.0 - 0.004 * index)
+
+    spec_d = small_spec(stages=[{"name": "advance",
+                                 "sweep": "advance_level"}])
+    _, result = run_tune(tmp_path, spec_d, backend, before_trial=drift)
+    assert abs(result["winner_overrides"]["advance_level"] - 27) <= 2
+    # anchors themselves normalize flat (same settings, drift cancelled)
+    import json
+    m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
+    anchors = [e for e in m["trials"]
+               if e["stage"] == "advance" and e["kind"] == "anchor"]
+    norms = [e["score_norm"] for e in anchors if e["score_norm"]]
+    assert max(norms) - min(norms) <= 0.02 * norms[0]
+    # ...while their raw scores visibly drifted
+    raws = [e["score_raw"] for e in anchors]
+    assert max(raws) - min(raws) > 0.02 * raws[0]
+
+
+# --------------------------------------------------------------------------
+# tie-break order: jitter, then FET temp, then closest-to-default
+# --------------------------------------------------------------------------
+def _cand(order, ov, score, jitter, fet):
+    return {"overrides": ov, "order": order, "value": order,
+            "entries": [{"score_raw": score, "score_norm": score,
+                         "disqualified": None, "jitter_pct": jitter,
+                         "fet_temp_c": fet}]}
+
+
+def test_tie_breaks_on_jitter_first(tmp_path):
+    tuner, _ = run_tune(tmp_path, small_spec(stages=[]), make_backend())
+    tuner.spec.objective.noise_floor_pct = 3.0
+    cands = [_cand(0, {"advance_level": 30}, 6.00, jitter=0.9, fet=40.0),
+             _cand(1, {"advance_level": 34}, 6.05, jitter=0.5, fet=60.0)]
+    assert tuner._pick_winner(cands)["overrides"] == {"advance_level": 34}
+
+
+def test_tie_breaks_on_fet_temp_second(tmp_path):
+    tuner, _ = run_tune(tmp_path, small_spec(stages=[]), make_backend())
+    tuner.spec.objective.noise_floor_pct = 3.0
+    cands = [_cand(0, {"advance_level": 30}, 6.00, jitter=0.5, fet=40.0),
+             _cand(1, {"advance_level": 34}, 6.05, jitter=0.5, fet=60.0)]
+    assert tuner._pick_winner(cands)["overrides"] == {"advance_level": 30}
+
+
+def test_tie_breaks_on_distance_to_default_third(tmp_path):
+    tuner, _ = run_tune(tmp_path, small_spec(stages=[]), make_backend())
+    tuner.spec.objective.noise_floor_pct = 3.0
+    # default advance_level is 26 (base page): 28 is closer than 34
+    cands = [_cand(0, {"advance_level": 34}, 6.05, jitter=0.5, fet=40.0),
+             _cand(1, {"advance_level": 28}, 6.00, jitter=0.5, fet=40.0)]
+    assert tuner._pick_winner(cands)["overrides"] == {"advance_level": 28}
+
+
+def test_outside_noise_floor_score_wins_regardless(tmp_path):
+    tuner, _ = run_tune(tmp_path, small_spec(stages=[]), make_backend())
+    tuner.spec.objective.noise_floor_pct = 3.0
+    cands = [_cand(0, {"advance_level": 30}, 6.50, jitter=9.9, fet=99.0),
+             _cand(1, {"advance_level": 34}, 6.00, jitter=0.1, fet=20.0)]
+    assert tuner._pick_winner(cands)["overrides"] == {"advance_level": 30}
+
+
+# --------------------------------------------------------------------------
+# startup stats (inline PR #22 stand-in)
+# --------------------------------------------------------------------------
+def test_startup_stats_counts_failed_cycles():
+    spec = tune_spec_from_dict({"name": "t", "constraints": {
+        "startup": {"cycles": 3, "spin_throttle": 0.15, "min_rpm": 1000}}})
+    profile = startup_profile(spec)
+    rows = []
+    t = 0.0
+    for seg in profile.segments:
+        n = int(seg.duration_s * 100)
+        for _ in range(n):
+            rpm = 0.0
+            if seg.label.startswith("spin"):
+                # spin0 healthy, spin1 fails (never spins), spin2 healthy
+                rpm = 0.0 if seg.label == "spin1" else 4000.0
+            rows.append({"t": t, "segment": seg.label,
+                         "stand_rpm": rpm, "perf_e_rpm": rpm * 7})
+            t += 0.01
+    result = RunResult(meta={"pole_pairs": 7}, rows=rows)
+    st = startup_stats(result, profile, min_rpm=1000.0)
+    assert st == {"cycles": 3, "failed": 1, "failed_segments": ["spin1"],
+                  "min_rpm": 1000.0}
+
+
+def test_startup_stats_uses_perf_erpm_when_stand_is_dead():
+    spec = tune_spec_from_dict({"name": "t", "constraints": {
+        "startup": {"cycles": 1}}})
+    profile = startup_profile(spec)
+    rows = [{"t": i * 0.01, "segment": "spin0", "stand_rpm": None,
+             "perf_e_rpm": 4000 * 7} for i in range(150)]
+    result = RunResult(meta={"pole_pairs": 7}, rows=rows)
+    assert startup_stats(result, profile, min_rpm=1000.0)["failed"] == 0

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -441,3 +441,97 @@ def test_baseline_pause_then_resume_completes(tmp_path):
     import json
     m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
     assert m["jitter_reference"] is not None
+
+
+# --------------------------------------------------------------------------
+# mech-ramp measure stage (measure: ramp_rate)
+# --------------------------------------------------------------------------
+def _step_rows(tau_s=0.08, base_rpm=60000.0, hi_rpm=140000.0,
+               base_i=3.0, pk_i=20.0, hi_i=8.0, dt=0.005):
+    """Synthetic tune_ramp_measure rows: first-order eRPM rise, current
+    spike decaying with the same tau."""
+    import math
+    rows = []
+    t = 0.0
+    def emit(seg, thr, dur, rpm_fn, i_fn):
+        nonlocal t
+        t0 = t
+        while t < t0 + dur:
+            rows.append({"t": t, "segment": seg, "throttle_cmd": thr,
+                         "perf_e_rpm": rpm_fn(t - t0),
+                         "stand_current_a": i_fn(t - t0)})
+            t += dt
+    emit("hold_lo", 0.20, 1.0, lambda dt_: base_rpm, lambda dt_: base_i)
+    emit("step_up", 0.55, 2.0,
+         lambda dt_: base_rpm + (hi_rpm - base_rpm) * (1 - math.exp(-dt_ / tau_s)),
+         lambda dt_: hi_i + (pk_i - hi_i) * math.exp(-dt_ / tau_s))
+    emit("drop", 0.20, 1.0, lambda dt_: base_rpm, lambda dt_: base_i)
+    emit("step_up2", 0.55, 2.0,
+         lambda dt_: base_rpm + (hi_rpm - base_rpm) * (1 - math.exp(-dt_ / tau_s)),
+         lambda dt_: hi_i + (pk_i - hi_i) * math.exp(-dt_ / tau_s))
+    return rows
+
+
+def test_mech_ramp_stats_recovers_plant_constants():
+    from hwci.tuner import mech_ramp_stats
+    s = mech_ramp_stats(_step_rows(tau_s=0.08))
+    assert s is not None
+    assert 60 <= s["tau_ms"] <= 100          # 80 ms +/- sampling grain
+    # k = (peak - base) / step_pct = (20 - 3) / 35
+    assert s["k_a_per_pct"] == pytest.approx(17.0 / 35.0, rel=0.15)
+    assert s["rpm_hi"] > s["rpm_lo"]
+
+
+def test_mech_ramp_stats_none_without_a_real_step():
+    from hwci.tuner import mech_ramp_stats
+    flat = [{"t": i * 0.005, "segment": s, "throttle_cmd": 0.2,
+             "perf_e_rpm": 60000.0, "stand_current_a": 3.0}
+            for s in ("hold_lo", "step_up") for i in range(100)]
+    assert mech_ramp_stats(flat) is None
+
+
+def test_compute_max_ramp_math_and_clamping():
+    from hwci.tuner import compute_max_ramp
+    stats = {"tau_ms": 50.0, "k_a_per_pct": 0.5}
+    # lead = 30/0.5 = 60%; rate = 60/50 = 1.2 %/ms -> 12 in 0.1%/ms units
+    assert compute_max_ramp(stats, current_budget_a=30.0, lo=1, hi=160,
+                            margin=1.0) == 12
+    assert compute_max_ramp(stats, current_budget_a=30.0, lo=1, hi=160,
+                            margin=0.5) == 6
+    assert compute_max_ramp(stats, current_budget_a=1e9, lo=1, hi=160,
+                            margin=1.0) == 160    # clamped to field max
+    assert compute_max_ramp(stats, current_budget_a=0.0, lo=4, hi=160,
+                            margin=1.0) == 4      # clamped to field min
+
+
+def test_measure_stage_spec_validation():
+    with pytest.raises(TuneSpecError, match="exactly one"):
+        tune_spec_from_dict(small_spec(stages=[
+            {"name": "r", "measure": "ramp_rate", "sweep": "max_ramp"}]))
+    with pytest.raises(TuneSpecError, match="ramp_rate"):
+        tune_spec_from_dict(small_spec(stages=[
+            {"name": "r", "measure": "bogus"}]))
+    with pytest.raises(TuneSpecError, match="margin"):
+        tune_spec_from_dict(small_spec(stages=[
+            {"name": "r", "measure": "ramp_rate", "margin": 5.0}]))
+
+
+def test_e2e_measure_stage_sets_max_ramp(tmp_path):
+    import json
+    spec_d = small_spec(stages=[
+        {"name": "ramp", "measure": "ramp_rate", "margin": 0.8}])
+    backend = make_backend(demag_prone=False)
+    _, result = run_tune(tmp_path, spec_d, backend)
+    m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
+    st = m["stages"]["ramp"]
+    assert st["measured"] is not None
+    assert st["measured"]["tau_ms"] > 0
+    assert st["computed_max_ramp"] is not None
+    from hwci.settings import resolve_field
+    f = resolve_field("max_ramp", None)
+    assert f.lo <= st["computed_max_ramp"] <= f.hi
+    # verify trial ran and the incumbent picked up the winner
+    kinds = [t["kind"] for t in m["trials"] if t["stage"] == "ramp"]
+    assert kinds[0] == "measure" and "verify" in kinds
+    if st["winner"] is not None:
+        assert m["incumbent"]["max_ramp"] == st["winner"]["max_ramp"]

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -5,8 +5,9 @@ import yaml
 
 from hwci.model import RunResult
 from hwci.sim import MotorParams
-from hwci.tuner import (SimTuneBackend, Tuner, objective_score, startup_stats,
-                        startup_profile, tune_spec_from_dict)
+from hwci.tuner import (SimTuneBackend, Tuner, TuneSpecError,
+                        objective_score, startup_stats, startup_profile,
+                        tune_spec_from_dict)
 
 
 def small_spec(**extra) -> dict:
@@ -349,3 +350,58 @@ def test_device_left_on_winner_when_confirmed(tmp_path):
     assert result["confirmed"]
     assert backend.read_page() == \
         (tmp_path / "tune" / "best_settings.bin").read_bytes()
+
+
+# --------------------------------------------------------------------------
+# hill-climb sweep (search: climb)
+# --------------------------------------------------------------------------
+def climb_spec(**extra):
+    d = small_spec(stages=[
+        {"name": "advance", "sweep": "advance_level", "search": "climb",
+         "fixed": {}},
+    ])
+    d.update(extra)
+    return d
+
+
+def test_climb_finds_injected_optimum(tmp_path):
+    backend = make_backend(advance_optimum=33.0)
+    _, result = run_tune(tmp_path, climb_spec(), backend)
+    # grid every 4 + refine step 2: within one refine step of the optimum
+    assert abs(result["winner_overrides"]["advance_level"] - 33) <= 2
+
+
+def test_climb_tests_fewer_values_than_grid(tmp_path):
+    import json
+    backend = make_backend(advance_optimum=33.0)
+    run_tune(tmp_path, climb_spec(), backend)
+    m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
+    swept = {e["overrides"].get("advance_level")
+             for e in m["trials"]
+             if e["stage"] == "advance" and e["kind"] == "trial"}
+    # 7-value grid (+2 refine): the climb from the default (26) toward 33
+    # must never visit the far low end
+    assert 14 not in swept and 18 not in swept
+    assert len(swept) < 7
+
+
+def test_climb_walks_downhill_direction_too(tmp_path):
+    # optimum BELOW the default: first (upward) direction fails immediately,
+    # the climb must then walk down and still find it
+    backend = make_backend(advance_optimum=17.0)
+    _, result = run_tune(tmp_path, climb_spec(), backend)
+    assert abs(result["winner_overrides"]["advance_level"] - 17) <= 3
+
+
+def test_climb_rejected_for_ab_and_constraint_stages():
+    with pytest.raises(TuneSpecError, match="climb"):
+        tune_spec_from_dict(small_spec(stages=[
+            {"name": "m", "ab_candidates": [{}, {"variable_pwm": 1}],
+             "search": "climb"}]))
+    with pytest.raises(TuneSpecError, match="climb"):
+        tune_spec_from_dict(small_spec(stages=[
+            {"name": "r", "sweep": "max_ramp", "constraint_only": True,
+             "search": "climb"}]))
+    with pytest.raises(TuneSpecError, match="search"):
+        tune_spec_from_dict(small_spec(stages=[
+            {"name": "a", "sweep": "advance_level", "search": "bogus"}]))

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -405,3 +405,39 @@ def test_climb_rejected_for_ab_and_constraint_stages():
     with pytest.raises(TuneSpecError, match="search"):
         tune_spec_from_dict(small_spec(stages=[
             {"name": "a", "sweep": "advance_level", "search": "bogus"}]))
+
+
+# --------------------------------------------------------------------------
+# baseline health gate: a session must not run against a broken reference
+# --------------------------------------------------------------------------
+def bad_safety_spec():
+    # impossible current limit: every run aborts -> baseline disqualified
+    return small_spec(probe={"dwell_s": 1.0,
+                             "safety": {"max_current_a": 0.001}})
+
+
+def test_baseline_disqualified_twice_pauses_session(tmp_path):
+    import json
+    from hwci.tuner import TunePaused
+    with pytest.raises(TunePaused, match="baseline"):
+        run_tune(tmp_path, bad_safety_spec(), make_backend())
+    m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
+    # ledger quarantined so a resume re-runs the baseline fresh, and no
+    # jitter reference was taken from the disqualified runs
+    assert m["trials"] == []
+    assert m["jitter_reference"] is None
+
+
+def test_baseline_pause_then_resume_completes(tmp_path):
+    from hwci.tuner import TunePaused
+    with pytest.raises(TunePaused):
+        run_tune(tmp_path, bad_safety_spec(), make_backend())
+    # "fix the limits", then resume the same session directory
+    spec = tune_spec_from_dict(small_spec())
+    t = Tuner(spec, make_backend(), tmp_path / "tune",
+              no_prompt=True, resume=True, log=lambda s: None)
+    result = t.run()
+    assert result["winner_overrides"] is not None
+    import json
+    m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
+    assert m["jitter_reference"] is not None

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -281,3 +281,71 @@ def test_startup_stats_uses_perf_erpm_when_stand_is_dead():
              "perf_e_rpm": 4000 * 7} for i in range(150)]
     result = RunResult(meta={"pole_pairs": 7}, rows=rows)
     assert startup_stats(result, profile, min_rpm=1000.0)["failed"] == 0
+
+
+# --------------------------------------------------------------------------
+# probe/step profile safety shape (bench-learned: snap transients trip the
+# 40 A harness limit - 43-75 A observed on a 0.5->0.7 snap on the 6S bench)
+# --------------------------------------------------------------------------
+def test_probe_profile_ramps_into_large_steps():
+    from hwci.tuner import probe_profile
+    spec = tune_spec_from_dict(small_spec(
+        probe={"dwell_s": 1.0,
+               "points": {"t30": 0.30, "t50": 0.50, "t70": 0.70}}))
+    labels = [s.label for s in probe_profile(spec).segments]
+    # w20->t30 is a 10% step: no ramp; the 20% steps each get one
+    assert "r_t30" not in labels
+    assert labels.index("r_t50") == labels.index("t50") - 1
+    assert labels.index("r_t70") == labels.index("t70") - 1
+
+
+def test_probe_profile_ramp_segments_are_not_steady():
+    from hwci.tuner import probe_profile
+    spec = tune_spec_from_dict(small_spec(
+        probe={"dwell_s": 1.0, "points": {"t30": 0.30, "t70": 0.70}}))
+    p = probe_profile(spec)
+    r70 = next(s for s in p.segments if s.label == "r_t70")
+    assert r70.ramp and not r70.steady and r70.throttle == 0.70
+
+
+def test_default_tune_probe_yaml_ramps_into_large_steps():
+    from hwci.tuner import probe_profile
+    spec = tune_spec_from_dict(small_spec())   # no points override
+    labels = [s.label for s in probe_profile(spec).segments]
+    for pt in ("t50", "t70", "t90"):
+        assert f"r_{pt}" in labels
+    assert "r_t30" not in labels
+
+
+def test_step_profile_current_limit_has_snap_headroom():
+    from hwci.tuner import step_profile
+    spec = tune_spec_from_dict(small_spec(
+        probe={"dwell_s": 1.0,
+               "safety": {"max_current_a": 40.0, "max_thrust_n": 16.0}}))
+    p = step_profile(spec)
+    # deliberate 0.3->0.95 snaps peak near 50 A on the bench: headroom to 55,
+    # while the other limits pass through unchanged
+    assert p.safety.max_current_a == 55.0
+    assert p.safety.max_thrust_n == 16.0
+    spec_hi = tune_spec_from_dict(small_spec(
+        probe={"dwell_s": 1.0, "safety": {"max_current_a": 70.0}}))
+    assert step_profile(spec_hi).safety.max_current_a == 70.0
+
+
+# --------------------------------------------------------------------------
+# session end leaves the device on the verdict settings
+# --------------------------------------------------------------------------
+def test_device_left_on_base_page_when_not_confirmed(tmp_path):
+    backend = make_backend(advance_optimum=26.0)   # optimum AT the default
+    _, result = run_tune(tmp_path, small_spec(), backend)
+    if not result["confirmed"]:
+        base = (tmp_path / "tune" / "base_settings.bin").read_bytes()
+        assert backend.read_page() == base
+
+
+def test_device_left_on_winner_when_confirmed(tmp_path):
+    backend = make_backend(advance_optimum=33.0)
+    _, result = run_tune(tmp_path, small_spec(), backend)
+    assert result["confirmed"]
+    assert backend.read_page() == \
+        (tmp_path / "tune" / "best_settings.bin").read_bytes()

--- a/hwci/tunes/example.yaml
+++ b/hwci/tunes/example.yaml
@@ -1,0 +1,82 @@
+# Example AM32 auto-tune spec for `hwci tune` (ARK 4IN1 + 5" prop bench).
+#
+# Validation is STRICT: unknown keys or parameters fail loudly (like rig
+# configs) - a typo must never silently become "use the default".
+#
+# Budget note: each probe trial is ~28 s of motor time plus flash+reboot;
+# this spec runs roughly 35-40 trials (~25 min of spinning) before finals.
+name: ark4in1-5inch
+description: >
+  Tune advance/pwm/mode/ramp for the JS 2306 1800KV + HQProp 5136 on the
+  ARK 4IN1 bench, maximizing g/W at the cruise-heavy weighting below.
+
+battery_cells: 4
+
+pack:
+  min_resting_cell_v: 3.5     # resting gate between trials (not the 3.3 abs min)
+  prompt_on_swap: true        # pause and wait for a pack swap (else clean exit)
+
+thermal:
+  max_start_fet_temp_c: 60.0  # cool-down gate before each trial
+
+probe:
+  # Four steady points x dwell (labels are the objective's weight keys).
+  points: {t30: 0.30, t50: 0.50, t70: 0.70, t90: 0.90}
+  dwell_s: 6.0
+  safety:
+    max_current_a: 40.0
+    max_thrust_n: 16.0
+    max_rpm: 32000
+
+objective:
+  weights: {t30: 1.0, t50: 2.0, t70: 1.0, t90: 0.5}
+  min_power_w: 20.0           # points below this are bench noise - never scored
+  noise_floor_pct: 3.0        # scores within 3% tie-break on jitter/temp/default
+
+constraints:
+  max_demag_events: 0
+  max_bemf_timeout_samples: 0
+  jitter_max_regression_pct: 25.0   # vs the session's default-settings anchor
+  max_fet_temp_c: 90.0
+  max_motor_temp_c: 95.0
+  startup:
+    cycles: 5
+    max_failed: 0
+    spin_throttle: 0.15
+    min_rpm: 1000
+
+anchors_every: 5              # re-run the incumbent every N trials (drift anchor)
+
+parameters:
+  advance_level:              # eeprom offset 23, firmware-valid 10..42
+    values: [14, 18, 22, 26, 30, 34, 38]
+    refine_step: 2
+  pwm_frequency:              # offset 24, valid 8..144; >48 buys nothing here
+    values: [8, 16, 24, 48]
+  variable_pwm: {values: [0, 1, 2]}       # offset 21
+  auto_advance: {values: [0, 1]}          # offset 47
+  max_ramp: {values: [160, 80, 40]}       # offset 5, listed best-first
+
+stages:
+  - name: advance
+    sweep: advance_level
+  - name: pwm
+    sweep: pwm_frequency
+    fixed: {variable_pwm: 0}  # sweep the base frequency with scaling off
+  - name: modes
+    ab_candidates:            # built on the sweep winners ({} = incumbent)
+      - {}
+      - {variable_pwm: 1}
+      - {variable_pwm: 2}
+      - {auto_advance: 1}
+    repeats: 2                # interleaved: A B C D | A B C D
+  - name: ramp
+    sweep: max_ramp
+    constraint_only: true     # first value with zero failures wins
+    profile: tune_step        # inline step-stress (steps from a spinning state)
+
+finals:
+  profile: efficiency_sweep   # full sweep, winner vs default
+  pattern: ABBA
+  repeats: 2
+  startup_check: true

--- a/hwci/tunes/example.yaml
+++ b/hwci/tunes/example.yaml
@@ -3,14 +3,17 @@
 # Validation is STRICT: unknown keys or parameters fail loudly (like rig
 # configs) - a typo must never silently become "use the default".
 #
-# Budget note: each probe trial is ~28 s of motor time plus flash+reboot;
-# this spec runs roughly 35-40 trials (~25 min of spinning) before finals.
+# Budget note: each probe trial is ~26 s of motor time plus flash+reboot;
+# with hill-climb sweeps (search: climb) this spec runs roughly 20-25
+# trials (~15 min of spinning) before finals. Dwell/repeat/anchor budgets
+# are sized to the post-prop-flip bench (thrust CV 5.5-8.8%; the wake no
+# longer impinges on the mounting plate).
 name: ark4in1-5inch
 description: >
   Tune advance/pwm/mode/ramp for the JS 2306 1800KV + HQProp 5136 on the
   ARK 4IN1 bench, maximizing g/W at the cruise-heavy weighting below.
 
-battery_cells: 4
+battery_cells: 6
 
 pack:
   min_resting_cell_v: 3.5     # resting gate between trials (not the 3.3 abs min)
@@ -21,15 +24,21 @@ thermal:
 
 probe:
   # Four steady points x dwell (labels are the objective's weight keys).
-  points: {t30: 0.30, t50: 0.50, t70: 0.70, t90: 0.90}
-  dwell_s: 6.0
+  # 4 s dwell = 2 s steady tail: offline truncation of four 10 s captures
+  # showed a 3 s tail moves gated points < +/-2%, and the post-prop-flip
+  # bench is quieter still.
+  # t60, NOT t70: on a fresh 6S pack t70 arrives at ~172-176k eRPM
+  # (~24.5-25k rotor) where the default advance desyncs 8/8 on this bench;
+  # t60 (150k) holds clean and t90 (192k+) arrives clean above the band.
+  points: {t30: 0.30, t50: 0.50, t60: 0.60, t90: 0.90}
+  dwell_s: 4.0
   safety:
     max_current_a: 40.0
     max_thrust_n: 16.0
     max_rpm: 32000
 
 objective:
-  weights: {t30: 1.0, t50: 2.0, t70: 1.0, t90: 0.5}
+  weights: {t30: 1.0, t50: 2.0, t60: 1.0, t90: 0.5}
   min_power_w: 20.0           # points below this are bench noise - never scored
   noise_floor_pct: 3.0        # scores within 3% tie-break on jitter/temp/default
 
@@ -45,7 +54,7 @@ constraints:
     spin_throttle: 0.15
     min_rpm: 1000
 
-anchors_every: 5              # re-run the incumbent every N trials (drift anchor)
+anchors_every: 6              # re-run the incumbent every N trials (drift anchor)
 
 parameters:
   advance_level:              # eeprom offset 23, firmware-valid 10..42
@@ -55,13 +64,17 @@ parameters:
     values: [8, 16, 24, 48]
   variable_pwm: {values: [0, 1, 2]}       # offset 21
   auto_advance: {values: [0, 1]}          # offset 47
-  max_ramp: {values: [160, 80, 40]}       # offset 5, listed best-first
 
 stages:
+  # climb: hill-climb the sorted values from the incumbent instead of
+  # testing the whole grid - efficiency is unimodal in advance and pwm
+  # frequency, so this typically tests 3-4 values instead of 7.
   - name: advance
     sweep: advance_level
+    search: climb
   - name: pwm
     sweep: pwm_frequency
+    search: climb
     fixed: {variable_pwm: 0}  # sweep the base frequency with scaling off
   - name: modes
     ab_candidates:            # built on the sweep winners ({} = incumbent)
@@ -71,12 +84,15 @@ stages:
       - {auto_advance: 1}
     repeats: 2                # interleaved: A B C D | A B C D
   - name: ramp
-    sweep: max_ramp
-    constraint_only: true     # first value with zero failures wins
-    profile: tune_step        # inline step-stress (steps from a spinning state)
+    measure: ramp_rate        # measure the powertrain step response once
+                              # (tau, transient A per % duty lead), COMPUTE
+                              # max_ramp from the physics, verify on the
+                              # step-stress profile (0.7x back-off on fail)
+    margin: 0.8               # keep 80% of the physics-derived rate
 
 finals:
   profile: efficiency_sweep   # full sweep, winner vs default
   pattern: ABBA
-  repeats: 2
+  repeats: 1                  # one ABBA block (2 paired deltas) - sized to
+                              # the quieter post-prop-flip bench
   startup_check: true

--- a/hwci/tunes/quick.yaml
+++ b/hwci/tunes/quick.yaml
@@ -1,0 +1,88 @@
+# Quick AM32 auto-tune spec: a coarse pass in ~10-12 min of bench time
+# (vs ~45-60 min for example.yaml).
+#
+# Budget: ~10 probe trials (~7 min inc. flashes) + one ABBA finals block on
+# the short probe profile (~3 min) + startup check. Cut down from
+# example.yaml by: coarser grids (3-point advance, 2-point pwm, no refine),
+# a 3-point probe with 4 s dwells, one A/B repeat, no ramp stage, finals on
+# tune_probe instead of the full efficiency_sweep, and 1 finals repeat.
+#
+# Caveat: the bench's same-firmware efficiency spread is up to 9.8 % at
+# >= 20 W (see hwci/baseline.py), and this spec scores most candidates from
+# a single run. Treat the winner as a starting point; confirm with
+# example.yaml (or at least rerun finals) before trusting small deltas.
+name: ark4in1-5inch-quick
+description: >
+  Coarse advance/pwm/mode pass for the JS 2306 1800KV + HQProp 5136 on the
+  ARK 4IN1 bench. Fast, single-shot scoring - indicative, not confirmatory.
+
+battery_cells: 6
+
+pack:
+  min_resting_cell_v: 3.5
+  prompt_on_swap: true
+
+thermal:
+  max_start_fet_temp_c: 60.0
+
+probe:
+  # Three steady points, shorter dwells; t90 dropped (worst heat/pack cost
+  # per unit of objective weight in example.yaml). t60, NOT t70: on a fresh
+  # 6S pack t70 arrives at ~172-176k eRPM (~24.5-25k rotor) where the
+  # default advance desyncs 8/8 on this bench (eRPM collapse + 47-80 A
+  # spike); t60 (150k) and t90 (192k+) hold/arrive clean.
+  points: {t30: 0.30, t50: 0.50, t60: 0.60}
+  dwell_s: 4.0
+  safety:
+    max_current_a: 40.0
+    max_thrust_n: 16.0
+    max_rpm: 32000
+
+objective:
+  weights: {t30: 1.0, t50: 2.0, t60: 1.0}
+  min_power_w: 20.0
+  noise_floor_pct: 3.0
+
+constraints:
+  max_demag_events: 0
+  max_bemf_timeout_samples: 0
+  jitter_max_regression_pct: 25.0
+  max_fet_temp_c: 90.0
+  max_motor_temp_c: 95.0
+  startup:
+    cycles: 3
+    max_failed: 0
+    spin_throttle: 0.15
+    min_rpm: 1000
+
+anchors_every: 6
+
+parameters:
+  advance_level: {values: [18, 26, 34]}   # coarse 3-point grid, no refine
+  pwm_frequency: {values: [16, 24]}
+  variable_pwm: {values: [0, 1]}
+
+stages:
+  - name: advance
+    sweep: advance_level
+    search: climb             # hill-climb from the incumbent: usually skips
+                              # the far side of the grid entirely
+  - name: pwm
+    sweep: pwm_frequency
+    fixed: {variable_pwm: 0}
+  - name: modes
+    ab_candidates:
+      - {}
+      - {variable_pwm: 1}
+    repeats: 1
+  - name: ramp
+    measure: ramp_rate        # 2 trials (~1 min): measure the powertrain
+                              # step response, compute max_ramp, verify on
+                              # the step-stress profile
+    margin: 0.8
+
+finals:
+  profile: tune_probe   # short probe instead of the full efficiency sweep
+  pattern: ABBA
+  repeats: 1
+  startup_check: true


### PR DESCRIPTION
## Summary

`hwci tune`: put a motor/prop on the rig, point it at a tune spec, and it finds the best AM32 eeprom settings for that motor — `advance_level`, `pwm_frequency`, `variable_pwm`, `auto_advance`, `max_ramp`, extensible by explicit byte offset (e.g. the demag level once #24 lands). Objective: weighted g/W across the throttle range, subject to hard constraints (zero demag/bemf-timeouts, jitter not regressed vs the session's default anchor, FET/motor temps bounded, startup reliability preserved).

## Settings write path — no rebuild per trial

AM32 reads its 192-byte settings page once at boot, so a trial is: **write the eeprom flash page over SWD → reset → run**. This reuses the existing one-shot OpenOCD `program verify reset` flow (~4 s/trial). Details that matter:

- The effective eeprom address is resolved from the live `eeprom_address` global (ELF symbol + SWD read, sanity-checked against the known AM32 addresses) — the bootloader devinfo can relocate it, so it's never hard-coded.
- Each trial blob is seeded from the device's current page, mutating only tuned bytes — version bytes, motor_kv, input_type, servo cal all preserved.
- Field offsets are DWARF-cross-checked against `EEprom_u` in the ELF at tune start (same pattern as the perf-struct layout check), and every write is read back and verified before a trial scores.
- Out-of-range values are **refused, never clamped** — the firmware silently falls back on bad bytes (e.g. `pwm_frequency`), which would make a "trial" a lie.
- `hwci settings read|write|diff` exposes the primitive standalone (e.g. apply a winner to the other 3 MCUs of the 4-in-1).

## Search strategy — designed for a noisy bench

The rig's own history says same-firmware efficiency spread reaches ~9.8% at ≥20 W and pack state drifts within a session, so:

- **~28 s probe profile** (4 steady points) for the inner loop; full `efficiency_sweep` only for finals.
- **Staged coordinate sweeps** (advance → PWM frequency → mode A/Bs built on the winners → max_ramp as a constraint-only startup/step stage), with refine-around-argmax.
- **Anchor runs** of the incumbent every N trials; scores reported raw and drift-normalized against anchor interpolation.
- **Interleaved ABBA finals** vs default (the PR #21 methodology): a winner must show a positive median paired delta with zero constraint failures, or the tuner honestly keeps the defaults.
- Pack management: resting-voltage gate with pack-swap prompts (`--no-prompt` for unattended exit/resume); ABBA blocks never straddle a swap. Optional FET-temp cool-down gate between trials.
- Crash-safe: atomic manifest, per-trial run dirs, `--resume` replays the ledger exactly (complete trials reused, partial ones quarantined, incumbent settings re-programmed to the device).

Budget: ~30–40 trials ≈ 35–45 min motor time and 1–2 pack swaps for the example spec.

## Verified

- **191 offline tests pass** (115 base + 76 new): settings encode/DWARF cross-check, injected-optimum recovery, drift normalization, constraint disqualification, crash→resume identical-winner, pack-swap path, CLI round-trips.
- End-to-end sim run (`hwci tune --sim --spec tunes/example.yaml`): 40 trials, staged sweep converges on the injected optimum (advance 26 / 24 kHz), and the ABBA finals correctly refuse to confirm a within-noise delta — "default kept". The honest-negative path works.
- Also fixes a pre-existing circular import (`hwci.sim` ↔ `flightstand/simulator.py`).

## Not verified (needs the rig)

- Real SWD page write + readback on the bench (mechanism is the existing flash path, but the first hardware tune should start with `hwci settings read`/`write`/`diff` round-trips).
- Per-trial reset overhead assumption (~10 s incl. app-alive + tare) — worth timing in the first session.
- The startup-reliability stage inlines a minimal metric with a TODO to delegate to #22's `startup_stats` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pvp2XLcgsviGSVn9PaaP6

---
_Generated by [Claude Code](https://claude.ai/code/session_011pvp2XLcgsviGSVn9PaaP6)_