### PR TITLE
feat(perf): PWM-phase histogram of zero-crossings (v4) — hump mechanism identified

### DIFF
--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -42,8 +42,13 @@
 #define HWCI_PERF_MAGIC   0x31435748u
 /* v2: appended the zero-cross jitter block (zc_*) after host_cmd.
  * v3: appended zc_confirm_reject after the v2 jitter block (host_cmd stays
- *     frozen at offset 60). */
-#define HWCI_PERF_VERSION 3u
+ *     frozen at offset 60).
+ * v4: appended the 32-bin PWM-phase histogram of accepted zero-crossings. */
+#define HWCI_PERF_VERSION 4u
+
+/* PWM-phase histogram bins (power of two: the binning multiply-shift and the
+ * host's modular math both assume it). */
+#define HWCI_ZC_PHASE_BINS 32u
 
 /* Commands the host may write to hwci_perf.host_cmd (cleared by firmware). */
 #define HWCI_CMD_NONE          0u
@@ -113,9 +118,27 @@ typedef struct hwci_perf_s {
      * rejected-edges-per-accepted-commutation ratio - the live monitor for
      * the F051 glitch-tolerant confirm loop's reject mechanism. */
     uint32_t zc_confirm_reject;        /* off 80 : confirm-loop early-outs  */
-} hwci_perf_t;                         /* total size: 84 bytes              */
+
+    /* --- v4: PWM-phase histogram of accepted zero-crossings ---
+     * bin = TIM1 phase (CNT/ARR) of the comparator edge at ISR entry, 32
+     * bins across the PWM period. Each bin is a monotonic u16 event counter
+     * that wraps naturally; the host differences consecutive snapshots
+     * per-bin (mod 2^16), so the per-window histogram is exact as long as
+     * one bin gains < 65536 events between 200 Hz reads (it gains < 100).
+     * Uniform phase distribution = commutation free-running vs PWM; strong
+     * peaks = ZC<->PWM phase correlation (injection locking) - the
+     * discriminator for the beat-band jitter hump investigation (PR #23
+     * found 3.3x edge-window enrichment at t30). */
+    uint16_t zc_phase_hist[HWCI_ZC_PHASE_BINS]; /* off 84..147              */
+} hwci_perf_t;                         /* total size: 148 bytes             */
 
 extern volatile hwci_perf_t hwci_perf;
+
+/* Q16 phase-binning factor, (HWCI_ZC_PHASE_BINS << 16) / (tim1_arr + 1).
+ * Recomputed from the main loop (HWCI_PERF_MAIN_LOOP snapshot branch, one
+ * soft division per ~1 ms, never in an ISR); 0 until first computed, which
+ * the commit macro treats as "histogram off". Defined in hwci_perf.c. */
+extern volatile uint32_t hwci_zc_phase_scale_q16;
 
 /* Apply a pending host_cmd (e.g. reset accumulators). Defined in hwci_perf.c. */
 void hwci_perf_apply_cmd(void);
