### PR TITLE
perf(f051): turn-on grid compensation - cuts the beat-band jitter hump 21% with zero cost elsewhere

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -1011,24 +1011,57 @@ RAM_FUNC void interruptRoutine()
 #ifdef MCU_F051
     // Turn-on-pileup timestamp compensation. A zero-cross that physically
     // occurs during the PWM off-window (freewheel) is invisible to the
-    // comparator and is only registered at the next turn-on (CNT wraps to 0),
-    // quantizing the timestamp to the PWM grid; those corrupted intervals feed
-    // waitTime and the commutation loop hunts, amplifying the quantization into
-    // the measured jitter hump (bench: ~23% at t60/t70 where the commutation
-    // rate beats against the 24 kHz PWM). When an accepted edge lands in the
-    // first ~2 phase bins after turn-on (cnt < arr/16) and there is an off-
-    // window (duty < 100%), the true crossing lay on average half the off-
-    // window earlier. Back-date thiszctime by that half-window AND carry the
-    // same offset into the interval timer's reset, so the loop tracks the
-    // estimated true crossing rather than the grid position and stops hunting.
+    // comparator and is only registered at the next turn-on, quantizing the
+    // timestamp to the PWM grid; those corrupted intervals feed waitTime and
+    // the commutation loop hunts, amplifying the quantization into the
+    // measured jitter hump (bench: ~23% at t60/t70 where the commutation rate
+    // beats against the 24 kHz PWM). Detections of such crossings land 1-3
+    // phase bins after turn-on (bin 1 peak = comparator+ISR latency of
+    // ~1.3-2.6 us; bin 0 stays at the uniform rate) and the true crossing lay
+    // on average half the off-window earlier - back-date thiszctime by that
+    // half-window so the loop tracks the estimated true crossing instead of
+    // the grid position.
+    //
+    // Guards, each tied to a bench-observed failure of the unguarded version
+    // (which cut hump jitter 23.4->17.9% but desynced on a throttle step and
+    // doubled low-RPM jitter):
+    //  - correct thiszctime ONLY; the interval timer still resets to zero at
+    //    the detection instant, so one bad estimate perturbs one interval and
+    //    cannot cascade into the next (the cascading variant lost sync at 70A)
+    //  - duty-slew guard: skip while adjusted_duty_cycle is moving, i.e.
+    //    during throttle transients, where the loop must track real
+    //    acceleration rather than have timestamps rewritten under it
+    //  - hump band only (commutation interval < 2 PWM periods): at low RPM the
+    //    interval dwarfs the PWM period, there is no hunting to break, and the
+    //    correction only adds variance
+    //  - clamp to interval/8 as a backstop against any degenerate state
     // Units: INTERVAL_TIMER (TIM2) is 2 MHz and TIM1 is 48 MHz, so one INTERVAL
     // tick is 24 TIM1 ticks; half an off-window of N TIM1 ticks is N/48 INTERVAL
     // ticks, computed as (N * 1365) >> 16 to keep a soft divide out of the ISR.
     uint16_t zc_grid_comp = 0;
