### PR TITLE
feat(perf): zc_confirm_reject counter — perf struct v3

### DIFF
--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -40,8 +40,10 @@
 /* ASCII "HWC1" in little-endian memory order - lets the host locate/validate
  * the struct either by ELF symbol or by scanning RAM for the magic. */
 #define HWCI_PERF_MAGIC   0x31435748u
-/* v2: appended the zero-cross jitter block (zc_*) after host_cmd. */
-#define HWCI_PERF_VERSION 2u
+/* v2: appended the zero-cross jitter block (zc_*) after host_cmd.
+ * v3: appended zc_confirm_reject after the v2 jitter block (host_cmd stays
+ *     frozen at offset 60). */
+#define HWCI_PERF_VERSION 3u
 
 /* Commands the host may write to hwci_perf.host_cmd (cleared by firmware). */
 #define HWCI_CMD_NONE          0u
@@ -104,7 +106,14 @@ typedef struct hwci_perf_s {
     uint32_t zc_interval_sum;          /* off 72 : sum raw interval, ticks  */
     uint16_t zc_jitter_max;            /* off 76 : worst single deviation   */
     uint16_t _pad2;                    /* off 78 : keep sizeof 4-aligned    */
-} hwci_perf_t;                         /* total size: 80 bytes              */
+
+    /* --- v3: zero-cross confirm rejections (fed by HWCI_PERF_CONFIRM_REJECT)
+     * Monotonic like the v2 sums: the host differences consecutive
+     * snapshots, so delta(reject)/delta(zc_count) over a window is the
+     * rejected-edges-per-accepted-commutation ratio - the live monitor for
+     * the F051 glitch-tolerant confirm loop's reject mechanism. */
+    uint32_t zc_confirm_reject;        /* off 80 : confirm-loop early-outs  */
+} hwci_perf_t;                         /* total size: 84 bytes              */
 
 extern volatile hwci_perf_t hwci_perf;
 
@@ -192,6 +201,14 @@ void hwci_perf_reset_stats(void);
     } while (0)
 
 /*
+ * Zero-cross confirm rejection counter. Fires on the confirm loop's
+ * early-out reject (an edge whose window failed confirmation and was handed
+ * back to the comparator). Runs in the comparator ISR, but only on the
+ * reject path - a single volatile u32 increment, off the hot accept path.
+ */
+#define HWCI_PERF_CONFIRM_REJECT() do { hwci_perf.zc_confirm_reject++; } while (0)
+
+/*
  * Background-loop instrumentation. Call once at the top of the main while(1).
  *
  * Every iteration: measures iteration time and counts iterations (the host
@@ -252,10 +269,11 @@ void hwci_perf_reset_stats(void);
 
 #else /* !HWCI_PERF - all hooks vanish, no struct, no code */
 