@@ -209,6 +232,33 @@ void hwci_perf_reset_stats(void);
 #define HWCI_PERF_CONFIRM_REJECT() do { hwci_perf.zc_confirm_reject++; } while (0)
 
 /*
+ * PWM-phase histogram of accepted zero-crossings (F051 only: reads TIM1
+ * registers directly). CAPTURE at the TOP of interruptRoutine() - the CNT
+ * read must happen at ISR entry, before the confirm loop's wall-clock window
+ * smears it (the capture is a local, so a rejected edge simply discards it).
+ * COMMIT after the zero-cross is accepted, outside the IRQ-masked timing
+ * section: one 32x32 multiply, shift, bounds check and u16 increment.
+ * Gated on zero_crosses >= 100 like HWCI_PERF_ZC (same "stable running"
+ * threshold), and on the Q16 scale being initialized.
+ */
+#if defined(MCU_F051)
+#define HWCI_PERF_ZC_PHASE_CAPTURE() uint16_t _hwci_zc_phase_cnt = (uint16_t)TIM1->CNT
+#define HWCI_PERF_ZC_PHASE_COMMIT()                                            \
+    do {                                                                       \
+        uint32_t _s = hwci_zc_phase_scale_q16;                                 \
+        if (_s != 0u && zero_crosses >= 100) {                                 \
+            uint32_t _bin = ((uint32_t)_hwci_zc_phase_cnt * _s) >> 16;         \
+            if (_bin < HWCI_ZC_PHASE_BINS) {                                   \
+                hwci_perf.zc_phase_hist[_bin]++;                               \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
+#else
+#define HWCI_PERF_ZC_PHASE_CAPTURE() do {} while (0)
+#define HWCI_PERF_ZC_PHASE_COMMIT()  do {} while (0)
+#endif
+
+/*
  * Background-loop instrumentation. Call once at the top of the main while(1).
  *
  * Every iteration: measures iteration time and counts iterations (the host
@@ -262,6 +312,10 @@ void hwci_perf_reset_stats(void);
             if (_armed && !_hwci_prev_armed)                                   \
                 hwci_perf_reset_stats(); /* drop aliased arming-tune maxima */ \
             _hwci_prev_armed = _armed;                                         \
+            /* phase-binning factor: one soft division per snapshot (~1 ms), \
+             * tracks variable-PWM tim1_arr changes automatically */          \
+            hwci_zc_phase_scale_q16 =                                          \
+                ((uint32_t)HWCI_ZC_PHASE_BINS << 16) / ((uint32_t)tim1_arr + 1u); \
             hwci_perf.update_count++;                                          \
             if (hwci_perf.host_cmd != HWCI_CMD_NONE) hwci_perf_apply_cmd();    \
         }                                                                      \
@@ -269,11 +323,13 @@ void hwci_perf_reset_stats(void);
 
 #else /* !HWCI_PERF - all hooks vanish, no struct, no code */
 
-#define HWCI_PERF_CTRL_ENTER()     do {} while (0)
-#define HWCI_PERF_CTRL_EXIT()      do {} while (0)
-#define HWCI_PERF_ZC()             do {} while (0)
-#define HWCI_PERF_MAIN_LOOP()      do {} while (0)
-#define HWCI_PERF_CONFIRM_REJECT() do {} while (0)
+#define HWCI_PERF_CTRL_ENTER()       do {} while (0)
+#define HWCI_PERF_CTRL_EXIT()        do {} while (0)
+#define HWCI_PERF_ZC()               do {} while (0)
+#define HWCI_PERF_MAIN_LOOP()        do {} while (0)
+#define HWCI_PERF_CONFIRM_REJECT()   do {} while (0)
+#define HWCI_PERF_ZC_PHASE_CAPTURE() do {} while (0)
+#define HWCI_PERF_ZC_PHASE_COMMIT()  do {} while (0)
 
 #endif /* HWCI_PERF */
 

--- a/Src/hwci_perf.c
+++ b/Src/hwci_perf.c
@@ -26,6 +26,11 @@ volatile hwci_perf_t hwci_perf = {
     .host_cmd = HWCI_CMD_NONE,
 };
 
+/* Phase-binning factor for the v4 histogram; 0 = not yet computed (the
+ * commit macro skips binning). The main-loop snapshot keeps it tracking
+ * tim1_arr. */
+volatile uint32_t hwci_zc_phase_scale_q16 = 0;
+
 /*
  * Clear the sticky min/max accumulators so worst-case timing can be measured
  * for a single test run without power-cycling the ESC. Called for the host

--- a/Src/main.c
+++ b/Src/main.c
@@ -947,6 +947,7 @@ RAM_FUNC void PeriodElapsedCallback()
  */
 RAM_FUNC void interruptRoutine()
 {
+    HWCI_PERF_ZC_PHASE_CAPTURE(); // TIM1 phase at ISR entry, pre-confirm
 //   if (average_interval > 125) {
 //        if ((INTERVAL_TIMER_COUNT < 125) && (duty_cycle < 600) && (zero_crosses < 500)) { // should be impossible, desync?exit anyway
 //           return;
@@ -1003,10 +1004,11 @@ RAM_FUNC void interruptRoutine()
     __disable_irq();
     maskPhaseInterrupts();
     lastzctime = thiszctime;
-    thiszctime = INTERVAL_TIMER_COUNT;  
+    thiszctime = INTERVAL_TIMER_COUNT;
     SET_INTERVAL_TIMER_COUNT(0);
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
     __enable_irq();
+    HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase
 }
 
 void startMotor()

--- a/hwci/hwci/elf.py
+++ b/hwci/hwci/elf.py
@@ -119,18 +119,48 @@ def _members_of(struct_die, cu) -> list[Member]:
     return members
 
 
-def _base_type(member_die, cu) -> tuple[int, bool]:
-    type_ref = member_die.attributes.get("DW_AT_type")
-    if type_ref is None:
-        return 0, False
-    die = cu.get_DIE_from_refaddr(type_ref.value + cu.cu_offset)
-    # Walk through typedef/const/volatile qualifiers to the base type.
+def _strip_qualifiers(die, cu):
+    """Walk through typedef/const/volatile qualifiers to the base type."""
     while die.tag in ("DW_TAG_typedef", "DW_TAG_const_type",
                       "DW_TAG_volatile_type"):
         nxt = die.attributes.get("DW_AT_type")
         if nxt is None:
-            return 0, False
+            return None
         die = cu.get_DIE_from_refaddr(nxt.value + cu.cu_offset)
+    return die
+
+
+def _base_type(member_die, cu) -> tuple[int, bool]:
+    type_ref = member_die.attributes.get("DW_AT_type")
+    if type_ref is None:
+        return 0, False
+    die = _strip_qualifiers(
+        cu.get_DIE_from_refaddr(type_ref.value + cu.cu_offset), cu)
+    if die is None:
+        return 0, False
+    if die.tag == "DW_TAG_array_type":
+        # total size = element size x count; the array DIE itself usually
+        # carries no DW_AT_byte_size (e.g. the v4 zc_phase_hist[32] member)
+        count = 0
+        for child in die.iter_children():
+            if child.tag == "DW_TAG_subrange_type":
+                cnt = child.attributes.get("DW_AT_count")
+                ub = child.attributes.get("DW_AT_upper_bound")
+                if cnt is not None:
+                    count = cnt.value
+                elif ub is not None:
+                    count = ub.value + 1
+        elem_ref = die.attributes.get("DW_AT_type")
+        if elem_ref is None or count == 0:
+            return 0, False
+        die = _strip_qualifiers(
+            cu.get_DIE_from_refaddr(elem_ref.value + cu.cu_offset), cu)
+        if die is None:
+            return 0, False
+        size_attr = die.attributes.get("DW_AT_byte_size")
+        enc_attr = die.attributes.get("DW_AT_encoding")
+        return ((size_attr.value if size_attr is not None else 0) * count,
+                bool(enc_attr and enc_attr.value in _ENCODING_SIGNED))
     size_attr = die.attributes.get("DW_AT_byte_size")
     size = size_attr.value if size_attr is not None else 0
     enc_attr = die.attributes.get("DW_AT_encoding")

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -181,6 +181,54 @@ def counter_per_zc(counter: np.ndarray, count: np.ndarray,
     return round(_wrap32(counter[a], counter[b]) / n, 4)
 
 
+_U16 = 1 << 16
+
+
+def zc_phase_window(rows: list[dict], idx: np.ndarray) -> dict | None:
+    """PWM-phase histogram of accepted zero-crossings over window ``idx``.
+
+    ``perf_zc_phase_hist`` is a semicolon-joined vector of 32 monotonic u16
+    bin counters (firmware wraps them naturally); differencing the first and
+    last valid snapshot per-bin (mod 2^16) gives the exact distribution of
+    the window's accepted-edge PWM phases. Interpretation:
+
+    * flat histogram - commutation free-runs against PWM (no correlation),
+    * strong peaks - ZC<->PWM phase locking (the injection-locking
+      hypothesis for the beat-band jitter hump; PR #23's blanking gate
+      measured 3.3x edge-window enrichment at t30 before being refuted).
+
+    Returns ``hist`` (32 deltas), ``total``, ``peak_bin`` and ``peak_ratio``
+    (max bin / uniform expectation; 1.0 = flat), or ``None`` when the
+    firmware predates v4 or nothing accumulated.
+    """
+    if idx.size == 0:
+        return None
+    def parse(r):
+        v = r.get("perf_zc_phase_hist")
+        if v in (None, ""):
+            return None
+        try:
+            bins = [int(float(x)) for x in str(v).split(";")]
+        except ValueError:
+            return None
+        return bins if len(bins) > 1 else None
+    valid = [(i, parse(rows[i])) for i in idx]
+    valid = [(i, b) for i, b in valid if b is not None]
+    if len(valid) < 2:
+        return None
+    (_, a), (_, b) = valid[0], valid[-1]
+    if len(a) != len(b):
+        return None
+    hist = [(y - x) % _U16 for x, y in zip(a, b)]
+    total = sum(hist)
+    if total <= 0:
+        return None
+    peak_bin = max(range(len(hist)), key=hist.__getitem__)
+    uniform = total / len(hist)
+    return {"hist": hist, "total": total, "peak_bin": peak_bin,
+            "peak_ratio": round(hist[peak_bin] / uniform, 2)}
+
+
 def compute(run: RunResult, profile: Profile) -> dict:
     rows = run.rows
     seg = np.array([r.get("segment") for r in rows], dtype=object)
@@ -236,6 +284,13 @@ def compute(run: RunResult, profile: Profile) -> dict:
             # rejected edges per accepted zero-cross (report-only, v3+)
             "confirm_rejects_per_zc": counter_per_zc(zc_reject, zc_count, tail),
         })
+        # PWM-phase distribution of accepted ZC edges (report-only, v4+)
+        phase = zc_phase_window(rows, tail)
+        steady_points[-1]["zc_phase_peak_ratio"] = (
+            phase["peak_ratio"] if phase else None)
+        steady_points[-1]["zc_phase_peak_bin"] = (
+            phase["peak_bin"] if phase else None)
+        steady_points[-1]["zc_phase_hist"] = phase["hist"] if phase else None
 
     demag = detect_demag(run, profile)
     starts = startup_stats(run, profile)

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -36,6 +36,8 @@ COLUMNS = [
     "perf_zc_jitter_max",
     # confirm-loop rejection counter (struct v3+; blank on older firmware)
     "perf_zc_confirm_reject",
+    # 32-bin PWM-phase histogram, semicolon-joined (struct v4+)
+    "perf_zc_phase_hist",
     "perf_bemf_timeout", "perf_e_rpm",
     # ESC input/arming state (proves the ESC decoded the throttle protocol)
     "perf_input", "perf_armed", "perf_running",
@@ -101,6 +103,10 @@ def make_row(t: float, segment: str, throttle_cmd: float,
             )
         if "zc_confirm_reject" in r:  # struct v3+
             row.update(perf_zc_confirm_reject=r["zc_confirm_reject"])
+        if "zc_phase_hist" in r:  # struct v4+
+            # one CSV cell, not 32 columns; _coerce leaves it a string on load
+            row["perf_zc_phase_hist"] = ";".join(
+                str(v) for v in r["zc_phase_hist"])
     return row
 
 

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 3
+VERSION = 4
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -70,10 +70,22 @@ FIELDS_V3: list[tuple[str, str]] = FIELDS_V2 + [
     ("zc_confirm_reject", "I"),
 ]
 
-FIELDS = FIELDS_V3
+# v4 appends the 32-bin PWM-phase histogram of accepted zero-crossings
+# (HWCI_PERF_ZC_PHASE_*). A repeat-count code ("32H") decodes to a tuple.
+ZC_PHASE_BINS = 32
+FIELDS_V4: list[tuple[str, str]] = FIELDS_V3 + [
+    ("zc_phase_hist", f"{ZC_PHASE_BINS}H"),
+]
+
+FIELDS = FIELDS_V4
 
 FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
-    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3}
+    1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4}
+
+
+def _field_count(code: str) -> int:
+    """Number of values a field code decodes to (e.g. "32H" -> 32)."""
+    return int(code[:-1]) if len(code) > 1 else 1
 
 
 def _format(fields: list[tuple[str, str]]) -> str:
