### PR TITLE
chore(build): pin xPack GCC 15.2.1 for CI and local builds

### DIFF
--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Build CI
         shell: bash
         run: |
+          # Installs the xPack GCC pin from make/tools.mk (currently 15.2.1-1.1).
           if [ "$RUNNER_OS" == "Linux" ]; then
             make arm_sdk_install
             make -j8

--- a/.github/workflows/hwci.yml
+++ b/.github/workflows/hwci.yml
@@ -60,10 +60,11 @@ jobs:
       - name: Ensure ARM toolchain
         shell: bash
         run: |
-          # make/tools.mk pins ARM_SDK_PREFIX to tools/linux/<xpack>/bin, so a
-          # system arm-none-eabi-gcc on PATH does NOT satisfy the build; install
-          # the pinned SDK whenever the pinned path is missing.
-          if ! ls tools/linux/*/bin/arm-none-eabi-gcc >/dev/null 2>&1; then
+          # make/tools.mk pins ARM_SDK_PREFIX to a specific xPack version under
+          # tools/linux/ (currently 15.2.1-1.1). A system gcc on PATH or an
+          # older extracted xpack does NOT satisfy the build — install when
+          # the exact pinned binary is missing.
+          if [ ! -x tools/linux/xpack-arm-none-eabi-gcc-15.2.1-1.1/bin/arm-none-eabi-gcc ]; then
             make arm_sdk_install
           fi
 

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -4,6 +4,10 @@
 #
 ###############################################################
 
+# Pin the xPack GNU Arm Embedded GCC version used for local builds and CI.
+# Keep in sync with make/tools_install.mk (arm_sdk_install downloads this).
+XPACK_GCC_VER := 15.2.1-1.1
+XPACK_GCC_DIR := xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)
 
 ifeq ($(OS),Windows_NT)
 UNAME_O := $(shell uname -o 2>/dev/null)
@@ -16,7 +20,7 @@ endif
 endif
 
 ifeq ($(WIN_CMD_FLOW),1)
-ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+ARM_SDK_PREFIX:=tools/windows/$(XPACK_GCC_DIR)/bin/arm-none-eabi-
 SHELL:=cmd.exe
 CP:=tools\\windows\\make\\bin\\cp
 DSEP:=\\
@@ -29,7 +33,7 @@ OSDIR:=windows
 
 else ifeq ($(OS),Windows_NT)
 # Cygwin
-ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+ARM_SDK_PREFIX:=tools/windows/$(XPACK_GCC_DIR)/bin/arm-none-eabi-
 CP:=cp
 DSEP:=/
 NUL:=/dev/null
@@ -43,7 +47,7 @@ else
 # MacOS and Linux
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-ARM_SDK_PREFIX:=tools/macos/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+ARM_SDK_PREFIX:=tools/macos/$(XPACK_GCC_DIR)/bin/arm-none-eabi-
 CP:=cp
 DSEP:=/
 NUL:=/dev/null
@@ -54,7 +58,7 @@ FGREP:=fgrep
 OSDIR:=macos
 else
 # assume Linux
-ARM_SDK_PREFIX:=tools/linux/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+ARM_SDK_PREFIX:=tools/linux/$(XPACK_GCC_DIR)/bin/arm-none-eabi-
 CP:=cp
 DSEP:=/
 NUL:=/dev/null

--- a/make/tools_install.mk
+++ b/make/tools_install.mk
@@ -1,18 +1,45 @@
-# rules to download and install the tools for windows and linux
+# Download and install the tools used for local builds and GitHub CI.
+#
+# The Arm compiler is the xPack GNU Arm Embedded GCC release pinned by
+# XPACK_GCC_VER in make/tools.mk. Archives come from GitHub Releases so CI
+# does not depend on a separately hosted tools tarball staying in sync with
+# the path in tools.mk.
+#
+# Windows additionally still pulls windows-tools.zip for the make/ utilities
+# used by the Windows CI job (tools/windows/make/bin/make).
 
-# download location for tools
-WINDOWS_TOOLS=https://firmware.ardupilot.org/Tools/AM32-tools/windows-tools.zip
-LINUX_TOOLS=https://firmware.ardupilot.org/Tools/AM32-tools/linux-tools.tar.gz
-MACOS_TOOLS=https://firmware.ardupilot.org/Tools/AM32-tools/macos-tools.tar.gz
+# Shared pin (must match make/tools.mk)
+XPACK_GCC_VER ?= 15.2.1-1.1
+XPACK_GCC_DIR ?= xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)
+XPACK_GCC_REL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_GCC_VER)
+
+# Windows helper utilities (make, etc.) — not the compiler
+WINDOWS_TOOLS_UTILS := https://firmware.ardupilot.org/Tools/AM32-tools/windows-tools.zip
 
 ifeq ($(OS),Windows_NT)
 
+# Windows recipes run under cmd.exe (see tools.mk SHELL). Use PowerShell only.
 arm_sdk_install:
 	@echo Installing windows tools
-	@echo downloading windows-tools.zip
-	@powershell -Command "& { (New-Object System.Net.WebClient).DownloadFile('$(WINDOWS_TOOLS)', 'windows-tools.zip') }"
-	@echo unpacking windows-tools.zip
-	@powershell -Command "Expand-Archive -Path windows-tools.zip -Force -DestinationPath ."
+	@powershell -NoProfile -Command "\
+		if (-not (Test-Path 'tools/windows/make/bin/make.exe')) { \
+			Write-Host 'downloading windows-tools.zip (make utilities)'; \
+			(New-Object System.Net.WebClient).DownloadFile('$(WINDOWS_TOOLS_UTILS)', 'windows-tools.zip'); \
+			Write-Host 'unpacking windows-tools.zip'; \
+			Expand-Archive -Path windows-tools.zip -Force -DestinationPath .; \
+		}; \
+		if (-not (Test-Path 'tools/windows/$(XPACK_GCC_DIR)/bin/arm-none-eabi-gcc.exe')) { \
+			Write-Host 'downloading $(XPACK_GCC_DIR) (win32-x64)'; \
+			(New-Object System.Net.WebClient).DownloadFile( \
+				'$(XPACK_GCC_REL)/xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)-win32-x64.zip', \
+				'xpack-gcc-win.zip'); \
+			Write-Host 'unpacking xpack gcc into tools/windows/'; \
+			New-Item -ItemType Directory -Force -Path tools/windows | Out-Null; \
+			Expand-Archive -Path xpack-gcc-win.zip -Force -DestinationPath tools/windows; \
+			Remove-Item -Force xpack-gcc-win.zip -ErrorAction SilentlyContinue; \
+		} else { \
+			Write-Host 'already installed: tools/windows/$(XPACK_GCC_DIR)'; \
+		}"
 	@echo windows tools install done
 
 else
@@ -21,18 +48,46 @@ UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
 
+# Prefer native arm64 on Apple Silicon; fall back to x64 (Rosetta).
+MAC_XPACK_ARCH := $(shell uname -m | sed 's/x86_64/x64/;s/arm64/arm64/')
+ifeq ($(MAC_XPACK_ARCH),arm64)
+MAC_XPACK_ASSET := xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)-darwin-arm64.tar.gz
+else
+MAC_XPACK_ASSET := xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)-darwin-x64.tar.gz
+endif
+
 arm_sdk_install:
-	@echo Installing macos tools
-	@wget $(MACOS_TOOLS)
-	@tar xzf macos-tools.tar.gz
+	@echo Installing macos tools \(gcc $(XPACK_GCC_VER)\)
+	@if [ ! -x tools/macos/$(XPACK_GCC_DIR)/bin/arm-none-eabi-gcc ]; then \
+		echo "downloading $(MAC_XPACK_ASSET)"; \
+		mkdir -p tools/macos downloads; \
+		wget -q -O downloads/$(MAC_XPACK_ASSET) $(XPACK_GCC_REL)/$(MAC_XPACK_ASSET); \
+		tar -xzf downloads/$(MAC_XPACK_ASSET) -C tools/macos; \
+	else \
+		echo "already installed: tools/macos/$(XPACK_GCC_DIR)"; \
+	fi
 	@echo macos tools install done
 
 else
 
+# Linux x64 default (GitHub ubuntu-latest). arm64 runners can override via env.
+LINUX_XPACK_ARCH ?= $(shell uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
+ifeq ($(LINUX_XPACK_ARCH),arm64)
+LINUX_XPACK_ASSET := xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)-linux-arm64.tar.gz
+else
+LINUX_XPACK_ASSET := xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)-linux-x64.tar.gz
+endif
+
 arm_sdk_install:
-	@echo Installing linux tools
-	@wget $(LINUX_TOOLS)
-	@tar xzf linux-tools.tar.gz
+	@echo Installing linux tools \(gcc $(XPACK_GCC_VER)\)
+	@if [ ! -x tools/linux/$(XPACK_GCC_DIR)/bin/arm-none-eabi-gcc ]; then \
+		echo "downloading $(LINUX_XPACK_ASSET)"; \
+		mkdir -p tools/linux downloads; \
+		wget -q -O downloads/$(LINUX_XPACK_ASSET) $(XPACK_GCC_REL)/$(LINUX_XPACK_ASSET); \
+		tar -xzf downloads/$(LINUX_XPACK_ASSET) -C tools/linux; \
+	else \
+		echo "already installed: tools/linux/$(XPACK_GCC_DIR)"; \
+	fi
 	@echo linux tools install done
 
 endif


### PR DESCRIPTION
## Summary

- Pin **xPack GNU Arm Embedded GCC 15.2.1-1.1** in `make/tools.mk` (linux / macos / windows).
- Rewrite `make arm_sdk_install` to download that pin from GitHub Releases (no longer depends on the ardupilot-hosted gcc 10.3 tools tarball staying in sync with `ARM_SDK_PREFIX`). Windows still pulls `windows-tools.zip` only for `make` utilities.
- GitHub CI (`CICD_build.yml`, `hwci.yml`) installs/uses the same pin; hardware-CI requires the exact 15.2.1 path.
- Fix `checkDeviceInfo()` for GCC 12+ `-Warray-bounds` so the tree builds under 15.2.

## Bench (ark-release, `noprop_smoke_95pct_3a`, 3 A supply)

| Toolchain | hold95 | Max CPU | `.text` |
|---|---|---:|---:|
| gcc 10.3 (old pin) | PASS ~39.4k RPM | 84.2% | 24104 |
| gcc 14.2 | PASS | 83.9% | 24092 |
| **gcc 15.2** | PASS ~39.5k RPM | 81.3% | **23636 (−468 B)** |

Free-run steady CPU is essentially flat across compilers; 15.2 is mainly a size/toolchain hygiene win, not a free-run headroom miracle.

## Test plan

- [x] `make arm_sdk_install` (linux) — installs or reports already present
- [x] `make ARK_4IN1_F051 HWCI_PERF=1` with default pin — links as GCC 15.2.1
- [x] 95% no-prop / 3 A free-run hold on ARK 4IN1 stand
- [ ] GitHub `CI Build Linux` workflow green (linux + windows matrix)
- [ ] Optional: self-hosted `hwci` workflow once a runner has the new pin