-#define HWCI_PERF_CTRL_ENTER() do {} while (0)
-#define HWCI_PERF_CTRL_EXIT()  do {} while (0)
-#define HWCI_PERF_ZC()         do {} while (0)
-#define HWCI_PERF_MAIN_LOOP()  do {} while (0)
+#define HWCI_PERF_CTRL_ENTER()     do {} while (0)
+#define HWCI_PERF_CTRL_EXIT()      do {} while (0)
+#define HWCI_PERF_ZC()             do {} while (0)
+#define HWCI_PERF_MAIN_LOOP()      do {} while (0)
+#define HWCI_PERF_CONFIRM_REJECT() do {} while (0)
 
 #endif /* HWCI_PERF */
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -982,6 +982,7 @@ RAM_FUNC void interruptRoutine()
             for (int i = 0; i < filter_level; i++) {
                 if (getCompOutputLevel() == rising) {
                     if (++bad > tolerance) {
+                        HWCI_PERF_CONFIRM_REJECT();
                         return;
                     }
                 }
@@ -994,6 +995,7 @@ RAM_FUNC void interruptRoutine()
 #else
             if (getCompOutputLevel() == rising) {
 #endif
+                HWCI_PERF_CONFIRM_REJECT();
                 return;
             }
         }

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -157,6 +157,30 @@ def zc_jitter_window(count: np.ndarray, jsum: np.ndarray, isum: np.ndarray,
     return out
 
 
+def counter_per_zc(counter: np.ndarray, count: np.ndarray,
+                   idx: np.ndarray) -> float | None:
+    """Ratio of a monotonic per-event counter to accepted commutations over
+    the sample window ``idx``.
+
+    Both are firmware u32 counters differenced wrap-safe between the first
+    and last valid snapshot (same scheme as :func:`zc_jitter_window`). Used
+    for ``confirm_rejects_per_zc``: rejected comparator edges per accepted
+    zero-cross - the live monitor for the F051 glitch-tolerant confirm's
+    reject mechanism (rare in clean running; balloons under real noise).
+    ``None`` when the firmware predates the counter or nothing accumulated.
+    """
+    if idx.size == 0:
+        return None
+    valid = idx[~np.isnan(counter[idx]) & ~np.isnan(count[idx])]
+    if valid.size < 2:
+        return None
+    a, b = valid[0], valid[-1]
+    n = _wrap32(count[a], count[b])
+    if n <= 0:
+        return None
+    return round(_wrap32(counter[a], counter[b]) / n, 4)
+
+
 def compute(run: RunResult, profile: Profile) -> dict:
     rows = run.rows
     seg = np.array([r.get("segment") for r in rows], dtype=object)
@@ -180,6 +204,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
     zc_jsum = _col(rows, "perf_zc_jitter_sum")
     zc_isum = _col(rows, "perf_zc_interval_sum")
     zc_jmax = _col(rows, "perf_zc_jitter_max")
+    zc_reject = _col(rows, "perf_zc_confirm_reject")
 
     steady_points = []
     for s in profile.segments:
@@ -208,6 +233,8 @@ def compute(run: RunResult, profile: Profile) -> dict:
             # bench has repeat captures establishing its run-to-run spread)
             "zc_jitter_pct": jitter["mean_pct"],
             "zc_jitter_max_pct": jitter["max_pct"],
+            # rejected edges per accepted zero-cross (report-only, v3+)
+            "confirm_rejects_per_zc": counter_per_zc(zc_reject, zc_count, tail),
         })
 
     demag = detect_demag(run, profile)

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -34,6 +34,8 @@ COLUMNS = [
     # firmware predates them - metrics treat blank as "metric unavailable")
     "perf_zc_count", "perf_zc_jitter_sum", "perf_zc_interval_sum",
     "perf_zc_jitter_max",
+    # confirm-loop rejection counter (struct v3+; blank on older firmware)
+    "perf_zc_confirm_reject",
     "perf_bemf_timeout", "perf_e_rpm",
     # ESC input/arming state (proves the ESC decoded the throttle protocol)
     "perf_input", "perf_armed", "perf_running",
@@ -97,6 +99,8 @@ def make_row(t: float, segment: str, throttle_cmd: float,
                 perf_zc_interval_sum=r["zc_interval_sum"],
                 perf_zc_jitter_max=r["zc_jitter_max"],
             )
+        if "zc_confirm_reject" in r:  # struct v3+
+            row.update(perf_zc_confirm_reject=r["zc_confirm_reject"])
     return row
 
 

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 2
+VERSION = 3
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -57,7 +57,7 @@ FIELDS_V1: list[tuple[str, str]] = [
 ]
 
 # v2 appends the zero-cross jitter block (see HWCI_PERF_ZC in Inc/hwci_perf.h).
-FIELDS: list[tuple[str, str]] = FIELDS_V1 + [
+FIELDS_V2: list[tuple[str, str]] = FIELDS_V1 + [
     ("zc_count", "I"),
     ("zc_jitter_sum", "I"),
     ("zc_interval_sum", "I"),
@@ -65,7 +65,15 @@ FIELDS: list[tuple[str, str]] = FIELDS_V1 + [
     ("_pad2", "H"),
 ]
 
-FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {1: FIELDS_V1, 2: FIELDS}
+# v3 appends the confirm-loop rejection counter (HWCI_PERF_CONFIRM_REJECT).
+FIELDS_V3: list[tuple[str, str]] = FIELDS_V2 + [
+    ("zc_confirm_reject", "I"),
+]
+
+FIELDS = FIELDS_V3
+
+FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
+    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3}
 
 
 def _format(fields: list[tuple[str, str]]) -> str:
@@ -76,7 +84,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 80 bytes (v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 84 bytes (v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -51,8 +51,13 @@ class PerfReader:
                           "relying on the canonical layout in hwci/hwci/perf.py")
             return
         # Pick the canonical layout matching the firmware's vintage by probing
-        # for a v2-only member, then verify every field of THAT layout.
-        fields = perf.FIELDS if "zc_count" in members else perf.FIELDS_V1
+        # for version-marker members, then verify every field of THAT layout.
+        if "zc_confirm_reject" in members:
+            fields = perf.FIELDS_V3
+        elif "zc_count" in members:
+            fields = perf.FIELDS_V2
+        else:
+            fields = perf.FIELDS_V1
         off = 0
         import struct as _struct
         for name, code in fields:

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -67,6 +67,8 @@ class RigSimulator:
         self.zc_jitter_sum = 0
         self.zc_interval_sum = 0
         self.zc_jitter_max = 0
+        # confirm-loop rejection counter (perf struct v3)
+        self.zc_confirm_reject = 0
 
     # --- model -------------------------------------------------------
     def _rpm_max(self) -> float:
@@ -115,6 +117,12 @@ class RigSimulator:
             self.zc_jitter_sum = (self.zc_jitter_sum + dev * n_comm) & 0xFFFFFFFF
             self.zc_interval_sum = (self.zc_interval_sum + interval * n_comm) & 0xFFFFFFFF
             self.zc_jitter_max = min(max(self.zc_jitter_max, dev), 0xFFFF)
+            # confirm rejects: rare in clean running, balloon during a desync.
+            # Stochastic rounding: the per-tick expectation (~0.8 rejects) is
+            # below 1, so a plain int() would truncate every tick to zero.
+            reject_frac = 0.2 if self.desync_remaining > 0 else 0.01
+            n_rej = int(n_comm * reject_frac + self._rng.random())
+            self.zc_confirm_reject = (self.zc_confirm_reject + n_rej) & 0xFFFFFFFF
         # idle loop iterations: ~120 kHz when idle, dropping with motor load
         idle_hz = 120000.0 * (1.0 - 0.25 * throttle)
         self.loop_iters += int(idle_hz * dt)
@@ -228,4 +236,5 @@ class RigSimulator:
             "zc_jitter_sum": self.zc_jitter_sum,
             "zc_interval_sum": self.zc_interval_sum,
             "zc_jitter_max": self.zc_jitter_max,
+            "zc_confirm_reject": self.zc_confirm_reject,
         })

--- a/hwci/tests/conftest.py
+++ b/hwci/tests/conftest.py
@@ -51,6 +51,33 @@ int main(void){ return (int)hwci_perf.size; }
 """
 
 
+# Frozen copy of the v2 struct (zero-cross jitter block, pre v3 confirm-reject
+# counter), so the host keeps decoding v2 firmware: an A/B bench session
+# flashes vintages with exactly this layout.
+_PROBE_V2_C = """\
+#include <stdint.h>
+typedef struct hwci_perf_s {
+    uint32_t magic; uint16_t version; uint16_t size;
+    uint16_t ctrl_exec_us_last; uint16_t ctrl_exec_us_max;
+    uint16_t ctrl_period_us_last; uint16_t ctrl_period_us_max;
+    uint16_t ctrl_period_us_min;
+    uint16_t main_loop_us_last; uint16_t main_loop_us_max;
+    uint16_t input; uint16_t duty_cycle; uint16_t e_rpm;
+    uint16_t voltage_cv; int16_t current_ca; int16_t temperature_c;
+    uint8_t bemf_timeout_state; uint8_t armed; uint8_t running;
+    uint8_t _pad0; uint16_t _pad1;
+    uint32_t loop_iters; uint32_t zero_cross_count;
+    uint32_t commutation_interval; uint32_t commutation_interval_max;
+    uint32_t update_count; volatile uint32_t host_cmd;
+    uint32_t zc_count; uint32_t zc_jitter_sum; uint32_t zc_interval_sum;
+    uint16_t zc_jitter_max; uint16_t _pad2;
+} hwci_perf_t;
+volatile hwci_perf_t hwci_perf = {
+  .magic = 0x31435748u, .version = 2, .size = (uint16_t)sizeof(hwci_perf_t) };
+int main(void){ return (int)hwci_perf.size; }
+"""
+
+
 def _compile_probe(tmp_path_factory, name: str, source: str,
                    include_dir=None) -> str:
     pytest.importorskip("elftools")
@@ -78,3 +105,8 @@ def host_perf_elf(tmp_path_factory):
 @pytest.fixture(scope="session")
 def host_perf_elf_v1(tmp_path_factory):
     return _compile_probe(tmp_path_factory, "perf_elf_v1", _PROBE_V1_C)
+
+
+@pytest.fixture(scope="session")
+def host_perf_elf_v2(tmp_path_factory):
+    return _compile_probe(tmp_path_factory, "perf_elf_v2", _PROBE_V2_C)

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 80
+    assert sym.size == perf.SIZE == 84
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -305,3 +305,30 @@ def test_steady_state_comm_spike_still_detected():
     d = metricsmod.detect_demag(RunResult(rows=rows), _profile())
     assert d["comm_spike_samples"] >= 8
     assert d["event_count"] >= 1
+
+
+def test_confirm_rejects_per_zc_from_deltas():
+    # 100 commutations and 3 rejects per tick -> 0.03 rejects per ZC.
+    rows = _rows(
+        100,
+        perf_zc_count=lambda i: 100 * i,
+        perf_zc_jitter_sum=lambda i: 100 * i,
+        perf_zc_interval_sum=lambda i: 200 * 100 * i,
+        perf_zc_jitter_max=lambda i: 5,
+        perf_zc_confirm_reject=lambda i: 3 * i,
+    )
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["steady_points"][0]["confirm_rejects_per_zc"] == 0.03
+
+
+def test_confirm_rejects_none_for_v2_runs():
+    # Runs from pre-v3 firmware have no reject column: None, never 0.
+    rows = _rows(
+        50,
+        perf_zc_count=lambda i: 100 * i,
+        perf_zc_jitter_sum=lambda i: 100 * i,
+        perf_zc_interval_sum=lambda i: 200 * 100 * i,
+        perf_zc_jitter_max=lambda i: 5,
+    )
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    assert m["steady_points"][0]["confirm_rejects_per_zc"] is None

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -8,7 +8,8 @@ from hwci import perf
 
 def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[1] == 64
-    assert perf.SIZE == perf.SIZE_BY_VERSION[2] == 80
+    assert perf.SIZE_BY_VERSION[2] == 80
+    assert perf.SIZE == perf.SIZE_BY_VERSION[3] == 84
 
 
 def test_host_cmd_offset_matches_layout():
@@ -107,3 +108,19 @@ def test_negative_current_is_signed():
     blob = perf.encode({"current_ca": -150})
     s = perf.decode(blob)
     assert s.current == pytest.approx(-1.5)
+
+
+def test_v3_roundtrip_confirm_reject():
+    blob = perf.encode({"zc_confirm_reject": 424242})
+    assert len(blob) == 84
+    assert perf.decode(blob).raw["zc_confirm_reject"] == 424242
+
+
+def test_v2_roundtrip_has_no_reject_key():
+    # v2 firmware (pre confirm-reject counter) must keep decoding, without
+    # the v3 key - the A side of an A/B session runs exactly this layout.
+    blob = perf.encode({"zc_count": 7}, version=2)
+    assert len(blob) == perf.SIZE_BY_VERSION[2]
+    s = perf.decode(blob)
+    assert s.raw["zc_count"] == 7
+    assert "zc_confirm_reject" not in s.raw

--- a/hwci/tests/test_perf_reader.py
+++ b/hwci/tests/test_perf_reader.py
@@ -97,3 +97,19 @@ def test_missing_struct_die_fails_hard(host_perf_elf, monkeypatch):
     dbg = MockDebugger(base=addr, size=perf.SIZE + 256)
     with pytest.raises(perf.PerfDecodeError):
         PerfReader(dbg, host_perf_elf)
+
+
+def test_v2_firmware_reads_and_resets(host_perf_elf_v2):
+    # v2 vintage (jitter block, no confirm-reject counter): the reader must
+    # size its read from the ELF, pass the DWARF cross-check against the v2
+    # canonical table, decode without the v3 key, and land RESET_STATS at
+    # the version-stable offset 60.
+    reader, dbg = _reader_with_mock(host_perf_elf_v2)
+    assert reader._read_size == perf.SIZE_BY_VERSION[2]
+    dbg.poke(reader.address, perf.encode({"zc_count": 55}, version=2))
+    sample = reader.read()
+    assert sample.raw["zc_count"] == 55
+    assert "zc_confirm_reject" not in sample.raw
+    reader.reset_stats(verify=False)
+    word = dbg.read_memory(reader.address + perf.HOST_CMD_OFFSET, 4)
+    assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -80,3 +80,16 @@ def test_perf_channel_carries_zc_jitter_accumulators():
         b["zc_interval_sum"] - a["zc_interval_sum"])
     assert 0.1 < mean_pct < 2.0
     assert b["zc_jitter_max"] >= 1
+
+
+def test_perf_channel_carries_confirm_reject_counter():
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.7)
+    a = perf.decode(rig.perf_bytes()).raw
+    _settle(rig, 0.7)
+    b = perf.decode(rig.perf_bytes()).raw
+    assert b["zc_confirm_reject"] > a["zc_confirm_reject"] > 0
+    # clean running: rejects stay a small fraction of accepted ZCs
+    ratio = (b["zc_confirm_reject"] - a["zc_confirm_reject"]) / (
+        b["zc_count"] - a["zc_count"])
+    assert 0.001 < ratio < 0.05


### PR DESCRIPTION
The instrumentation salvaged from #23 (per its bench verdict), without any of the blanking: a monotonic counter on the zero-cross confirm loop's **reject path**, giving live visibility into the #21 glitch-tolerant confirm. `Δreject/Δzc_count` over a window = rejected comparator edges per accepted commutation — rare in clean running, balloons under real noise — so "the tolerance is working" becomes a measurement instead of an inference.

## Contents

- **Firmware**: `hwci_perf` struct **v3** (84 B) — one u32 (`zc_confirm_reject`, offset 80) appended after the v2 jitter block, `host_cmd` frozen at 60 per the versioning contract. `HWCI_PERF_CONFIRM_REJECT()` fires on the F051 tolerant loop's early-out *and* the generic strict-loop reject; compiles to nothing without `HWCI_PERF`. Production builds byte-identical.
- **Host**: v1/v2/v3 decode (with a compiled v2-ELF regression fixture, same pattern as v1's), `perf_zc_confirm_reject` CSV column, `confirm_rejects_per_zc` per steady point (report-only, `None` on pre-v3 firmware), sim support.
- 131 offline tests pass (6 new); instrumented + production ARK_4IN1_F051 builds clean.

## Version bookkeeping

⚠️ This claims **v3 at offset 80** (size 84). PR #24 (demag compensation) also drafts a v3 at offset 80 — after this merges, #24 should rebase its fields to offset 84+ and bump to **v4**.

Not bench-tested per @alexklimaj — instrumentation-only, no behavioral change, and the identical counter ran on the bench inside #23's builds during the A/B session without issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)