@@ -84,7 +96,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 84 bytes (v2: 80, v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 148 bytes (v3: 84, v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.
@@ -191,8 +203,13 @@ def decode(data: bytes, *, host_monotonic: float | None = None,
     if len(data) < expected:
         raise PerfDecodeError(
             f"v{ver} struct needs {expected} bytes, got {len(data)}")
-    names = [name for name, _ in fields]
-    raw = dict(zip(names, struct.unpack(fmt, data[:expected])))
+    values = struct.unpack(fmt, data[:expected])
+    raw: dict = {}
+    pos = 0
+    for name, code in fields:
+        n = _field_count(code)
+        raw[name] = values[pos] if n == 1 else tuple(values[pos:pos + n])
+        pos += n
     if validate and raw["size"] != expected:
         raise PerfDecodeError(
             f"struct size {raw['size']} != host-expected {expected} for "
@@ -205,9 +222,13 @@ def decode(data: bytes, *, host_monotonic: float | None = None,
 def encode(raw: dict, version: int = VERSION) -> bytes:
     """Inverse of :func:`decode` (used by the simulator and tests)."""
     fields = FIELDS_BY_VERSION[version]
-    full = {name: 0 for name, _ in fields}
+    full = {name: ((0,) * _field_count(code) if _field_count(code) > 1 else 0)
+            for name, code in fields}
     full.update({"magic": MAGIC, "version": version,
                  "size": SIZE_BY_VERSION[version]})
     full.update({k: v for k, v in raw.items() if k in full})
-    return struct.pack(_FORMAT_BY_VERSION[version],
-                       *(full[name] for name, _ in fields))
+    flat: list = []
+    for name, code in fields:
+        v = full[name]
+        flat.extend(v) if _field_count(code) > 1 else flat.append(v)
+    return struct.pack(_FORMAT_BY_VERSION[version], *flat)

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -52,7 +52,9 @@ class PerfReader:
             return
         # Pick the canonical layout matching the firmware's vintage by probing
         # for version-marker members, then verify every field of THAT layout.
-        if "zc_confirm_reject" in members:
+        if "zc_phase_hist" in members:
+            fields = perf.FIELDS_V4
+        elif "zc_confirm_reject" in members:
             fields = perf.FIELDS_V3
         elif "zc_count" in members:
             fields = perf.FIELDS_V2

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -69,6 +69,10 @@ class RigSimulator:
         self.zc_jitter_max = 0
         # confirm-loop rejection counter (perf struct v3)
         self.zc_confirm_reject = 0
+        # PWM-phase histogram of accepted ZCs (perf struct v4): the sim
+        # models mild phase locking - 20% of edges pile onto one bin
+        self.zc_phase_hist = [0] * 32
+        self._phase_rr = 0
 
     # --- model -------------------------------------------------------
     def _rpm_max(self) -> float:
@@ -123,6 +127,18 @@ class RigSimulator:
             reject_frac = 0.2 if self.desync_remaining > 0 else 0.01
             n_rej = int(n_comm * reject_frac + self._rng.random())
             self.zc_confirm_reject = (self.zc_confirm_reject + n_rej) & 0xFFFFFFFF
+            # v4 phase histogram: 80% uniform across bins (round-robin the
+            # integer remainder), 20% locked onto the throttle-derived bin
+            peak_bin = int(self.throttle * 32) & 31
+            per_bin, rem = divmod(int(n_comm * 0.8), 32)
+            for i in range(32):
+                self.zc_phase_hist[i] = (self.zc_phase_hist[i] + per_bin) & 0xFFFF
+            self.zc_phase_hist[self._phase_rr] = (
+                self.zc_phase_hist[self._phase_rr] + rem) & 0xFFFF
+            self._phase_rr = (self._phase_rr + 1) & 31
+            n_peak = int(n_comm * 0.2 + self._rng.random())
+            self.zc_phase_hist[peak_bin] = (
+                self.zc_phase_hist[peak_bin] + n_peak) & 0xFFFF
         # idle loop iterations: ~120 kHz when idle, dropping with motor load
         idle_hz = 120000.0 * (1.0 - 0.25 * throttle)
         self.loop_iters += int(idle_hz * dt)
@@ -237,4 +253,5 @@ class RigSimulator:
             "zc_interval_sum": self.zc_interval_sum,
             "zc_jitter_max": self.zc_jitter_max,
             "zc_confirm_reject": self.zc_confirm_reject,
+            "zc_phase_hist": tuple(self.zc_phase_hist),
         })

--- a/hwci/tests/conftest.py
+++ b/hwci/tests/conftest.py
@@ -110,3 +110,16 @@ def host_perf_elf_v1(tmp_path_factory):
 @pytest.fixture(scope="session")
 def host_perf_elf_v2(tmp_path_factory):
     return _compile_probe(tmp_path_factory, "perf_elf_v2", _PROBE_V2_C)
+
+
+# Frozen copy of the v3 struct (confirm-reject counter, pre v4 phase
+# histogram), for the decode-compat regression like the v1/v2 probes.
+_PROBE_V3_C = _PROBE_V2_C.replace(
+    "uint16_t zc_jitter_max; uint16_t _pad2;",
+    "uint16_t zc_jitter_max; uint16_t _pad2;\n    uint32_t zc_confirm_reject;"
+).replace(".version = 2,", ".version = 3,")
+
+
+@pytest.fixture(scope="session")
+def host_perf_elf_v3(tmp_path_factory):
+    return _compile_probe(tmp_path_factory, "perf_elf_v3", _PROBE_V3_C)

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 84
+    assert sym.size == perf.SIZE == 148
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_metrics.py
+++ b/hwci/tests/test_metrics.py
@@ -332,3 +332,41 @@ def test_confirm_rejects_none_for_v2_runs():
     )
     m = metricsmod.compute(RunResult(rows=rows), _profile())
     assert m["steady_points"][0]["confirm_rejects_per_zc"] is None
+
+
+def _hist_str(bins):
+    return ";".join(str(b & 0xFFFF) for b in bins)
+
+
+def test_zc_phase_window_from_deltas():
+    # Bin 5 gains 300/tick, every other bin 10/tick -> strong peak at 5.
+    def hist(i):
+        return _hist_str([300 * i if b == 5 else 10 * i for b in range(32)])
+    rows = _rows(100, perf_zc_phase_hist=hist)
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    pt = m["steady_points"][0]
+    assert pt["zc_phase_peak_bin"] == 5
+    # peak/uniform: 300 / ((300 + 31*10)/32) = 15.7x
+    assert 15.0 < pt["zc_phase_peak_ratio"] < 16.5
+    assert len(pt["zc_phase_hist"]) == 32
+
+
+def test_zc_phase_window_survives_u16_bin_wrap():
+    # A bin sitting just under 2^16 wraps mid-window; per-bin modular
+    # differencing must keep its delta exact.
+    def hist(i):
+        return _hist_str([(65500 + 40 * i) if b == 0 else 100 * i
+                          for b in range(32)])
+    rows = _rows(50, perf_zc_phase_hist=hist)
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    pt = m["steady_points"][0]
+    h = pt["zc_phase_hist"]
+    assert h[0] == 40 * 24  # 24 tail ticks (tail = last half of 49 deltas)
+
+
+def test_zc_phase_none_for_pre_v4_runs():
+    rows = _rows(50, perf_zc_count=lambda i: 100 * i)
+    m = metricsmod.compute(RunResult(rows=rows), _profile())
+    pt = m["steady_points"][0]
+    assert pt["zc_phase_peak_ratio"] is None
+    assert pt["zc_phase_hist"] is None

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -9,7 +9,8 @@ from hwci import perf
 def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[1] == 64
     assert perf.SIZE_BY_VERSION[2] == 80
-    assert perf.SIZE == perf.SIZE_BY_VERSION[3] == 84
+    assert perf.SIZE_BY_VERSION[3] == 84
+    assert perf.SIZE == perf.SIZE_BY_VERSION[4] == 148
 
 
 def test_host_cmd_offset_matches_layout():
@@ -111,9 +112,11 @@ def test_negative_current_is_signed():
 
 
 def test_v3_roundtrip_confirm_reject():
-    blob = perf.encode({"zc_confirm_reject": 424242})
+    blob = perf.encode({"zc_confirm_reject": 424242}, version=3)
     assert len(blob) == 84
-    assert perf.decode(blob).raw["zc_confirm_reject"] == 424242
+    s = perf.decode(blob)
+    assert s.raw["zc_confirm_reject"] == 424242
+    assert "zc_phase_hist" not in s.raw
 
 
 def test_v2_roundtrip_has_no_reject_key():
@@ -124,3 +127,11 @@ def test_v2_roundtrip_has_no_reject_key():
     s = perf.decode(blob)
     assert s.raw["zc_count"] == 7
     assert "zc_confirm_reject" not in s.raw
+
+
+def test_v4_roundtrip_phase_histogram():
+    hist = tuple((i * 7) % 65536 for i in range(32))
+    blob = perf.encode({"zc_phase_hist": hist})
+    assert len(blob) == 148
+    s = perf.decode(blob)
+    assert s.raw["zc_phase_hist"] == hist

--- a/hwci/tests/test_perf_reader.py
+++ b/hwci/tests/test_perf_reader.py
@@ -113,3 +113,15 @@ def test_v2_firmware_reads_and_resets(host_perf_elf_v2):
     reader.reset_stats(verify=False)
     word = dbg.read_memory(reader.address + perf.HOST_CMD_OFFSET, 4)
     assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS
+
+
+def test_v3_firmware_reads_and_resets(host_perf_elf_v3):
+    reader, dbg = _reader_with_mock(host_perf_elf_v3)
+    assert reader._read_size == perf.SIZE_BY_VERSION[3]
+    dbg.poke(reader.address, perf.encode({"zc_confirm_reject": 9}, version=3))
+    sample = reader.read()
+    assert sample.raw["zc_confirm_reject"] == 9
+    assert "zc_phase_hist" not in sample.raw
+    reader.reset_stats(verify=False)
+    word = dbg.read_memory(reader.address + perf.HOST_CMD_OFFSET, 4)
+    assert int.from_bytes(word, "little") == perf.CMD_RESET_STATS

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -93,3 +93,16 @@ def test_perf_channel_carries_confirm_reject_counter():
     ratio = (b["zc_confirm_reject"] - a["zc_confirm_reject"]) / (
         b["zc_count"] - a["zc_count"])
     assert 0.001 < ratio < 0.05
+
+
+def test_perf_channel_carries_phase_histogram():
+    rig = RigSimulator(noise=0.0)
+    _settle(rig, 0.7)
+    a = perf.decode(rig.perf_bytes()).raw["zc_phase_hist"]
+    _settle(rig, 0.7)
+    b = perf.decode(rig.perf_bytes()).raw["zc_phase_hist"]
+    delta = [(y - x) % 65536 for x, y in zip(a, b)]
+    assert sum(delta) > 0
+    # the sim locks 20% of edges onto the throttle-derived bin
+    peak = int(0.7 * 32) & 31
+    assert max(range(32), key=delta.__getitem__) == peak


### PR DESCRIPTION
The diagnostic proposed after #23's refutation: a 32-bin histogram of the PWM phase (`TIM1->CNT/ARR`) at which each accepted zero-cross fired. Captured at ISR entry (pre-confirm), committed on accept only, monotonic u16 bins differenced by the host per steady tail. Perf struct **v4** (148 B); host decodes v1–v4; includes DWARF array-member sizing support and a frozen v3 compat fixture. 137 offline tests, both build variants clean.

## First capture answers the question (`runs/phase-hist-probe`, jitter_probe)

The phase distributions are massively non-uniform — and the structure identifies the hump mechanism:

| point | duty | off-time | detections in bins 0-2 (uniform: 9.4%) | jitter |
|---|---|---|---|---|
| t30 | 24% | 76% | 27.1% | 4.9% |
| **t60** | **61%** | **39%** | **35.9%** | **23.5%** |
| **t70** | **71%** | **29%** | **30.8%** | **18.6%** |
| t90 | 90% | 10% | 25.8% | 7.2% |
| t100 | 100% | 0% | 12.8% (≈uniform) | 2.9% |

Two features, consistent at every point:
1. **A large pile-up in bins 0–2 — immediately after PWM turn-on** — scaling with the off-time fraction, and
2. **Heavy depletion of the bins covering the PWM off-period** (at t60, bins ~17–31 are nearly empty out of 45k events; the off-edge sits at bin ~19.5). At t100 there is no off-time and the distribution is nearly flat — and jitter is at its floor.

## The mechanism

**Zero-crossings that occur during the PWM off-time cannot be detected; they surface as comparator edges at the next turn-on.** Detection is quantized to the PWM grid by up to the full off-window (~19 µs at t60, on a 66 µs commutation interval). Those quantized timestamps feed `commutation_interval` → `advance`/`waitTime`, so the control loop schedules the next window off a corrupted measurement and hunts — which is why measured jitter (23%) is several times the direct quantization error (~4%), and why the hump lives where commutation frequency approaches PWM frequency (the walk through the off-window beats slowly). It also explains every prior negative result: coarse/fine sampling, glitch tolerance, and #23's blanking all operate at the detection instant — none of them can see a crossing the comparator was blind to.

## Proposed next experiment (cheap, concrete)

**Turn-on pile-up timestamp compensation**: for detections landing within the first ~2 bins after turn-on when duty < 100%, the true crossing occurred somewhere in the preceding off-window — subtract half the off-window duration (duty and ARR are both known) from `thiszctime`. On average this halves the quantization error, and more importantly decouples the commutation loop from the PWM grid, which should collapse the hunting amplification. Fully measurable with this histogram + the jitter metric via the interleaved A/B protocol.

Merging this PR adds the instrument (report-only metrics: `zc_phase_peak_ratio`/`peak_bin` + full histogram per steady point); the compensation experiment would be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)