### PR TITLE
fix: absolute voltage cutoff scale (upstream #386)

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -2218,7 +2218,7 @@ if(zero_crosses < 5){
                 }
             }
             if (eepromBuffer.low_voltage_cut_off == 2 ){   // absolute cut off
-              if (battery_voltage <  eepromBuffer.absolute_voltage_cutoff) {
+              if (battery_voltage <  (eepromBuffer.absolute_voltage_cutoff * 50)) {
                 low_voltage_count++;    
                 } else {
                   if(!LOW_VOLTAGE_CUTOFF){


### PR DESCRIPTION
Cherry-pick of upstream [am32-firmware/AM32#386](https://github.com/am32-firmware/AM32/pull/386) (merged upstream 2026-07-03 as `a455358`), applied clean with `-x`.

## What it fixes

`eepromBuffer.absolute_voltage_cutoff` is stored in **0.5 V increments** (1–100), but `battery_voltage` is in **centivolts**. The absolute-cutoff comparison (`low_voltage_cut_off == 2`) compared the two raw values, so e.g. a configured 5.0 V cutoff compared `2500 < 10` — absolute cutoff mode could never fire. The fix scales the eeprom value ×50 into centivolts.

## Why we want it on the bench

With absolute cutoff working, the ESC's own in-run low-voltage cutoff becomes usable as a test-rig safety layer with a key operational advantage: when the Flight Stand's vendor cutoff latches, clearing it requires the Windows UI (two incidents so far); the AM32 cutoff latches in firmware RAM (`LOW_VOLTAGE_CUTOFF`) and clears with an SWD reset — fully remote. Setting the ESC absolute cutoff slightly *above* the Flight Stand threshold gives: hwci pre-flight (refuse to arm) → AM32 in-run cutoff (remote recovery) → Flight Stand cutoff (last resort).

Note the cell-count mode (`low_voltage_cut_off == 1`) was already functional and unaffected; this only fixes mode 2.

## Verification

- Instrumented + production builds compile clean for ARK_4IN1_F051.
- Bench plan (needs stand + pack): enable mode 2 with cutoff set just below resting pack voltage, spin to a throttle whose loaded sag crosses it, confirm the motor cuts and `LOW_VOLTAGE_CUTOFF` recovery via SWD reset works; then set the real threshold (e.g. 40 = 20.0 V for 6S) and confirm a normal sweep is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)