-    if (zero_crosses >= 100 && zc_pwm_cnt < (uint16_t)(tim1_arr >> 4)
-            && adjusted_duty_cycle < tim1_arr) {
-        zc_grid_comp = (uint16_t)(((uint32_t)(tim1_arr - adjusted_duty_cycle)
-                                   * 1365u) >> 16);
+    {
+        static uint16_t zc_prev_duty;
+        const uint16_t zc_arr = tim1_arr;
+        const uint16_t zc_duty = adjusted_duty_cycle;
+        const uint16_t zc_slew = (zc_duty >= zc_prev_duty)
+            ? (uint16_t)(zc_duty - zc_prev_duty)
+            : (uint16_t)(zc_prev_duty - zc_duty);
+        zc_prev_duty = zc_duty;
+        const uint32_t zc_ci = commutation_interval;
+        if (zero_crosses >= 100
+                && zc_duty < zc_arr                      /* off-window exists */
+                && zc_pwm_cnt >= (uint16_t)(zc_arr >> 5) /* pile-up bins 1-3 */
+                && zc_pwm_cnt < (uint16_t)(zc_arr >> 3)
+                && zc_slew <= (uint16_t)(zc_arr >> 8)    /* duty steady */
+                && (zc_ci * 12u) < (uint32_t)zc_arr + 1u /* hump band only */
+        ) {
+            uint32_t comp = ((uint32_t)(zc_arr - zc_duty) * 1365u) >> 16;
+            const uint32_t cap = zc_ci >> 3;
+            if (comp > cap) {
+                comp = cap;
+            }
+            zc_grid_comp = (uint16_t)comp;
+        }
     }
 #endif
     __disable_irq();
@@ -1036,11 +1069,10 @@ RAM_FUNC void interruptRoutine()
     lastzctime = thiszctime;
 #ifdef MCU_F051
     thiszctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
-    SET_INTERVAL_TIMER_COUNT(zc_grid_comp);
 #else
     thiszctime = INTERVAL_TIMER_COUNT;
-    SET_INTERVAL_TIMER_COUNT(0);
 #endif
+    SET_INTERVAL_TIMER_COUNT(0);
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
     __enable_irq();
     HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase

--- a/Src/main.c
+++ b/Src/main.c
@@ -948,6 +948,13 @@ RAM_FUNC void PeriodElapsedCallback()
 RAM_FUNC void interruptRoutine()
 {
     HWCI_PERF_ZC_PHASE_CAPTURE(); // TIM1 phase at ISR entry, pre-confirm
+#ifdef MCU_F051
+    // PWM phase (TIM1 CNT) at the edge, sampled before the confirm loop's
+    // wall-clock window advances it: the turn-on-pileup compensation below
+    // keys off where the comparator edge actually appeared, not where it was
+    // finally accepted.
+    uint16_t zc_pwm_cnt = (uint16_t)TIM1->CNT;
+#endif
 //   if (average_interval > 125) {
 //        if ((INTERVAL_TIMER_COUNT < 125) && (duty_cycle < 600) && (zero_crosses < 500)) { // should be impossible, desync?exit anyway
 //           return;
@@ -1001,11 +1008,39 @@ RAM_FUNC void interruptRoutine()
             }
         }
 #endif
+#ifdef MCU_F051
+    // Turn-on-pileup timestamp compensation. A zero-cross that physically
+    // occurs during the PWM off-window (freewheel) is invisible to the
+    // comparator and is only registered at the next turn-on (CNT wraps to 0),
+    // quantizing the timestamp to the PWM grid; those corrupted intervals feed
+    // waitTime and the commutation loop hunts, amplifying the quantization into
+    // the measured jitter hump (bench: ~23% at t60/t70 where the commutation
+    // rate beats against the 24 kHz PWM). When an accepted edge lands in the
+    // first ~2 phase bins after turn-on (cnt < arr/16) and there is an off-
+    // window (duty < 100%), the true crossing lay on average half the off-
+    // window earlier. Back-date thiszctime by that half-window AND carry the
+    // same offset into the interval timer's reset, so the loop tracks the
+    // estimated true crossing rather than the grid position and stops hunting.
+    // Units: INTERVAL_TIMER (TIM2) is 2 MHz and TIM1 is 48 MHz, so one INTERVAL
+    // tick is 24 TIM1 ticks; half an off-window of N TIM1 ticks is N/48 INTERVAL
+    // ticks, computed as (N * 1365) >> 16 to keep a soft divide out of the ISR.
+    uint16_t zc_grid_comp = 0;
+    if (zero_crosses >= 100 && zc_pwm_cnt < (uint16_t)(tim1_arr >> 4)
+            && adjusted_duty_cycle < tim1_arr) {
+        zc_grid_comp = (uint16_t)(((uint32_t)(tim1_arr - adjusted_duty_cycle)
+                                   * 1365u) >> 16);
+    }
+#endif
     __disable_irq();
     maskPhaseInterrupts();
     lastzctime = thiszctime;
+#ifdef MCU_F051
+    thiszctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
+    SET_INTERVAL_TIMER_COUNT(zc_grid_comp);
+#else
     thiszctime = INTERVAL_TIMER_COUNT;
     SET_INTERVAL_TIMER_COUNT(0);
+#endif
     SET_AND_ENABLE_COM_INT(waitTime+1); // enable COM_TIMER interrupt
     __enable_irq();
     HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase


### PR DESCRIPTION
## What

Implements the fix PR #29's phase histogram pointed at: zero-crossings that occur during the PWM off-window are invisible to the comparator and only register at the next turn-on, quantizing `thiszctime` to the PWM grid and driving the commutation loop into hunting — the t60/t70 jitter hump. When an accepted edge lands in the turn-on pile-up (phase bins 1-3), back-date `thiszctime` by half the off-window so the loop tracks the estimated true crossing instead of the grid position.

F051-only (`#ifdef` in `interruptRoutine`); all other targets build byte-identical. No divide in the ISR — the TIM1→INTERVAL_TIMER unit conversion (48 MHz → 2 MHz, half-window → /48) is a `*1365>>16` multiply-shift, verified in disassembly.

## Two-iteration bench history (both on the interleaved A/B protocol)

**v1 (naive, first commit)** validated the mechanism — t60 jitter 23.4→17.9% — but failed two ways:
- **desynced on the t60→t70 throttle step** (jitter_max 74→377 ticks in one commutation → eRPM 163k→63k → 70 A → harness abort). Root cause: it also carried the correction into the interval-timer reset, so one bad estimate cascaded into the next interval.
- **doubled t30 jitter** (4.8→8.5%): at low RPM there's no hunting to break, so the correction only added variance.

**v2 (this PR's head)** adds one guard per observed failure:
- **No reset-to-delta** — interval timer resets to 0; only `thiszctime` is corrected, so a bad estimate perturbs exactly one interval.
- **Pile-up gate re-aimed at bins 1-3** (was 0-1): the histogram shows the pile-up *peaks at bin 1* (comparator+ISR latency ~1.3-2.6 µs after turn-on) with bin 0 at the uniform rate — bin-0 detections are genuine crossings that must not be touched.
- **Duty-slew guard**: correction disabled while `adjusted_duty_cycle` moves >arr/256 per commutation (throttle transients).
- **Hump band only**: `interval*12 < arr+1` (commutation interval < 2 PWM periods).
- **Clamp** ≤ interval/8 backstop.

## v2 results — interleaved A1(base)/C1(v2)/A2(base), one 6S pack, jitter_probe, HQ5136

| seg | RPM | A1 | **C1 (v2)** | A2 | C vs mean(A) |
|---|---|---|---|---|---|
| t30 | 9.5k | 4.79 | **4.67** | 4.29 | +0.13 (neutral) |
| t60 | 21.5k | 23.43 | **18.14** | 22.71 | **−4.94 pts (−21%)** |
| t70 | 23.7k | 18.13 | **14.64** | 16.05 | **−2.45 pts** |
| t90 | 27.7k | 7.22 | **7.08** | 7.03 | −0.05 (neutral) |
| t100 | 29.3k | 2.88 | **3.08** | 2.97 | +0.16 (neutral) |

- **Completed the full profile including the step that killed v1** — jitter_max flat at 67 ticks straight through the t60→t70 spool (v1: 377), 3600/3600 samples, 0 demag, 0 bemf timeouts, normal currents/temps all legs.
- **BEMF-noise health unchanged**: confirm-rejects per ZC statistically identical to baseline at every point.
- **Histogram unchanged (bins 0-3 ≈ 45% at t60 on all three legs)** — as expected: the compensation can't make the comparator see off-window crossings, it corrects their timestamps after the fact. The instrument keeps measuring detection physics, so it stays valid for future A/Bs.
- t60 now sits at **upstream-main's level** (17.2-19.2 measured 07-02) while keeping ark-release's wins everywhere else (t30 4.7 vs upstream 9.1-9.9, t100 3.1 vs upstream ~2.1's neighborhood).

The residual t60 hump (~18% vs the 2.9% t100 floor) is the part a mean correction cannot remove: the true crossing is uniformly distributed in the off-window, so subtracting the mean off/2 removes the bias but not the ±off/2 spread. Getting further means recovering per-event timing the comparator never saw (e.g. BEMF slope extrapolation) — much bigger surgery, separate discussion.

Runs: `runs/gridcomp-A1`, `runs/gridcomp-B1` (v1, aborted), `runs/gridcomp-C1`, `runs/gridcomp-A2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
