### PR TITLE
Add SITL (software in the loop) simulation of a BLDC with GUI control

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.bat text eol=crlf

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -1,0 +1,102 @@
+name: SITL Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  sitl-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build SITL
+        run: make AM32_SITL_CAN
+
+      - name: Install pydronecan
+        run: python3 -m pip install dronecan
+
+      - name: Run SITL tests
+        run: |
+          mkdir sitl_test_run && cd sitl_test_run
+          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_2.20.elf
+
+      - name: Upload SITL log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sitl-test-log
+          path: sitl_test_run/sitl_ci.log
+
+  gui-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt system libraries
+        run: sudo apt-get update && sudo apt-get install -y libgl1 libegl1 libfontconfig1 libxkbcommon0
+
+      - name: Build SITL
+        run: make AM32_SITL_CAN
+
+      - name: Create GUI environment
+        run: python3 Mcu/SITL/make_gui_env.py
+
+      - name: Run GUI test (offscreen)
+        run: |
+          mkdir gui_test_run && cd gui_test_run
+          python3 ../Mcu/SITL/gui_ci_test.py \
+            --gui-python ../Mcu/SITL/venv/bin/python3 \
+            --sitl ../obj/AM32_AM32_SITL_CAN_2.20.elf
+
+      - name: Upload SITL log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-test-log
+          path: gui_test_run/sitl_ci.log
+
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Cygwin
+        uses: cygwin/cygwin-install-action@v4
+        with:
+          packages: gcc-core make
+
+      - name: Build SITL
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+        run: |
+          cd $(cygpath -u "$GITHUB_WORKSPACE")
+          make AM32_SITL_CAN
+          ls -la obj/
+
+      - name: Boot smoke test
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+        run: |
+          cd $(cygpath -u "$GITHUB_WORKSPACE")
+          ./obj/AM32_AM32_SITL_CAN_2.20.elf --can-uri none --input-type 1 >boot.log 2>&1 &
+          sleep 3
+          kill %1 || true
+          cat boot.log
+          grep -q "PWM/DShot input on udp port" boot.log
+          grep -q "state/model port udp" boot.log
+
+      - name: Package binary with cygwin runtime
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+        run: |
+          cd $(cygpath -u "$GITHUB_WORKSPACE")
+          mkdir -p sitl-windows
+          cp obj/AM32_AM32_SITL_CAN_*.elf sitl-windows/AM32_SITL_CAN.exe
+          cp /bin/cygwin1.dll sitl-windows/
+
+      - name: Upload Windows SITL binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: sitl-windows
+          path: sitl-windows/

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run SITL tests
         run: |
           mkdir sitl_test_run && cd sitl_test_run
-          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_2.20.elf
+          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_*.elf
 
       - name: Upload SITL log on failure
         if: failure()
@@ -50,7 +50,7 @@ jobs:
           mkdir gui_test_run && cd gui_test_run
           python3 ../Mcu/SITL/gui_ci_test.py \
             --gui-python ../Mcu/SITL/venv/bin/python3 \
-            --sitl ../obj/AM32_AM32_SITL_CAN_2.20.elf
+            --sitl ../obj/AM32_AM32_SITL_CAN_*.elf
 
       - name: Upload SITL log on failure
         if: failure()
@@ -73,7 +73,7 @@ jobs:
       - name: Run SITL tests
         run: |
           mkdir sitl_test_run && cd sitl_test_run
-          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_2.20.elf
+          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_*.elf
 
       - name: Upload SITL log on failure
         if: failure()
@@ -103,7 +103,7 @@ jobs:
         shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
         run: |
           cd $(cygpath -u "$GITHUB_WORKSPACE")
-          ./obj/AM32_AM32_SITL_CAN_2.20.elf --can-uri none --input-type 1 >boot.log 2>&1 &
+          ./obj/AM32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1 >boot.log 2>&1 &
           sleep 3
           kill %1 || true
           cat boot.log

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -2,37 +2,56 @@ name: SITL Tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "ark-release"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "ark-release"]
   workflow_dispatch:
 
 jobs:
   sitl-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       - name: Build SITL
         run: make AM32_SITL_CAN
 
-      - name: Install pydronecan
-        run: python3 -m pip install dronecan
+      - name: Install CI Python deps
+        run: |
+          python3 -m venv sitl-venv
+          sitl-venv/bin/pip install -U pip
+          sitl-venv/bin/pip install -r Mcu/SITL/requirements-ci.txt
 
-      - name: Run SITL tests
+      - name: Run SITL pytest suite
         run: |
           mkdir sitl_test_run && cd sitl_test_run
-          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_*.elf
+          ../sitl-venv/bin/python ../Mcu/SITL/run_ci_tests.py \
+            --sitl ../obj/AM32_AM32_SITL_CAN_*.elf \
+            --junitxml=sitl-results.xml
 
       - name: Upload SITL log on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: sitl-test-log
-          path: sitl_test_run/sitl_ci.log
+          path: |
+            sitl_test_run/sitl_ci.log
+            sitl_test_run/**/sitl_ci.log
+            sitl_test_run/sitl-results.xml
+          if-no-files-found: ignore
+
+      - name: Upload junit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sitl-junit
+          path: sitl_test_run/sitl-results.xml
+          if-no-files-found: ignore
 
   gui-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -58,32 +77,44 @@ jobs:
         with:
           name: gui-test-log
           path: gui_test_run/sitl_ci.log
+          if-no-files-found: ignore
 
   macos-tests:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       - name: Build SITL
         run: make AM32_SITL_CAN
 
-      - name: Install pydronecan
-        run: python3 -m pip install --break-system-packages dronecan
+      - name: Install CI Python deps
+        run: |
+          python3 -m venv sitl-venv
+          sitl-venv/bin/pip install -U pip
+          sitl-venv/bin/pip install -r Mcu/SITL/requirements-ci.txt
 
-      - name: Run SITL tests
+      - name: Run SITL pytest suite
         run: |
           mkdir sitl_test_run && cd sitl_test_run
-          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_*.elf
+          ../sitl-venv/bin/python ../Mcu/SITL/run_ci_tests.py \
+            --sitl ../obj/AM32_AM32_SITL_CAN_*.elf \
+            --junitxml=sitl-results.xml
 
       - name: Upload SITL log on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: sitl-test-log-macos
-          path: sitl_test_run/sitl_ci.log
+          path: |
+            sitl_test_run/sitl_ci.log
+            sitl_test_run/**/sitl_ci.log
+            sitl_test_run/sitl-results.xml
+          if-no-files-found: ignore
 
   windows-build:
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -59,6 +59,29 @@ jobs:
           name: gui-test-log
           path: gui_test_run/sitl_ci.log
 
+  macos-tests:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build SITL
+        run: make AM32_SITL_CAN
+
+      - name: Install pydronecan
+        run: python3 -m pip install --break-system-packages dronecan
+
+      - name: Run SITL tests
+        run: |
+          mkdir sitl_test_run && cd sitl_test_run
+          python3 ../Mcu/SITL/run_ci_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_2.20.elf
+
+      - name: Upload SITL log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sitl-test-log-macos
+          path: sitl_test_run/sitl_ci.log
+
   windows-build:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -79,39 +79,6 @@ jobs:
           path: gui_test_run/sitl_ci.log
           if-no-files-found: ignore
 
-  macos-tests:
-    runs-on: macos-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build SITL
-        run: make AM32_SITL_CAN
-
-      - name: Install CI Python deps
-        run: |
-          python3 -m venv sitl-venv
-          sitl-venv/bin/pip install -U pip
-          sitl-venv/bin/pip install -r Mcu/SITL/requirements-ci.txt
-
-      - name: Run SITL pytest suite
-        run: |
-          mkdir sitl_test_run && cd sitl_test_run
-          ../sitl-venv/bin/python ../Mcu/SITL/run_ci_tests.py \
-            --sitl ../obj/AM32_AM32_SITL_CAN_*.elf \
-            --junitxml=sitl-results.xml
-
-      - name: Upload SITL log on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: sitl-test-log-macos
-          path: |
-            sitl_test_run/sitl_ci.log
-            sitl_test_run/**/sitl_ci.log
-            sitl_test_run/sitl-results.xml
-          if-no-files-found: ignore
-
   windows-build:
     runs-on: windows-latest
     timeout-minutes: 20

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Mcu/SITL/venv/
 **/sitl_ci.log
 am32_eeprom.bin
 am32_eeprom.bin.lock
+am32_eeprom.bin.rtc

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ Keil_Projects/Listings
 windows-tools.zip
 .settings/
 Mcu/SITL/venv/
+.pytest_cache/
+**/__pycache__/
+**/sitl_ci.log
+am32_eeprom.bin
+am32_eeprom.bin.lock

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Keil_Projects/Listings
 /Debug/
 windows-tools.zip
 .settings/
+Mcu/SITL/venv/

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -353,6 +353,19 @@
 #define MILLIVOLT_PER_AMP 9
 #endif
 ///
+#ifdef AM32_SITL_CAN
+#define FIRMWARE_NAME "AM32 SITL"
+#define FILE_NAME "AM32_SITL_CAN"
+#define DRONECAN_SUPPORT 1
+#define DRONECAN_NODE_NAME "org.am32.sitl"
+#define DEAD_TIME 80
+#define HARDWARE_GROUP_SITL_A
+#define TARGET_STALL_PROTECTION_INTERVAL 20000
+#define TARGET_VOLTAGE_DIVIDER 110
+#define MILLIVOLT_PER_AMP 20
+#define CURRENT_OFFSET 0
+#endif
+
 #ifdef REF_G431
 #define FIRMWARE_NAME "Ref G431"
 #define FILE_NAME "REF_G431"
@@ -4065,6 +4078,12 @@
 
 #endif
 
+#ifdef HARDWARE_GROUP_SITL_A
+
+#define MCU_SITL
+
+#endif
+
 #ifdef HARDWARE_GROUP_G4_A
 
 #define MCU_G431
@@ -5561,6 +5580,30 @@
   #define COMPARATOR_IRQ   EXTI2_IRQn
 #endif
 
+#endif
+
+#ifdef MCU_SITL
+// software in the loop simulation, emulating a G431 class MCU with the
+// hardware replaced by a motor/battery simulation. See Mcu/SITL
+#define STMICRO
+#define CPU_FREQUENCY_MHZ 160
+#ifndef EEPROM_START_ADD
+#define EEPROM_START_ADD (uint32_t)0x0800F800
+#endif
+#define INTERVAL_TIMER TIM2
+#define TEN_KHZ_TIMER TIM6
+#define UTILITY_TIMER TIM17
+#define COM_TIMER TIM16
+#define APPLICATION_ADDRESS 0x08001000
+#define TARGET_MIN_BEMF_COUNTS 3
+#define COMPARATOR_IRQ SITL_IRQ_COMP
+#define COM_TIMER_IRQ SITL_IRQ_COM
+#define IC_DMA_IRQ_NAME SITL_IRQ_DMA
+#define USE_ADC
+#define DSHOT_PRIORITY_THRESHOLD 60
+// the SITL harness provides the real main(), the firmware main() is
+// started by the harness under this name
+#define main am32_main
 #endif
 
 #ifndef LOOP_FREQUENCY_HZ

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -1,5 +1,16 @@
 
 
+/*
+  ELF section placement for the flash layout tooling (app signature,
+  file name). Not meaningful for the SITL build and mach-o (macOS) has
+  a different section syntax, so it becomes a no-op there
+ */
+#ifdef __APPLE__
+#define AM32_FLASH_SECTION(name)
+#else
+#define AM32_FLASH_SECTION(name) __attribute__((section(name)))
+#endif
+
 #ifndef USE_MAKE
 // #define F031_DEV
 // #define FD6288_F051

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ has_can_suffix = $(findstring _CAN,$1)
 $(foreach MCU,$(MCU_TYPES),$(eval SVD_$(MCU) := $(wildcard $(HAL_FOLDER_$(MCU))/*.svd)))
 
 .PHONY : clean all binary $(foreach MCU,$(MCU_TYPES),$(call lc,$(MCU)))
-ALL_TARGETS := $(foreach MCU,$(MCU_TYPES),$(TARGETS_$(MCU)))
+# Host-native SITL is opt-in (`make AM32_SITL_CAN` / `make sitl`), not part of
+# the cross-compiled `make all` matrix used by Linux firmware CI.
+ALL_TARGETS := $(foreach MCU,$(filter-out SITL,$(MCU_TYPES)),$(TARGETS_$(MCU)))
 all : $(ALL_TARGETS)
 
 # create targets for compiling one mcu type, eg "make f421"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include $(ROOT)/make/tools.mk
 
 # supported MCU types
 
-MCU_TYPES := E230 F031 F051 F415 F421 G071 L431 G431 V203 G031 A153
+MCU_TYPES := E230 F031 F051 F415 F421 G071 L431 G431 V203 G031 A153 SITL
 
 MCU_TYPE := NONE
 
@@ -94,7 +94,8 @@ clean :
 define CREATE_BUILD_TARGET
 $(2)_BASENAME = $(BIN_DIR)/$(IDENTIFIER)_$(2)_$(FIRMWARE_VERSION)
 
-$(2) : $$($(2)_BASENAME).bin
+# native (SITL) targets build to an executable elf, no bin/hex conversion
+$(2) : $$($(2)_BASENAME).$(if $(NATIVE_$(1)),elf,bin)
 
 # get MCU specific compiler, objcopy and link script or use the ARM SDK one
 $(eval xCC := $(if $($(MCU)_CC), $($(MCU)_CC), $(CC)))
@@ -114,21 +115,26 @@ $(eval xLDSCRIPT := $$(if $$(call has_can_suffix,$$(2)),$(LDSCRIPT_CAN_$(1)),$(L
 $(eval xCFLAGS := $$(if $$(call has_can_suffix,$$(2)),$(CFLAGS_CAN_$(1))))
 $(eval xSRC := $$(if $$(call has_can_suffix,$$(2)),$(SRC_CAN_$(1))))
 
-CFLAGS_$(2) = -DAM32_MCU=\"$(MCU)\" $(MCU_$(1)) -D$(2) $(CFLAGS_$(1)) $(CFLAGS_COMMON) $(xCFLAGS)
-LDFLAGS_$(2) = $(LDFLAGS_COMMON) $(LDFLAGS_$(1)) -T$(xLDSCRIPT)
+# allow an MCU type to override the common compiler/linker flags (used by SITL
+# for a native build) and to have no linker script
+$(eval xCFLAGS_COMMON := $(if $(CFLAGS_COMMON_$(1)),$(CFLAGS_COMMON_$(1)),$(CFLAGS_COMMON)))
+$(eval xLDFLAGS_COMMON := $(if $(LDFLAGS_COMMON_$(1)),$(LDFLAGS_COMMON_$(1)),$(LDFLAGS_COMMON)))
+
+CFLAGS_$(2) = -DAM32_MCU=\"$(MCU)\" $(MCU_$(1)) -D$(2) $(CFLAGS_$(1)) $(xCFLAGS_COMMON) $(xCFLAGS)
+LDFLAGS_$(2) = $(xLDFLAGS_COMMON) $(LDFLAGS_$(1)) $(if $(xLDSCRIPT),-T$(xLDSCRIPT))
 
 -include $$($(2)_BASENAME).d
 
 $$($(2)_BASENAME).elf: $(SRC_COMMON) $$(SRC_$(1)) $(xSRC)
 	@$(ECHO) Compiling $$(notdir $$@)
 	$(QUIET)$(MKDIR) -p $(OBJ)
-	$(QUIET)$(xCC) $$(CFLAGS_$(2)) $$(LDFLAGS_$(2)) -MMD -MP -MF $$(@:.elf=.d) -o $$(@) $(SRC_COMMON) $$(SRC_$(1)) $(xSRC)
+	$(QUIET)$(xCC) $$(CFLAGS_$(2)) $$(LDFLAGS_$(2)) -MMD -MP -MF $$(@:.elf=.d) -o $$(@) $(SRC_COMMON) $$(SRC_$(1)) $(xSRC) $(LDLIBS_$(1))
 # we copy debug.elf to give us a constant debug target for vscode
 # this means the debug button will always debug the last target built
-	$(QUIET)$(CP) -f $$(SVD_$(1)) $(OBJ)/debug.svd
+	$(if $(SVD_$(1)),$(QUIET)$(CP) -f $$(SVD_$(1)) $(OBJ)/debug.svd)
 # also copy the openocd.cfg from the MCU directory to obj/openocd.cfg for auto config of Cortex-Debug
 # in vscode
-	$(QUIET)$(CP) -f Mcu$(DSEP)$(call lc,$(1))$(DSEP)openocd.cfg $(OBJ)$(DSEP)openocd.cfg > $(NUL)
+	$(if $(NATIVE_$(1)),,$(QUIET)$(CP) -f Mcu$(DSEP)$(call lc,$(1))$(DSEP)openocd.cfg $(OBJ)$(DSEP)openocd.cfg > $(NUL))
 endef
 $(foreach MCU,$(MCU_TYPES),$(foreach TARGET,$(TARGETS_$(MCU)), $(eval $(call CREATE_BUILD_TARGET,$(MCU),$(TARGET)))))
 

--- a/Mcu/SITL/Inc/ADC.h
+++ b/Mcu/SITL/Inc/ADC.h
@@ -1,0 +1,16 @@
+/*
+ * ADC.h - SITL
+ */
+
+#include "main.h"
+#include "targets.h"
+
+#ifndef ADC_H_
+#define ADC_H_
+
+void ADC_DMA_Callback(void);
+void enableADC_DMA(void);
+void activateADC(void);
+void ADC_Init(void);
+
+#endif /* ADC_H_ */

--- a/Mcu/SITL/Inc/IO.h
+++ b/Mcu/SITL/Inc/IO.h
@@ -1,0 +1,27 @@
+/*
+ * IO.h - SITL (dshot/servo input is not supported, stubs only)
+ */
+
+#ifndef IO_H_
+#define IO_H_
+
+#include "main.h"
+
+void changeToOutput(void);
+void changeToInput(void);
+void receiveDshotDma(void);
+void sendDshotDma(void);
+
+uint8_t getInputPinState(void);
+void setInputPolarityRising(void);
+void setInputPullDown(void);
+void setInputPullUp(void);
+void enableHalfTransferInt(void);
+void setInputPullNone(void);
+
+extern volatile char inputSet;
+extern char dshot;
+extern volatile char servoPwm;
+extern volatile char send_telemetry;
+
+#endif /* IO_H_ */

--- a/Mcu/SITL/Inc/comparator.h
+++ b/Mcu/SITL/Inc/comparator.h
@@ -1,0 +1,18 @@
+/*
+ * comparator.h - SITL
+ */
+
+#ifndef COMPARATOR_H_
+#define COMPARATOR_H_
+
+#include "main.h"
+
+uint8_t getCompOutputLevel(void);
+void maskPhaseInterrupts(void);
+void enableCompInterrupts(void);
+void changeCompInput(void);
+
+extern volatile char rising;
+extern char step;
+
+#endif /* COMPARATOR_H_ */

--- a/Mcu/SITL/Inc/main.h
+++ b/Mcu/SITL/Inc/main.h
@@ -1,0 +1,60 @@
+/*
+  main.h for the SITL "MCU". Provides just enough of the STM32 LL/CMSIS
+  surface for the shared firmware sources to build natively, backed by the
+  emulation in Mcu/SITL/Src
+ */
+
+#ifndef __MAIN_H
+#define __MAIN_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "sitl.h"
+#include "sitl_nvic.h"
+
+// emulated timers. Dereferencing syncs CNT from simulated time
+#define TIM1 sitl_tim_deref(SITL_TIM1_IDX)
+#define TIM2 sitl_tim_deref(SITL_TIM2_IDX)
+#define TIM6 sitl_tim_deref(SITL_TIM6_IDX)
+#define TIM16 sitl_tim_deref(SITL_TIM16_IDX)
+#define TIM17 sitl_tim_deref(SITL_TIM17_IDX)
+
+// minimal register structs so common.h externs compile
+typedef struct {
+    volatile uint32_t IDR;
+    volatile uint32_t ODR;
+    volatile uint32_t BSRR;
+    volatile uint32_t BRR;
+} GPIO_TypeDef;
+
+typedef struct {
+    volatile uint32_t CSR;
+} COMP_TypeDef;
+
+extern GPIO_TypeDef sitl_gpio_dummy;
+extern COMP_TypeDef sitl_comp_dummy[2];
+#define GPIOA (&sitl_gpio_dummy)
+#define GPIOB (&sitl_gpio_dummy)
+#define COMP1 (&sitl_comp_dummy[0])
+#define COMP2 (&sitl_comp_dummy[1])
+
+// ADC: the simulation provides the raw values directly, conversion start
+// is a no-op and the "temperature calculation" is a pass through (the
+// simulation stores degrees C in ADC_raw_temp)
+#define ADC1 0
+#define LL_ADC_REG_StartConversion(adc) do { (void)(adc); } while (0)
+#define LL_ADC_RESOLUTION_12B 0
+#define __LL_ADC_CALC_TEMPERATURE(vref, raw, res) ((int32_t)(raw))
+
+// watchdog
+#define IWDG 0
+#define LL_IWDG_ReloadCounter(wdg) sitl_watchdog_reload()
+
+#ifndef RESET
+#define RESET 0
+#endif
+
+void Error_Handler(void);
+
+#endif /* __MAIN_H */

--- a/Mcu/SITL/Inc/peripherals.h
+++ b/Mcu/SITL/Inc/peripherals.h
@@ -1,0 +1,46 @@
+/*
+  peripherals.h for the SITL MCU. Same macro API as the g431 version with
+  the register pokes routed into the emulation
+ */
+
+#ifndef PERIPHERALS_H_
+#define PERIPHERALS_H_
+#endif /* PERIPHERALS_H_ */
+
+#include "ADC.h"
+#include "main.h"
+
+#define INTERVAL_TIMER_COUNT (sitl_interval_timer_count())
+#define RELOAD_WATCHDOG_COUNTER() sitl_watchdog_reload()
+#define DISABLE_COM_TIMER_INT() sitl_com_int_disable()
+#define ENABLE_COM_TIMER_INT() sitl_com_int_enable()
+#define SET_AND_ENABLE_COM_INT(time) sitl_com_int_arm(time)
+#define SET_INTERVAL_TIMER_COUNT(intertime) sitl_interval_timer_set(intertime)
+#define SET_PRESCALER_PWM(presc) sitl_tim1_set_psc(presc)
+#define SET_AUTO_RELOAD_PWM(relval) sitl_tim1_set_arr(relval)
+#define SET_DUTY_CYCLE_ALL(newdc) sitl_tim1_set_duty_all(newdc)
+
+void initAfterJump(void);
+void initCorePeripherals(void);
+void SystemClock_Config(void);
+void MX_GPIO_Init(void);
+void MX_DMA_Init(void);
+void MX_ADC1_Init(void);
+void MX_COMP2_Init(void);
+void MX_COMP1_Init(void);
+void MX_TIM1_Init(void);
+void MX_TIM2_Init(void);
+void MX_TIM3_Init(void);
+void MX_TIM14_Init(void);
+void MX_TIM17_Init(void);
+void MX_TIM16_Init(void);
+void MX_IWDG_Init(void);
+void MX_TIM6_Init(void);
+void MX_TIM15_Init(void);
+void resetInputCaptureTimer(void);
+void setPWMCompare1(uint16_t compareone);
+void setPWMCompare2(uint16_t comparetwo);
+void setPWMCompare3(uint16_t comparethree);
+void enableCorePeripherals(void);
+void reloadWatchDogCounter(void);
+void generatePwmTimerEvent(void);

--- a/Mcu/SITL/Inc/phaseouts.h
+++ b/Mcu/SITL/Inc/phaseouts.h
@@ -1,0 +1,18 @@
+/*
+ * phaseouts.h - SITL
+ */
+
+#ifndef PHASEOUTS_H_
+#define PHASEOUTS_H_
+
+#include "main.h"
+
+extern void allOff(void);
+extern void comStep(int newStep);
+extern void fullBrake(void);
+extern void allpwm(void);
+extern void proportionalBrake(void);
+extern void twoChannelForward(void);
+extern void twoChannelReverse(void);
+
+#endif /* PHASEOUTS_H_ */

--- a/Mcu/SITL/Inc/serial_telemetry.h
+++ b/Mcu/SITL/Inc/serial_telemetry.h
@@ -1,0 +1,13 @@
+/*
+ * serial_telemetry.h - SITL stub
+ */
+
+#include "main.h"
+
+#ifndef SERIAL_TELEMETRY_H_
+#define SERIAL_TELEMETRY_H_
+
+void telem_UART_Init(void);
+void send_telem_DMA(uint8_t bytes);
+
+#endif /* SERIAL_TELEMETRY_H_ */

--- a/Mcu/SITL/Inc/sitl.h
+++ b/Mcu/SITL/Inc/sitl.h
@@ -75,6 +75,7 @@ void sitl_nvic_disable_irq(int irq);
 void sitl_irq_pend(int irq);
 void sitl_primask_set(void); // __disable_irq
 void sitl_primask_clear(void); // __enable_irq
+uint32_t sitl_primask_get(void); // __get_PRIMASK
 void sitl_system_reset(void) __attribute__((noreturn));
 
 // watchdog

--- a/Mcu/SITL/Inc/sitl.h
+++ b/Mcu/SITL/Inc/sitl.h
@@ -31,7 +31,7 @@ enum sitl_irq {
 
 // PWM/DShot input over UDP (sitl_input.c)
 void sitl_input_init(void);
-void sitl_input_poll(void); // sim thread, every 100us
+void sitl_input_poll(void); // sim thread, every physics step
 void sitl_input_arm(void); // receiveDshotDma()
 void sitl_input_timer_reset(void); // resetInputCaptureTimer()
 void sitl_input_send_reply(void); // sendDshotDma()

--- a/Mcu/SITL/Inc/sitl.h
+++ b/Mcu/SITL/Inc/sitl.h
@@ -118,6 +118,9 @@ void sitl_timers_init(void);
 // side compare is active for the current TIM1 counter phase
 bool sitl_tim1_pwm_out(int chan, uint64_t now_ns);
 
+// dead time in ns decoded from the emulated TIM1 BDTR DTG field
+uint32_t sitl_tim1_dead_time_ns(void);
+
 // EXTI emulation for the comparator lines
 #define SITL_EXTI_LINE_21 (1UL << 21)
 #define SITL_EXTI_LINE_22 (1UL << 22)

--- a/Mcu/SITL/Inc/sitl.h
+++ b/Mcu/SITL/Inc/sitl.h
@@ -39,6 +39,11 @@ void sitl_input_dma_irq(void); // DMA transfer complete handler
 uint8_t sitl_input_pin_state(void); // getInputPinState()
 void sitl_input_stats(uint32_t out[4]);
 
+// simulation state streaming + runtime model control (sitl_state.c)
+void sitl_state_init(void);
+void sitl_state_poll(void); // sim thread, every 100us
+void sitl_state_step(uint64_t now_ns); // sim thread, every physics step
+
 // simulated monotonic time since start
 uint64_t sitl_time_ns(void);
 

--- a/Mcu/SITL/Inc/sitl.h
+++ b/Mcu/SITL/Inc/sitl.h
@@ -47,6 +47,9 @@ void sitl_state_step(uint64_t now_ns); // sim thread, every physics step
 // simulated monotonic time since start
 uint64_t sitl_time_ns(void);
 
+// a non blocking close-on-exec UDP socket (sitl_compat.c)
+int sitl_udp_socket(void);
+
 // true when called from the sim thread (i.e. from interrupt context)
 bool sitl_in_sim_thread(void);
 

--- a/Mcu/SITL/Inc/sitl.h
+++ b/Mcu/SITL/Inc/sitl.h
@@ -23,11 +23,21 @@ enum sitl_irq {
     SITL_IRQ_COMP = 0, // BEMF comparator EXTI
     SITL_IRQ_COM, // commutation timer (TIM16) update
     SITL_IRQ_TENKHZ, // 20kHz loop timer (TIM6)
-    SITL_IRQ_DMA, // input capture DMA (unused, dshot not supported)
-    SITL_IRQ_EXTI15, // software interrupt for dshot (unused)
+    SITL_IRQ_DMA, // input capture DMA (PWM/DShot over UDP)
+    SITL_IRQ_EXTI15, // software interrupt for dshot processing
     SITL_IRQ_CAN, // CAN frame RX poll
     SITL_IRQ_MAX
 };
+
+// PWM/DShot input over UDP (sitl_input.c)
+void sitl_input_init(void);
+void sitl_input_poll(void); // sim thread, every 100us
+void sitl_input_arm(void); // receiveDshotDma()
+void sitl_input_timer_reset(void); // resetInputCaptureTimer()
+void sitl_input_send_reply(void); // sendDshotDma()
+void sitl_input_dma_irq(void); // DMA transfer complete handler
+uint8_t sitl_input_pin_state(void); // getInputPinState()
+void sitl_input_stats(uint32_t out[4]);
 
 // simulated monotonic time since start
 uint64_t sitl_time_ns(void);

--- a/Mcu/SITL/Inc/sitl.h
+++ b/Mcu/SITL/Inc/sitl.h
@@ -1,0 +1,152 @@
+/*
+  sitl.h - internal API of the AM32 SITL runtime
+
+  The firmware runs unmodified in one thread ("firmware thread") while a
+  second thread ("sim thread") owns simulated time, the motor physics and
+  delivery of emulated interrupts. Interrupt handlers always execute in the
+  sim thread with the firmware thread suspended, giving the same
+  run-to-completion semantics as a real MCU.
+
+  All state shared between the two threads is either written through the
+  helpers here or is a plain volatile word. x86 total-store-ordering is
+  assumed.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// emulated interrupt sources, in NVIC style. Default priorities are set to
+// match the g431 target, main.c re-prioritises at runtime
+enum sitl_irq {
+    SITL_IRQ_COMP = 0, // BEMF comparator EXTI
+    SITL_IRQ_COM, // commutation timer (TIM16) update
+    SITL_IRQ_TENKHZ, // 20kHz loop timer (TIM6)
+    SITL_IRQ_DMA, // input capture DMA (unused, dshot not supported)
+    SITL_IRQ_EXTI15, // software interrupt for dshot (unused)
+    SITL_IRQ_CAN, // CAN frame RX poll
+    SITL_IRQ_MAX
+};
+
+// simulated monotonic time since start
+uint64_t sitl_time_ns(void);
+
+// true when called from the sim thread (i.e. from interrupt context)
+bool sitl_in_sim_thread(void);
+
+// advance the simulation by one physics step. Only legal from the sim
+// thread; used so that busy loops inside interrupt handlers (delayMicros,
+// comparator filter re-reads) still see time advance
+void sitl_step_from_isr(void);
+
+// account for one register/comparator read from interrupt context. Each
+// read costs sim.isr_read_ns (about what a peripheral read costs on the
+// real MCU); whole physics steps run once enough time has accumulated
+void sitl_isr_read_tick(void);
+
+// account for a register read from the firmware thread; grants simulated
+// time while the firmware holds PRIMASK
+void sitl_fw_read_tick(void);
+
+
+// NVIC emulation
+void sitl_nvic_set_priority(int irq, uint32_t prio);
+void sitl_nvic_enable_irq(int irq);
+void sitl_nvic_disable_irq(int irq);
+void sitl_irq_pend(int irq);
+void sitl_primask_set(void); // __disable_irq
+void sitl_primask_clear(void); // __enable_irq
+void sitl_system_reset(void) __attribute__((noreturn));
+
+// watchdog
+void sitl_watchdog_reload(void);
+void sitl_watchdog_enable(void);
+
+// timers (see sitl_timers.c)
+enum sitl_tim_idx {
+    SITL_TIM1_IDX = 0, // PWM timer, 160MHz, ARR/CCR preloaded
+    SITL_TIM2_IDX, // INTERVAL_TIMER, 2MHz, 32 bit
+    SITL_TIM6_IDX, // TEN_KHZ_TIMER, 1MHz, periodic update
+    SITL_TIM16_IDX, // COM_TIMER, 2MHz, update interrupt
+    SITL_TIM17_IDX, // UTILITY_TIMER, 1MHz, 16 bit free running
+    SITL_NUM_TIMS
+};
+
+typedef struct {
+    volatile uint32_t CNT;
+    volatile uint32_t ARR;
+    volatile uint32_t PSC;
+    volatile uint32_t DIER;
+    volatile uint32_t SR;
+    volatile uint32_t BDTR;
+    volatile uint32_t CCR1;
+    volatile uint32_t CCR2;
+    volatile uint32_t CCR3;
+} SITL_TIM_TypeDef;
+
+// dereference an emulated timer, syncing CNT from simulated time
+SITL_TIM_TypeDef* sitl_tim_deref(int idx);
+
+uint32_t sitl_interval_timer_count(void);
+void sitl_interval_timer_set(uint32_t cnt);
+void sitl_com_int_arm(uint32_t time);
+void sitl_com_int_disable(void);
+void sitl_com_int_enable(void);
+void sitl_tim1_set_duty_all(uint16_t duty);
+void sitl_tim1_set_duty(int chan, uint16_t duty);
+void sitl_tim1_set_psc(uint16_t psc);
+void sitl_tim1_set_arr(uint16_t arr);
+void sitl_tim1_force_update(void);
+void sitl_tenkhz_enable(void);
+
+// called by the sim thread each physics step to check timer events
+void sitl_timers_step(uint64_t now_ns);
+void sitl_timers_init(void);
+
+// PWM output sampling for the physics (phase 0..2), true when the high
+// side compare is active for the current TIM1 counter phase
+bool sitl_tim1_pwm_out(int chan, uint64_t now_ns);
+
+// EXTI emulation for the comparator lines
+#define SITL_EXTI_LINE_21 (1UL << 21)
+#define SITL_EXTI_LINE_22 (1UL << 22)
+
+typedef struct {
+    volatile uint32_t IMR;
+    volatile uint32_t RTSR;
+    volatile uint32_t FTSR;
+    volatile uint32_t PR;
+} sitl_exti_t;
+
+extern sitl_exti_t sitl_exti;
+
+// bridge output modes per phase, set by phaseouts.c, read by the physics
+enum sitl_phase_mode {
+    SITL_PHASE_FLOAT = 0, // both fets off
+    SITL_PHASE_LOW, // low side on
+    SITL_PHASE_PWM, // high side pwm, low side complementary if comp_pwm
+    SITL_PHASE_PWM_NOCOMP, // high side pwm, low side off
+    SITL_PHASE_BRAKE_PWM, // low side driven by complementary pwm
+};
+
+extern volatile uint8_t sitl_phase_mode[3];
+
+// comparator state: which phase is floating and the latched output
+extern volatile uint8_t sitl_comp_phase; // 0=A 1=B 2=C
+extern volatile uint8_t sitl_comp_out;
+
+// sensor snapshot from the physics, seqlock protected
+typedef struct {
+    float bus_voltage; // V at the ESC input
+    float bus_current; // A into the bridge
+    float temperature_c;
+    float rpm; // mechanical, signed
+} sitl_sensors_t;
+
+void sitl_sensors_read(sitl_sensors_t* out);
+void sitl_sensors_write(const sitl_sensors_t* in); // sim thread only
+
+// lifecycle
+void sitl_start_sim_thread(void);
+extern char** sitl_saved_argv;

--- a/Mcu/SITL/Inc/sitl_nvic.h
+++ b/Mcu/SITL/Inc/sitl_nvic.h
@@ -1,0 +1,36 @@
+/*
+  sitl_nvic.h - CMSIS style interrupt controls mapped onto the SITL runtime
+ */
+
+#pragma once
+
+#include "sitl.h"
+
+typedef int IRQn_Type;
+
+static inline void NVIC_SetPriority(IRQn_Type irq, uint32_t prio)
+{
+    sitl_nvic_set_priority(irq, prio);
+}
+
+static inline void NVIC_EnableIRQ(IRQn_Type irq)
+{
+    sitl_nvic_enable_irq(irq);
+}
+
+static inline void NVIC_DisableIRQ(IRQn_Type irq)
+{
+    sitl_nvic_disable_irq(irq);
+}
+
+#define NVIC_SystemReset() sitl_system_reset()
+
+static inline void __disable_irq(void)
+{
+    sitl_primask_set();
+}
+
+static inline void __enable_irq(void)
+{
+    sitl_primask_clear();
+}

--- a/Mcu/SITL/Inc/sitl_nvic.h
+++ b/Mcu/SITL/Inc/sitl_nvic.h
@@ -34,3 +34,8 @@ static inline void __enable_irq(void)
 {
     sitl_primask_clear();
 }
+
+static inline uint32_t __get_PRIMASK(void)
+{
+    return sitl_primask_get();
+}

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -140,6 +140,25 @@ stream stops) followed by zero-throttle re-arming. Running both inputs
 at once exercises exactly this behaviour, which is what the input
 priority/failover parameter work is developing against.
 
+## Windows
+
+The SITL builds under Cygwin (packages: gcc-core, make) with the same
+`make AM32_SITL_CAN`, producing a native console executable, and the
+POSIX signal based scheduler runs correctly under the Cygwin runtime.
+The GUI uses a normal Windows python: `py Mcu/SITL/make_gui_env.py`
+creates the environment and prints the interpreter to use; after that
+`sitl_gui.bat` in the repository root launches the GUI (double click or
+from cmd, extra arguments are passed through). Notes:
+
+- to run the binary from outside a Cygwin shell (cmd, double click),
+  copy `C:\cygwin64\bin\cygwin1.dll` next to it - its only Cygwin
+  dependency (the CI artifact ships it bundled).
+- Windows Firewall must allow inbound UDP for the SITL binary (or ports
+  57732-57734) for CAN and the input/state ports to receive.
+- a socket never receives its own multicast on Windows, so the CAN TX
+  self test is skipped there; on a machine with several interfaces pass
+  an explicit one as `--can-uri mcast:0:<ip>`.
+
 ## Headless / CI use
 
 Everything runs without a display: the SITL is a plain console binary

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -1,0 +1,82 @@
+# AM32 SITL (software in the loop)
+
+Runs the AM32 firmware as a native Linux executable against a simulation
+of the motor, bridge and battery, with DroneCAN input/output over
+multicast UDP. This allows testing of the firmware logic (startup,
+commutation, DroneCAN protocol, parameters) without ESC hardware.
+
+## Building
+
+```
+make AM32_SITL_CAN
+```
+
+produces `obj/AM32_AM32_SITL_CAN_<version>.elf`, a normal Linux
+executable.
+
+## Running
+
+```
+obj/AM32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
+```
+
+Options:
+
+- `--config FILE` JSON file with motor/battery/esc/sim properties (see
+  `example.json`, all keys optional)
+- `--eeprom FILE` eeprom backing file (default `am32_eeprom.bin`). A
+  missing file is seeded with the AM32 configurator default settings
+- `--can-uri URI` CAN interface, default `mcast:0` (group 239.65.82.N
+  port 57732, wire compatible with libcanard and ArduPilot SITL)
+- `--node-id N` force the DroneCAN node ID, otherwise DNA is used
+- `--speedup X` simulation speed relative to wall clock, 0 = free running
+- `--uid STR` string used to derive the 16 byte unique ID
+- `--verbose` 1Hz state line on stderr
+- `--nosleep` busy wait instead of sleeping. Uses two full CPU cores but
+  avoids OS sleep/wakeup latency for the most accurate wall clock pacing
+
+The virtual ESC can then be controlled with the DroneCAN GUI tool or
+pydronecan on `mcast:0`. A test script is included:
+
+```
+python3 Mcu/SITL/sitl_can_test.py --throttle 0.5 --duration 20
+```
+
+which arms, ramps the throttle via `esc.RawCommand` and reports the
+`esc.Status` telemetry (RPM, voltage, current, temperature).
+
+Note that with no DroneCAN traffic directed at the node it will reboot
+every 2 seconds from the firmware signal-timeout logic, exactly as real
+hardware does. Reboots (including `RestartNode` and watchdog resets)
+re-exec the process; the eeprom file persists.
+
+Each instance holds a lock on its eeprom file: two instances sharing an
+eeprom (and therefore a node ID) would interleave their DroneCAN
+transfers on the bus, which shows up as erratic telemetry. To run
+multiple ESCs give each its own `--eeprom` and `--node-id`.
+
+## Architecture
+
+The firmware runs unmodified (built as `am32_main()`) in one thread. A
+simulation thread owns simulated time, advancing it in fixed physics
+steps (500ns default) and delivering emulated interrupts (BEMF
+comparator, commutation timer, 20kHz loop timer, CAN RX) by suspending
+the firmware thread with a signal and running the handler, reproducing
+the run-to-completion interrupt semantics of the real MCU. Simulated
+time is decoupled from wall time and paced to `--speedup`.
+
+The emulated MCU follows the G431 target: TIM1 PWM generation with
+preloaded ARR/CCR, a 2MHz interval timer, one-shot commutation timer,
+20kHz loop timer and 1MHz utility timer, plus comparator/EXTI blanking
+behaviour matching `Mcu/g431`. Timer reads from interrupt context step
+the physics, so `delayMicros()` inside handlers and the comparator
+filter loop behave as on hardware.
+
+The motor model (`sim/motor.c`) is a trapezoidal back-EMF BLDC model
+based on open-bldc-csim: per-phase currents, solved star point voltage
+(so the floating phase terminal voltage and its zero crossings are
+physical), fet Rds_on, body diode clamping of a floating phase carrying
+current, and battery voltage sag from internal resistance. The
+comparator compares the floating phase against the virtual neutral with
+configurable noise and hysteresis, so the firmware's blanking and
+filtering logic is genuinely exercised at PWM switching level.

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -35,6 +35,9 @@ Options:
   disables)
 - `--state-port N` UDP port for high rate simulation state streaming
   and runtime motor model loading (default 57734, 0 disables)
+- `--bind-any` bind the input and state ports on all interfaces instead
+  of loopback only, needed when the GUI runs on a different host. The
+  ports accept unauthenticated control, so only use on trusted networks
 - `--input-type N` force the eeprom INPUT_SIGNAL_TYPE setting (0=auto
   1=dshot 2=servo 5=dronecan)
 - `--speedup X` simulation speed relative to wall clock, 0 = free running

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -33,6 +33,8 @@ Options:
 - `--node-id N` force the DroneCAN node ID, otherwise DNA is used
 - `--input-port N` UDP port for PWM/DShot input (default 57733, 0
   disables)
+- `--state-port N` UDP port for high rate simulation state streaming
+  and runtime motor model loading (default 57734, 0 disables)
 - `--input-type N` force the eeprom INPUT_SIGNAL_TYPE setting (0=auto
   1=dshot 2=servo 5=dronecan)
 - `--speedup X` simulation speed relative to wall clock, 0 = free running
@@ -89,7 +91,21 @@ Tools in `Mcu/SITL/`:
 - `sitl_gui.py` — Qt (PySide6) GUI driving both the PWM/DShot input and
   DroneCAN input with per-input enable switches (for failover testing),
   BDShot/EDT and esc.Status telemetry with rates, and an
-  `INPUT_SIGNAL_TYPE` parameter panel. `--control-port N` accepts UI
+  `INPUT_SIGNAL_TYPE` parameter panel. The simulation panel selects the
+  motor model (the JSON files in `Mcu/SITL/models/`, applied to the
+  running simulation over the state port; switch at zero throttle for
+  clean results) and has optional high rate views, both default off:
+  pyqtgraph scopes of the phase currents and the phase terminal
+  voltages, each in its own window (sample period down to the 500ns
+  physics step and adjustable window; the sample rate is automatically
+  limited to about 200k samples/s of wall clock, so fine periods take
+  effect as the speedup is lowered — the PWM dead time diode conduction
+  is visible on the voltages at fine sample periods), and a motor/bridge
+  animation showing rotor angle, per phase bridge modes and the
+  comparator. A speedup slider (0.01x to 2x)
+  changes the simulation pace at runtime, for watching the animation in
+  slow motion; input frames arriving faster than the slowed simulation
+  consumes them are dropped, as on a real wire. `--control-port N` accepts UI
   commands over a localhost TCP connection for scripted tests (default
   off); `--log FILE` records every UI action with timestamps and
   `--replay FILE` plays a recording back, so a failing interactive

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -140,6 +140,31 @@ stream stops) followed by zero-throttle re-arming. Running both inputs
 at once exercises exactly this behaviour, which is what the input
 priority/failover parameter work is developing against.
 
+## Headless / CI use
+
+Everything runs without a display: the SITL is a plain console binary
+and the GUI works under Qt's offscreen platform
+(`QT_QPA_PLATFORM=offscreen`) driven through `--control-port`, so full
+interactive scenarios can run in CI. On a minimal Debian/Ubuntu the
+requirements are:
+
+```
+apt install gcc make python3 python3-venv \
+    libgl1 libegl1 libfontconfig1 libxkbcommon0
+pip install dronecan        # for the DroneCAN tests
+python3 Mcu/SITL/make_gui_env.py   # for GUI-driven tests
+```
+
+Multicast CAN over loopback works on a stock VM with no route
+configuration (the SITL self-tests its TX at startup). Timing notes for
+slow or virtualised runners: the simulation paces itself and reports
+the achieved ratio in `--verbose` (x1.00 = real time); the python test
+senders keep their average frame rate under coarse sleep granularity by
+sending catch-up bursts, which matters because the firmware's
+bidirectional DShot auto-detect needs more than 100 frames before
+zero-throttle arming completes, putting a floor of roughly 100Hz on the
+usable frame rate.
+
 ## Architecture
 
 The firmware runs unmodified (built as `am32_main()`) in one thread. A

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -140,6 +140,13 @@ stream stops) followed by zero-throttle re-arming. Running both inputs
 at once exercises exactly this behaviour, which is what the input
 priority/failover parameter work is developing against.
 
+## macOS
+
+Builds and runs natively (Apple Silicon or Intel) with the stock Xcode
+command line tools: `make AM32_SITL_CAN`. The GUI bootstrap is the same
+`python3 Mcu/SITL/make_gui_env.py`. Multicast CAN over loopback works
+without configuration.
+
 ## Windows
 
 The SITL builds under Cygwin (packages: gcc-core, make) with the same

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -12,7 +12,12 @@ make AM32_SITL_CAN
 ```
 
 produces `obj/AM32_AM32_SITL_CAN_<version>.elf`, a normal Linux
-executable.
+executable. SITL is **not** part of `make all` (that target stays
+cross-firmware only); use `make sitl` or the product name above.
+
+Also note: RTC backup registers used by DroneCAN boot/FW-update handoff
+persist across SITL re-execs in a sibling file `<eeprom>.rtc` next to the
+eeprom backing file.
 
 ## Running
 
@@ -40,7 +45,8 @@ Options:
   ports accept unauthenticated control, so only use on trusted networks
 - `--input-type N` force the eeprom INPUT_SIGNAL_TYPE setting (0=auto
   1=dshot 2=servo 5=dronecan)
-- `--speedup X` simulation speed relative to wall clock, 0 = free running
+- `--speedup X` simulation speed relative to wall clock, 0 = free
+  running; clamped to `[0, 100]` (same as the GUI/state-port control)
 - `--uid STR` string used to derive the 16 byte unique ID
 - `--verbose` 1Hz state line on stderr
 - `--nosleep` busy wait instead of sleeping. Uses two full CPU cores but

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -27,8 +27,14 @@ Options:
 - `--eeprom FILE` eeprom backing file (default `am32_eeprom.bin`). A
   missing file is seeded with the AM32 configurator default settings
 - `--can-uri URI` CAN interface, default `mcast:0` (group 239.65.82.N
-  port 57732, wire compatible with libcanard and ArduPilot SITL)
+  port 57732, wire compatible with libcanard and ArduPilot SITL). An
+  optional interface may be given (`mcast:0:lo`). `none` disables CAN,
+  for pure PWM/DShot testing
 - `--node-id N` force the DroneCAN node ID, otherwise DNA is used
+- `--input-port N` UDP port for PWM/DShot input (default 57733, 0
+  disables)
+- `--input-type N` force the eeprom INPUT_SIGNAL_TYPE setting (0=auto
+  1=dshot 2=servo 5=dronecan)
 - `--speedup X` simulation speed relative to wall clock, 0 = free running
 - `--uid STR` string used to derive the 16 byte unique ID
 - `--verbose` 1Hz state line on stderr
@@ -54,6 +60,69 @@ Each instance holds a lock on its eeprom file: two instances sharing an
 eeprom (and therefore a node ID) would interleave their DroneCAN
 transfers on the bus, which shows up as erratic telemetry. To run
 multiple ESCs give each its own `--eeprom` and `--node-id`.
+
+## PWM/DShot input over UDP
+
+The SITL listens on a UDP port (default 57733) for PWM or DShot input
+frames. Each packet is one frame on the virtual signal wire, synthesized
+into input-capture edge timestamps and decoded by the firmware's
+unmodified `Src/signal.c`/`Src/dshot.c` logic, including input type
+auto-detection, CRC checking, zero-throttle arming, DShot commands and
+bidirectional DShot auto-detect (idle high line).
+
+packet format (little endian):
+
+| field | size | meaning |
+|-------|------|---------|
+| magic | u16  | 0x4453 |
+| type  | u8   | 0=PWM 1=DSHOT150 2=DSHOT300 3=DSHOT600 |
+| len   | u8   | payload bytes after the header (4) |
+| flags | u16  | bit0: line idle level (1 = idle high, bidir DShot) |
+| data  | u16  | PWM pulse width in us, or the full 16 bit DShot frame |
+
+Bidirectional DShot replies (eRPM plus extended telemetry frames) are
+sent back to the most recent sender in the same format, with `data`
+carrying the 16 bit GCR-decoded reply frame.
+
+Tools in `Mcu/SITL/`:
+
+- `sitl_gui.py` — Qt (PySide6) GUI driving both the PWM/DShot input and
+  DroneCAN input with per-input enable switches (for failover testing),
+  BDShot/EDT and esc.Status telemetry with rates, and an
+  `INPUT_SIGNAL_TYPE` parameter panel. `--control-port N` accepts UI
+  commands over a localhost TCP connection for scripted tests (default
+  off); `--log FILE` records every UI action with timestamps and
+  `--replay FILE` plays a recording back, so a failing interactive
+  session can be reproduced exactly. Install the
+  dependencies (PySide6, pyqtgraph, dronecan; Linux/Windows/macOS) into
+  a self-contained environment with
+
+```
+python3 Mcu/SITL/make_gui_env.py
+```
+
+  which creates `Mcu/SITL/venv` and prints the interpreter to run the
+  GUI with. A system python with the packages from
+  `Mcu/SITL/requirements-gui.txt` installed works too. The UI backends
+  live in `sitl_gui_backend.py`, UI-independent for headless tests
+- `dshot_test.py` — headless scripted test (arming, throttle, EDT,
+  bad-CRC injection), e.g.:
+
+```
+obj/AM32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1
+python3 Mcu/SITL/dshot_test.py --type dshot600 --bidir --edt --throttle 800
+```
+
+Note that the eeprom default `INPUT_SIGNAL_TYPE` is DRONECAN_IN, which
+disables the PWM/DShot input interrupts at startup — set it to 0/1/2
+first (via `--input-type`, the GUI parameter panel, or
+`dshot_test.py --input-type`). Also be aware of the current firmware
+input arbitration: once any `esc.RawCommand` has been received, the 1kHz
+DroneCAN input keep-alive overrides the `dshot`/`inputSet` flags and
+PWM/DShot input is dead until a reboot (signal timeout after the CAN
+stream stops) followed by zero-throttle re-arming. Running both inputs
+at once exercises exactly this behaviour, which is what the input
+priority/failover parameter work is developing against.
 
 ## Architecture
 

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -180,9 +180,23 @@ requirements are:
 ```
 apt install gcc make python3 python3-venv \
     libgl1 libegl1 libfontconfig1 libxkbcommon0
-pip install dronecan        # for the DroneCAN tests
+python3 -m venv sitl-venv && sitl-venv/bin/pip install -r Mcu/SITL/requirements-ci.txt
 python3 Mcu/SITL/make_gui_env.py   # for GUI-driven tests
 ```
+
+Build and run the pytest suite (boot, DShot/BDShot/EDT, PWM, DroneCAN
+throttle + arming, parameter GetSet/save, motor model load):
+
+```
+make AM32_SITL_CAN
+sitl-venv/bin/python Mcu/SITL/run_ci_tests.py
+# or: sitl-venv/bin/pytest Mcu/SITL/tests -v --sitl obj/AM32_AM32_SITL_CAN_*.elf
+```
+
+`run_ci_tests.py` prefers pytest; pass `--legacy` for the smaller
+stdlib-only smoke suite. The GitHub Actions workflow
+`.github/workflows/SITL.yml` runs this on every push/PR to `main` and
+`ark-release` (plus a GUI offscreen job and Windows/macOS checks).
 
 Multicast CAN over loopback works on a stock VM with no route
 configuration (the SITL self-tests its TX at startup). Timing notes for

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -196,7 +196,7 @@ sitl-venv/bin/python Mcu/SITL/run_ci_tests.py
 `run_ci_tests.py` prefers pytest; pass `--legacy` for the smaller
 stdlib-only smoke suite. The GitHub Actions workflow
 `.github/workflows/SITL.yml` runs this on every push/PR to `main` and
-`ark-release` (plus a GUI offscreen job and Windows/macOS checks).
+`ark-release` (plus a GUI offscreen job and a Windows build/smoke job).
 
 Multicast CAN over loopback works on a stock VM with no route
 configuration (the SITL self-tests its TX at startup). Timing notes for

--- a/Mcu/SITL/Src/ADC.c
+++ b/Mcu/SITL/Src/ADC.c
@@ -1,0 +1,37 @@
+/*
+  ADC.c - SITL. Converts the simulation sensor values into the raw ADC
+  counts the firmware expects, inverting the conversions in main.c
+ */
+
+#include "ADC.h"
+
+#include "sitl.h"
+#include "targets.h"
+
+extern uint16_t ADC_raw_temp;
+extern uint16_t ADC_raw_volts;
+extern uint16_t ADC_raw_current;
+
+void ADC_DMA_Callback(void)
+{
+    sitl_sensors_t s;
+    sitl_sensors_read(&s);
+
+    // main.c: battery_voltage(10mV) = raw * 3300 / 4095 * VOLTAGE_DIVIDER / 100
+    const float pin_mv_volts = s.bus_voltage * 1000.0f * 10.0f / TARGET_VOLTAGE_DIVIDER;
+    ADC_raw_volts = (uint16_t)(pin_mv_volts * 4095.0f / 3300.0f + 0.5f);
+
+    // main.c: actual_current(10mA) = ((raw*3300/41) - CURRENT_OFFSET*100) / MILLIVOLT_PER_AMP
+    float pin_mv_current = s.bus_current * MILLIVOLT_PER_AMP + CURRENT_OFFSET;
+    if (pin_mv_current < 0) {
+        pin_mv_current = 0;
+    }
+    ADC_raw_current = (uint16_t)(pin_mv_current * 4095.0f / 3300.0f + 0.5f);
+
+    // __LL_ADC_CALC_TEMPERATURE is a pass through in SITL
+    ADC_raw_temp = (uint16_t)(s.temperature_c + 0.5f);
+}
+
+void ADC_Init(void) { }
+void enableADC_DMA(void) { }
+void activateADC(void) { }

--- a/Mcu/SITL/Src/IO.c
+++ b/Mcu/SITL/Src/IO.c
@@ -1,25 +1,36 @@
 /*
-  IO.c - SITL stubs. DShot/servo signal input is not supported in SITL,
-  input comes from DroneCAN
+  IO.c - SITL signal IO. DShot/servo input arrives as UDP packets handled
+  by sitl_input.c, which emulates the input capture timer + DMA
  */
 
 #include "IO.h"
 
+#include "sitl.h"
 #include "targets.h"
 
 uint32_t dma_buffer[64];
 volatile char out_put;
-char ic_timer_prescaler;
+char ic_timer_prescaler = CPU_FREQUENCY_MHZ / 6;
 uint8_t buffer_padding;
 
 void changeToOutput(void) { }
 void changeToInput(void) { }
-void receiveDshotDma(void) { }
-void sendDshotDma(void) { }
+
+void receiveDshotDma(void)
+{
+    out_put = 0;
+    sitl_input_arm();
+}
+
+void sendDshotDma(void)
+{
+    out_put = 1;
+    sitl_input_send_reply();
+}
 
 uint8_t getInputPinState(void)
 {
-    return 1; // idle high, no signal
+    return sitl_input_pin_state();
 }
 
 void setInputPolarityRising(void) { }

--- a/Mcu/SITL/Src/IO.c
+++ b/Mcu/SITL/Src/IO.c
@@ -1,0 +1,29 @@
+/*
+  IO.c - SITL stubs. DShot/servo signal input is not supported in SITL,
+  input comes from DroneCAN
+ */
+
+#include "IO.h"
+
+#include "targets.h"
+
+uint32_t dma_buffer[64];
+volatile char out_put;
+char ic_timer_prescaler;
+uint8_t buffer_padding;
+
+void changeToOutput(void) { }
+void changeToInput(void) { }
+void receiveDshotDma(void) { }
+void sendDshotDma(void) { }
+
+uint8_t getInputPinState(void)
+{
+    return 1; // idle high, no signal
+}
+
+void setInputPolarityRising(void) { }
+void setInputPullDown(void) { }
+void setInputPullUp(void) { }
+void setInputPullNone(void) { }
+void enableHalfTransferInt(void) { }

--- a/Mcu/SITL/Src/comparator.c
+++ b/Mcu/SITL/Src/comparator.c
@@ -1,0 +1,72 @@
+/*
+  comparator.c - SITL BEMF comparator emulation. Mirrors the g431 logic:
+  the floating phase is compared against the virtual neutral point, EXTI
+  edge selection follows `rising` (rising BEMF arms a falling edge on the
+  comparator output)
+ */
+
+#include "comparator.h"
+
+#include "common.h"
+#include "sitl.h"
+#include "targets.h"
+
+sitl_exti_t sitl_exti;
+
+volatile uint8_t sitl_comp_phase = 2;
+volatile uint8_t sitl_comp_out;
+
+COMP_TypeDef* active_COMP = &sitl_comp_dummy[1];
+uint32_t current_EXTI_LINE = SITL_EXTI_LINE_22;
+
+uint8_t getCompOutputLevel(void)
+{
+    if (sitl_in_sim_thread()) {
+        // called from interrupt context (filter loop in interruptRoutine):
+        // account for the read time so consecutive reads see fresh samples
+        sitl_isr_read_tick();
+    }
+    return sitl_comp_out;
+}
+
+void maskPhaseInterrupts(void)
+{
+    sitl_exti.IMR &= ~(SITL_EXTI_LINE_21 | SITL_EXTI_LINE_22);
+    sitl_exti.PR &= ~(SITL_EXTI_LINE_21 | SITL_EXTI_LINE_22);
+}
+
+void enableCompInterrupts(void)
+{
+    sitl_exti.IMR |= current_EXTI_LINE;
+    // as on the STM32: an edge that latched PR while masked fires as
+    // soon as the interrupt is unmasked
+    if (sitl_exti.PR & current_EXTI_LINE) {
+        sitl_irq_pend(SITL_IRQ_COMP);
+    }
+}
+
+void changeCompInput(void)
+{
+    if (step == 1 || step == 4) { // c floating
+        sitl_comp_phase = 2;
+        current_EXTI_LINE = SITL_EXTI_LINE_22;
+        active_COMP = &sitl_comp_dummy[1];
+    }
+    if (step == 2 || step == 5) { // a floating
+        sitl_comp_phase = 0;
+        current_EXTI_LINE = SITL_EXTI_LINE_21;
+        active_COMP = &sitl_comp_dummy[0];
+    }
+    if (step == 3 || step == 6) { // b floating
+        sitl_comp_phase = 1;
+        current_EXTI_LINE = SITL_EXTI_LINE_22;
+        active_COMP = &sitl_comp_dummy[1];
+    }
+    if (rising) {
+        sitl_exti.RTSR &= ~(SITL_EXTI_LINE_21 | SITL_EXTI_LINE_22);
+        sitl_exti.FTSR |= current_EXTI_LINE;
+    } else { // falling bemf
+        sitl_exti.RTSR |= current_EXTI_LINE;
+        sitl_exti.FTSR &= ~(SITL_EXTI_LINE_21 | SITL_EXTI_LINE_22);
+    }
+}

--- a/Mcu/SITL/Src/eeprom.c
+++ b/Mcu/SITL/Src/eeprom.c
@@ -47,6 +47,15 @@ void read_flash_bin(uint8_t* data, uint32_t add, int out_buff_len)
                 len = out_buff_len;
             }
             memcpy(data, def, len);
+            if (out_buff_len > 27) {
+                // make the seeded settings describe the simulated motor,
+                // as a properly configured ESC would: a mismatched
+                // MOTOR_KV makes low rpm power protection clamp the duty
+                // at the wrong rpm. eeprom offsets 26/27 = motor_kv/poles,
+                // kv is stored as (kv-20)/40
+                data[26] = (uint8_t)((sitl_cfg.motor.kv - 20.0f) / 40.0f + 0.5f);
+                data[27] = (uint8_t)sitl_cfg.motor.poles;
+            }
         }
         return;
     }

--- a/Mcu/SITL/Src/eeprom.c
+++ b/Mcu/SITL/Src/eeprom.c
@@ -1,0 +1,58 @@
+/*
+  eeprom.c - SITL flash emulation backed by a file. The firmware reads and
+  writes 192 bytes at eeprom_address; the offset within the backing file is
+  relative to EEPROM_START_ADD
+ */
+
+#include "eeprom.h"
+
+#include "sitl_config.h"
+#include "targets.h"
+
+#include <stdio.h>
+#include <string.h>
+
+void save_flash_nolib(uint8_t* data, int length, uint32_t add)
+{
+    const uint32_t offset = add - EEPROM_START_ADD;
+    FILE* f = fopen(sitl_cfg.eeprom_path, "r+b");
+    if (!f) {
+        f = fopen(sitl_cfg.eeprom_path, "w+b");
+    }
+    if (!f) {
+        perror("SITL: eeprom open");
+        return;
+    }
+    fseek(f, offset, SEEK_SET);
+    fwrite(data, 1, length, f);
+    fclose(f);
+}
+
+// provided by DroneCAN.c on CAN builds: the AM32 configurator default
+// settings, used to seed a missing eeprom file so first boot behaves like
+// a factory flashed ESC rather than erased flash
+const uint8_t* DroneCAN_default_settings(unsigned* len) __attribute__((weak));
+
+void read_flash_bin(uint8_t* data, uint32_t add, int out_buff_len)
+{
+    const uint32_t offset = add - EEPROM_START_ADD;
+    // erased flash reads as 0xFF
+    memset(data, 0xFF, out_buff_len);
+    FILE* f = fopen(sitl_cfg.eeprom_path, "rb");
+    if (!f) {
+        if (DroneCAN_default_settings != NULL && offset == 0) {
+            unsigned len = 0;
+            const uint8_t* def = DroneCAN_default_settings(&len);
+            if ((int)len > out_buff_len) {
+                len = out_buff_len;
+            }
+            memcpy(data, def, len);
+        }
+        return;
+    }
+    fseek(f, offset, SEEK_SET);
+    if (fread(data, 1, out_buff_len, f) < (size_t)out_buff_len) {
+        // short file, rest stays 0xFF
+    }
+    fclose(f);
+}

--- a/Mcu/SITL/Src/peripherals.c
+++ b/Mcu/SITL/Src/peripherals.c
@@ -1,0 +1,114 @@
+/*
+  peripherals.c - SITL clock/peripheral bring-up, mirroring the g431
+  version with the hardware replaced by the emulation
+ */
+
+#include "peripherals.h"
+
+#include "ADC.h"
+#include "comparator.h"
+#include "sitl.h"
+#include "targets.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+GPIO_TypeDef sitl_gpio_dummy;
+COMP_TypeDef sitl_comp_dummy[2];
+
+void initAfterJump(void) { }
+
+void SystemClock_Config(void) { }
+void MX_GPIO_Init(void) { }
+void MX_DMA_Init(void) { }
+void MX_COMP1_Init(void) { }
+void MX_COMP2_Init(void) { }
+void MX_TIM2_Init(void) { }
+void MX_TIM3_Init(void) { }
+void MX_TIM15_Init(void) { }
+void MX_TIM17_Init(void) { }
+
+void MX_TIM1_Init(void)
+{
+    sitl_tim1_set_psc(0);
+    sitl_tim1_set_arr(TIM1_AUTORELOAD);
+    sitl_tim1_force_update();
+}
+
+void MX_TIM6_Init(void)
+{
+    sitl_tim_deref(SITL_TIM6_IDX)->ARR = 1000000 / LOOP_FREQUENCY_HZ;
+}
+
+void MX_TIM16_Init(void) { }
+
+void MX_IWDG_Init(void)
+{
+    sitl_watchdog_enable();
+}
+
+void initCorePeripherals(void)
+{
+    sitl_timers_init();
+    SystemClock_Config();
+    MX_GPIO_Init();
+    MX_DMA_Init();
+    MX_TIM1_Init();
+    MX_TIM2_Init();
+    MX_TIM6_Init();
+    MX_TIM16_Init();
+    MX_TIM17_Init();
+    MX_COMP1_Init();
+    MX_COMP2_Init();
+}
+
+void enableCorePeripherals(void)
+{
+    // default NVIC priorities matching the g431 target
+    sitl_nvic_set_priority(SITL_IRQ_COMP, 0);
+    sitl_nvic_set_priority(SITL_IRQ_COM, 0);
+    sitl_nvic_set_priority(SITL_IRQ_TENKHZ, 2);
+    sitl_nvic_set_priority(SITL_IRQ_DMA, 1);
+    sitl_nvic_set_priority(SITL_IRQ_EXTI15, 3);
+    sitl_nvic_set_priority(SITL_IRQ_CAN, 4);
+
+    sitl_nvic_enable_irq(SITL_IRQ_COMP);
+    sitl_nvic_enable_irq(SITL_IRQ_COM);
+    sitl_nvic_enable_irq(SITL_IRQ_TENKHZ);
+    sitl_nvic_enable_irq(SITL_IRQ_CAN);
+
+    sitl_tenkhz_enable();
+}
+
+void setPWMCompare1(uint16_t compareone)
+{
+    sitl_tim1_set_duty(0, compareone);
+}
+
+void setPWMCompare2(uint16_t comparetwo)
+{
+    sitl_tim1_set_duty(1, comparetwo);
+}
+
+void setPWMCompare3(uint16_t comparethree)
+{
+    sitl_tim1_set_duty(2, comparethree);
+}
+
+void generatePwmTimerEvent(void)
+{
+    sitl_tim1_force_update();
+}
+
+void resetInputCaptureTimer(void) { }
+
+void reloadWatchDogCounter(void)
+{
+    sitl_watchdog_reload();
+}
+
+void Error_Handler(void)
+{
+    fprintf(stderr, "SITL: Error_Handler called\n");
+    exit(1);
+}

--- a/Mcu/SITL/Src/peripherals.c
+++ b/Mcu/SITL/Src/peripherals.c
@@ -32,6 +32,9 @@ void MX_TIM1_Init(void)
 {
     sitl_tim1_set_psc(0);
     sitl_tim1_set_arr(TIM1_AUTORELOAD);
+    // dead time as on the g431 target; loadEEpromSettings ORs
+    // dead_time_override into BDTR on top of this
+    sitl_tim_deref(SITL_TIM1_IDX)->BDTR = DEAD_TIME;
     sitl_tim1_force_update();
 }
 

--- a/Mcu/SITL/Src/peripherals.c
+++ b/Mcu/SITL/Src/peripherals.c
@@ -69,12 +69,14 @@ void enableCorePeripherals(void)
     sitl_nvic_set_priority(SITL_IRQ_COM, 0);
     sitl_nvic_set_priority(SITL_IRQ_TENKHZ, 2);
     sitl_nvic_set_priority(SITL_IRQ_DMA, 1);
-    sitl_nvic_set_priority(SITL_IRQ_EXTI15, 3);
+    sitl_nvic_set_priority(SITL_IRQ_EXTI15, 2);
     sitl_nvic_set_priority(SITL_IRQ_CAN, 4);
 
     sitl_nvic_enable_irq(SITL_IRQ_COMP);
     sitl_nvic_enable_irq(SITL_IRQ_COM);
     sitl_nvic_enable_irq(SITL_IRQ_TENKHZ);
+    sitl_nvic_enable_irq(SITL_IRQ_DMA);
+    sitl_nvic_enable_irq(SITL_IRQ_EXTI15);
     sitl_nvic_enable_irq(SITL_IRQ_CAN);
 
     sitl_tenkhz_enable();
@@ -100,7 +102,10 @@ void generatePwmTimerEvent(void)
     sitl_tim1_force_update();
 }
 
-void resetInputCaptureTimer(void) { }
+void resetInputCaptureTimer(void)
+{
+    sitl_input_timer_reset();
+}
 
 void reloadWatchDogCounter(void)
 {

--- a/Mcu/SITL/Src/phaseouts.c
+++ b/Mcu/SITL/Src/phaseouts.c
@@ -1,0 +1,114 @@
+/*
+  phaseouts.c - SITL bridge output control. Instead of GPIO mode changes
+  each phase gets a mode that the motor simulation samples together with
+  the emulated TIM1 to derive fet gate states
+ */
+
+#include "phaseouts.h"
+
+#include "common.h"
+#include "sitl.h"
+#include "targets.h"
+
+volatile uint8_t sitl_phase_mode[3];
+
+static void phasePWM(int p)
+{
+    if (!eepromBuffer.comp_pwm) {
+        sitl_phase_mode[p] = SITL_PHASE_PWM_NOCOMP;
+    } else {
+        sitl_phase_mode[p] = SITL_PHASE_PWM;
+    }
+}
+
+static void phaseFLOAT(int p)
+{
+    sitl_phase_mode[p] = SITL_PHASE_FLOAT;
+}
+
+static void phaseLOW(int p)
+{
+    sitl_phase_mode[p] = SITL_PHASE_LOW;
+}
+
+void proportionalBrake(void)
+{
+    for (int p = 0; p < 3; p++) {
+        sitl_phase_mode[p] = SITL_PHASE_BRAKE_PWM;
+    }
+}
+
+void allOff(void)
+{
+    phaseFLOAT(0);
+    phaseFLOAT(1);
+    phaseFLOAT(2);
+}
+
+// commutation debug logging in the simulation
+extern void motor_log_commutation(int step);
+
+void comStep(int newStep)
+{
+    motor_log_commutation(newStep);
+    switch (newStep) {
+    case 1: // A-B
+        phasePWM(0);
+        phaseLOW(1);
+        phaseFLOAT(2);
+        break;
+    case 2: // C-B
+        phaseFLOAT(0);
+        phaseLOW(1);
+        phasePWM(2);
+        break;
+    case 3: // C-A
+        phaseLOW(0);
+        phaseFLOAT(1);
+        phasePWM(2);
+        break;
+    case 4: // B-A
+        phaseLOW(0);
+        phasePWM(1);
+        phaseFLOAT(2);
+        break;
+    case 5: // B-C
+        phaseFLOAT(0);
+        phasePWM(1);
+        phaseLOW(2);
+        break;
+    case 6: // A-C
+        phasePWM(0);
+        phaseFLOAT(1);
+        phaseLOW(2);
+        break;
+    }
+}
+
+void fullBrake(void)
+{
+    phaseLOW(0);
+    phaseLOW(1);
+    phaseLOW(2);
+}
+
+void allpwm(void)
+{
+    phasePWM(0);
+    phasePWM(1);
+    phasePWM(2);
+}
+
+void twoChannelForward(void)
+{
+    phasePWM(0);
+    phaseLOW(1);
+    phasePWM(2);
+}
+
+void twoChannelReverse(void)
+{
+    phaseLOW(0);
+    phasePWM(1);
+    phaseLOW(2);
+}

--- a/Mcu/SITL/Src/serial_telemetry.c
+++ b/Mcu/SITL/Src/serial_telemetry.c
@@ -1,0 +1,12 @@
+/*
+  serial_telemetry.c - SITL stub
+ */
+
+#include "serial_telemetry.h"
+
+void telem_UART_Init(void) { }
+
+void send_telem_DMA(uint8_t bytes)
+{
+    (void)bytes;
+}

--- a/Mcu/SITL/Src/sitl_compat.c
+++ b/Mcu/SITL/Src/sitl_compat.c
@@ -19,6 +19,10 @@ int sitl_udp_socket(void)
     if (fd >= 0) {
         fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
         fcntl(fd, F_SETFD, FD_CLOEXEC);
+        // Without this, a failed send() on a connected UDP socket raises
+        // SIGPIPE (process exit -13) instead of returning -1/EPIPE.
+        const int one = 1;
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
     }
     return fd;
 #else

--- a/Mcu/SITL/Src/sitl_compat.c
+++ b/Mcu/SITL/Src/sitl_compat.c
@@ -1,0 +1,27 @@
+/*
+  sitl_compat.c - small portability helpers for non Linux hosts
+ */
+
+#include "sitl.h"
+
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+/*
+  a non blocking, close-on-exec UDP socket. macOS has no
+  SOCK_NONBLOCK/SOCK_CLOEXEC socket() flags
+ */
+int sitl_udp_socket(void)
+{
+#ifdef __APPLE__
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd >= 0) {
+        fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
+        fcntl(fd, F_SETFD, FD_CLOEXEC);
+    }
+    return fd;
+#else
+    return socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+#endif
+}

--- a/Mcu/SITL/Src/sitl_input.c
+++ b/Mcu/SITL/Src/sitl_input.c
@@ -280,9 +280,20 @@ void sitl_input_dma_irq(void)
 
 /*
   called from the sim thread every physics step: service deferred DMA
-  IRQs, then drain the UDP input socket (up to SITL_INPUT_DRAIN_MAX
-  packets). DMA complete for a received frame is deferred until the last
-  synthesized edge time so frame duration is visible in sim time.
+  IRQs, then pull UDP frames. DMA complete for a received frame is
+  deferred until the last synthesized edge time so frame duration is
+  visible in sim time.
+
+  Wire-busy policy:
+  - BDShot TX or RX DMA still waiting for the last edge: stop receiving
+    and leave remaining datagrams queued. Consuming them would destroy
+    DShot command bursts (firmware needs 6 identical commands) that
+    GUI/catch-up senders place in the socket at once.
+  - Capture not armed: drain and drop (same as a real wire with no
+    DMA arm) so the socket does not accumulate stale zero-throttle
+    frames that would delay a later throttle change.
+  - After accepting a full capture: stop this poll so the rest of a
+    burst stays queued for the next free window.
  */
 void sitl_input_poll(void)
 {
@@ -292,6 +303,10 @@ void sitl_input_poll(void)
     service_deferred_dma();
 
     for (int n = 0; n < SITL_INPUT_DRAIN_MAX; n++) {
+        // short busy windows: keep UDP queued for the next free step
+        if (out_put || dma_done_ns != 0) {
+            break;
+        }
         struct input_pkt pkt;
         struct sockaddr_in src;
         socklen_t srclen = sizeof(src);
@@ -309,9 +324,7 @@ void sitl_input_poll(void)
         last_type = pkt.type;
         pin_idle_level = (pkt.flags & SITL_INPUT_FLAG_IDLE_HIGH) ? 1 : 0;
         stats.frames++;
-        // capture not armed, reply TX on the wire, or RX DMA still
-        // waiting for the last edge: frame is lost, as on a real wire
-        if (!cap_armed || out_put || dma_done_ns != 0) {
+        if (!cap_armed) {
             stats.dropped++;
             continue;
         }
@@ -321,6 +334,7 @@ void sitl_input_poll(void)
             // complete at the last edge (or immediately if already past)
             dma_done_ns = last_edge_ns ? last_edge_ns : sitl_time_ns();
             service_deferred_dma();
+            break;
         }
     }
 }

--- a/Mcu/SITL/Src/sitl_input.c
+++ b/Mcu/SITL/Src/sitl_input.c
@@ -1,0 +1,307 @@
+/*
+  sitl_input.c - PWM/DShot signal input over UDP for the AM32 SITL
+
+  Emulates the g431 input capture timer + DMA: each UDP packet carries one
+  frame on the virtual signal wire (a servo pulse or a complete 16 bit
+  DShot frame). Edge timestamps are synthesized in ticks of the emulated
+  capture timer and fed through the firmware's unmodified detection and
+  decode logic in Src/signal.c and Src/dshot.c, including input type
+  auto-detection, CRC checking and bidirectional DShot auto-detect.
+
+  Bidirectional DShot replies (eRPM and extended telemetry) are decoded
+  from the firmware's GCR output buffer and sent back to the most recent
+  sender in the same packet format.
+
+  packet format (little endian):
+    u16 magic 0x4453
+    u8  type: 0=PWM, 1=DSHOT150, 2=DSHOT300, 3=DSHOT600
+    u8  len: payload bytes after the 6 byte header (4)
+    u16 flags: bit0 = line idle level (1 = idle high, ie. inverted
+               bidirectional DShot)
+    u16 data: PWM pulse width in microseconds, or the full 16 bit DShot
+              frame (11 bit value, telemetry bit, 4 bit CRC)
+ */
+
+#include "targets.h"
+#include "common.h"
+#include "dshot.h"
+#include "IO.h"
+#include "sitl.h"
+#include "sitl_config.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define SITL_INPUT_MAGIC 0x4453
+
+enum sitl_input_type {
+    SITL_INPUT_PWM = 0,
+    SITL_INPUT_DSHOT150 = 1,
+    SITL_INPUT_DSHOT300 = 2,
+    SITL_INPUT_DSHOT600 = 3,
+};
+
+#define SITL_INPUT_FLAG_IDLE_HIGH 0x0001
+
+struct __attribute__((packed)) input_pkt {
+    uint16_t magic;
+    uint8_t type;
+    uint8_t len;
+    uint16_t flags;
+    uint16_t data;
+};
+
+extern void transfercomplete(void);
+extern const char gcr_encode_table[16];
+extern volatile char out_put;
+
+static int fd = -1;
+static struct sockaddr_in last_sender;
+static bool have_sender;
+
+/*
+  virtual input capture peripheral, mirroring TIM15 + DMA on the g431:
+  reset-on-arm timer at 160MHz/(prescaler+1), capture values are the
+  timer count mod 65536 at each signal edge
+ */
+static volatile bool cap_armed;
+static uint8_t cap_psc; // prescaler sampled at arm
+static uint32_t cap_count; // DMA CNDTR equivalent
+static uint32_t cap_index;
+static uint64_t cap_base_ns; // sim time of CNT=0
+
+static volatile uint8_t pin_idle_level; // from the last packet flags
+static uint8_t last_type = SITL_INPUT_DSHOT300;
+static uint64_t tx_done_ns; // sim time the BDShot reply transmit completes
+
+static struct {
+    uint32_t frames;
+    uint32_t dropped;
+    uint32_t replies;
+    uint32_t bad_gcr;
+} stats;
+
+void sitl_input_init(void)
+{
+    if (sitl_cfg.input_port <= 0) {
+        return;
+    }
+    fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        perror("SITL: input socket");
+        return;
+    }
+    const int one = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)sitl_cfg.input_port);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+        perror("SITL: input bind");
+        close(fd);
+        fd = -1;
+        return;
+    }
+    fprintf(stderr, "SITL: PWM/DShot input on udp port %d\n", sitl_cfg.input_port);
+}
+
+// capture timer count at a simulated time, in ticks of 6.25ns*(psc+1)
+static uint32_t cap_cnt_at(uint64_t t_ns)
+{
+    const uint64_t elapsed = t_ns - cap_base_ns;
+    return (uint32_t)((elapsed * 4U) / (25ULL * (cap_psc + 1U))) & 0xffffU;
+}
+
+void sitl_input_arm(void)
+{
+    cap_armed = false;
+    cap_psc = (uint8_t)ic_timer_prescaler;
+    cap_count = buffersize;
+    cap_index = 0;
+    cap_base_ns = sitl_time_ns();
+    cap_armed = true;
+}
+
+void sitl_input_timer_reset(void)
+{
+    // resetInputCaptureTimer(): PSC=0, CNT=0, capture DMA untouched
+    cap_psc = 0;
+    cap_base_ns = sitl_time_ns();
+}
+
+uint8_t sitl_input_pin_state(void)
+{
+    return pin_idle_level;
+}
+
+static void add_edge(uint64_t t_ns)
+{
+    if (cap_index < cap_count && cap_index < 64) {
+        dma_buffer[cap_index++] = cap_cnt_at(t_ns);
+    }
+}
+
+static void synth_frame(uint8_t type, uint16_t data)
+{
+    const uint64_t now = sitl_time_ns();
+    if (type == SITL_INPUT_PWM) {
+        // one pulse: rising then falling edge
+        add_edge(now);
+        add_edge(now + data * 1000ULL);
+        return;
+    }
+    uint32_t bit_ns;
+    switch (type) {
+    case SITL_INPUT_DSHOT150:
+        bit_ns = 6667;
+        break;
+    case SITL_INPUT_DSHOT300:
+        bit_ns = 3333;
+        break;
+    case SITL_INPUT_DSHOT600:
+    default:
+        bit_ns = 1667;
+        break;
+    }
+    // 16 bits MSB first, T1H = 0.75T, T0H = 0.375T. Polarity does not
+    // change the captured values with both-edge capture
+    for (int i = 0; i < 16; i++) {
+        const uint64_t start = now + (uint64_t)i * bit_ns;
+        const uint32_t high_ns = (data & (0x8000U >> i)) ? (bit_ns * 3U) / 4U : (bit_ns * 3U) / 8U;
+        add_edge(start);
+        add_edge(start + high_ns);
+    }
+}
+
+/*
+  decode the firmware's GCR output buffer back to the 16 bit BDShot reply
+  frame. gcr[bp] is the pre-transition idle level; the 21 bit line code is
+  gcr[bp+1..bp+21] (each entry 0 or 128, one output bit period each) and
+  the 20 GCR bits are the transitions between adjacent periods
+ */
+static bool decode_gcr(uint16_t* frame_out)
+{
+    uint32_t gcrnum = 0;
+    for (int j = 2; j <= 21; j++) {
+        const uint8_t bit = (gcr[buffer_padding + j] != 0) != (gcr[buffer_padding + j - 1] != 0);
+        gcrnum = (gcrnum << 1) | bit;
+    }
+    uint16_t frame = 0;
+    for (int q = 3; q >= 0; q--) {
+        const uint8_t code = (gcrnum >> (q * 5)) & 0x1f;
+        int nibble = -1;
+        for (int i = 0; i < 16; i++) {
+            if ((uint8_t)gcr_encode_table[i] == code) {
+                nibble = i;
+                break;
+            }
+        }
+        if (nibble < 0) {
+            return false;
+        }
+        frame = (frame << 4) | (uint16_t)nibble;
+    }
+    *frame_out = frame;
+    return true;
+}
+
+void sitl_input_send_reply(void)
+{
+    uint16_t frame;
+    if (!decode_gcr(&frame)) {
+        stats.bad_gcr++;
+        frame = 0;
+    } else if (fd >= 0 && have_sender) {
+        struct input_pkt pkt = {
+            .magic = SITL_INPUT_MAGIC,
+            .type = last_type,
+            .len = 4,
+            // the BDShot reply line idles high, pulses are active low
+            .flags = SITL_INPUT_FLAG_IDLE_HIGH,
+            .data = frame,
+        };
+        sendto(fd, &pkt, sizeof(pkt), 0, (struct sockaddr*)&last_sender, sizeof(last_sender));
+        stats.replies++;
+    }
+    // the reply DMA completes after (23+buffer_padding) bit periods of
+    // 109 ticks at 160MHz/(output_timer_prescaler+1)
+    const uint64_t bit_ns = (109ULL * 25ULL * (uint64_t)(output_timer_prescaler + 1)) / 4ULL;
+    tx_done_ns = sitl_time_ns() + (23ULL + buffer_padding) * bit_ns;
+}
+
+/*
+  DMA transfer complete interrupt, mirroring the g431
+  DMA1_Channel1_IRQHandler. The servo half-transfer polarity flip is
+  deliberately collapsed: both edges of a pulse are captured at once
+ */
+void sitl_input_dma_irq(void)
+{
+    if (armed && dshot_telemetry) {
+        if (out_put) {
+            receiveDshotDma();
+            compute_dshot_flag = 2;
+        } else {
+            sendDshotDma();
+            compute_dshot_flag = 1;
+        }
+        sitl_irq_pend(SITL_IRQ_EXTI15);
+        return;
+    }
+    transfercomplete();
+    sitl_irq_pend(SITL_IRQ_EXTI15);
+}
+
+// called from the sim thread every 100us
+void sitl_input_poll(void)
+{
+    if (fd < 0) {
+        return;
+    }
+    // complete a pending BDShot reply transmit
+    if (out_put && tx_done_ns != 0 && sitl_time_ns() >= tx_done_ns) {
+        tx_done_ns = 0;
+        sitl_irq_pend(SITL_IRQ_DMA);
+        return;
+    }
+    struct input_pkt pkt;
+    struct sockaddr_in src;
+    socklen_t srclen = sizeof(src);
+    const ssize_t ret = recvfrom(fd, &pkt, sizeof(pkt), MSG_DONTWAIT, (struct sockaddr*)&src, &srclen);
+    if (ret < 0) {
+        return;
+    }
+    if (ret < (ssize_t)sizeof(pkt) || pkt.magic != SITL_INPUT_MAGIC || pkt.type > SITL_INPUT_DSHOT600) {
+        return;
+    }
+    last_sender = src;
+    have_sender = true;
+    last_type = pkt.type;
+    pin_idle_level = (pkt.flags & SITL_INPUT_FLAG_IDLE_HIGH) ? 1 : 0;
+    stats.frames++;
+    if (!cap_armed || out_put) {
+        // capture not armed (or the wire is driven by the reply): the
+        // frame is lost, as on the real signal wire
+        stats.dropped++;
+        return;
+    }
+    synth_frame(pkt.type, pkt.data);
+    if (cap_index >= cap_count) {
+        cap_armed = false;
+        sitl_irq_pend(SITL_IRQ_DMA);
+    }
+}
+
+void sitl_input_stats(uint32_t out[4])
+{
+    out[0] = stats.frames;
+    out[1] = stats.dropped;
+    out[2] = stats.replies;
+    out[3] = stats.bad_gcr;
+}

--- a/Mcu/SITL/Src/sitl_input.c
+++ b/Mcu/SITL/Src/sitl_input.c
@@ -91,7 +91,7 @@ void sitl_input_init(void)
     if (sitl_cfg.input_port <= 0) {
         return;
     }
-    fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    fd = sitl_udp_socket();
     if (fd < 0) {
         perror("SITL: input socket");
         return;

--- a/Mcu/SITL/Src/sitl_input.c
+++ b/Mcu/SITL/Src/sitl_input.c
@@ -78,6 +78,11 @@ static uint64_t cap_base_ns; // sim time of CNT=0
 static volatile uint8_t pin_idle_level; // from the last packet flags
 static uint8_t last_type = SITL_INPUT_DSHOT300;
 static uint64_t tx_done_ns; // sim time the BDShot reply transmit completes
+static uint64_t dma_done_ns; // sim time RX capture DMA should complete (0 = idle)
+static uint64_t last_edge_ns; // timestamp of the most recent synth edge
+
+// max UDP frames drained per poll so a flood cannot starve the sim thread
+#define SITL_INPUT_DRAIN_MAX 32
 
 static struct {
     uint32_t frames;
@@ -145,6 +150,7 @@ static void add_edge(uint64_t t_ns)
 {
     if (cap_index < cap_count && cap_index < 64) {
         dma_buffer[cap_index++] = cap_cnt_at(t_ns);
+        last_edge_ns = t_ns;
     }
 }
 
@@ -177,6 +183,20 @@ static void synth_frame(uint8_t type, uint16_t data)
         const uint32_t high_ns = (data & (0x8000U >> i)) ? (bit_ns * 3U) / 4U : (bit_ns * 3U) / 8U;
         add_edge(start);
         add_edge(start + high_ns);
+    }
+}
+
+// service deferred DMA completions (RX capture end / BDShot TX end)
+static void service_deferred_dma(void)
+{
+    const uint64_t now = sitl_time_ns();
+    if (out_put && tx_done_ns != 0 && now >= tx_done_ns) {
+        tx_done_ns = 0;
+        sitl_irq_pend(SITL_IRQ_DMA);
+    }
+    if (dma_done_ns != 0 && now >= dma_done_ns) {
+        dma_done_ns = 0;
+        sitl_irq_pend(SITL_IRQ_DMA);
     }
 }
 
@@ -258,44 +278,50 @@ void sitl_input_dma_irq(void)
     sitl_irq_pend(SITL_IRQ_EXTI15);
 }
 
-// called from the sim thread every 100us
+/*
+  called from the sim thread every physics step: service deferred DMA
+  IRQs, then drain the UDP input socket (up to SITL_INPUT_DRAIN_MAX
+  packets). DMA complete for a received frame is deferred until the last
+  synthesized edge time so frame duration is visible in sim time.
+ */
 void sitl_input_poll(void)
 {
     if (fd < 0) {
         return;
     }
-    // complete a pending BDShot reply transmit
-    if (out_put && tx_done_ns != 0 && sitl_time_ns() >= tx_done_ns) {
-        tx_done_ns = 0;
-        sitl_irq_pend(SITL_IRQ_DMA);
-        return;
-    }
-    struct input_pkt pkt;
-    struct sockaddr_in src;
-    socklen_t srclen = sizeof(src);
-    const ssize_t ret = recvfrom(fd, &pkt, sizeof(pkt), MSG_DONTWAIT, (struct sockaddr*)&src, &srclen);
-    if (ret < 0) {
-        return;
-    }
-    if (ret < (ssize_t)sizeof(pkt) || pkt.magic != SITL_INPUT_MAGIC || pkt.type > SITL_INPUT_DSHOT600
-        || pkt.len != 4) {
-        return;
-    }
-    last_sender = src;
-    have_sender = true;
-    last_type = pkt.type;
-    pin_idle_level = (pkt.flags & SITL_INPUT_FLAG_IDLE_HIGH) ? 1 : 0;
-    stats.frames++;
-    if (!cap_armed || out_put) {
-        // capture not armed (or the wire is driven by the reply): the
-        // frame is lost, as on the real signal wire
-        stats.dropped++;
-        return;
-    }
-    synth_frame(pkt.type, pkt.data);
-    if (cap_index >= cap_count) {
-        cap_armed = false;
-        sitl_irq_pend(SITL_IRQ_DMA);
+    service_deferred_dma();
+
+    for (int n = 0; n < SITL_INPUT_DRAIN_MAX; n++) {
+        struct input_pkt pkt;
+        struct sockaddr_in src;
+        socklen_t srclen = sizeof(src);
+        const ssize_t ret = recvfrom(fd, &pkt, sizeof(pkt), MSG_DONTWAIT,
+            (struct sockaddr*)&src, &srclen);
+        if (ret < 0) {
+            break;
+        }
+        if (ret < (ssize_t)sizeof(pkt) || pkt.magic != SITL_INPUT_MAGIC
+            || pkt.type > SITL_INPUT_DSHOT600 || pkt.len != 4) {
+            continue;
+        }
+        last_sender = src;
+        have_sender = true;
+        last_type = pkt.type;
+        pin_idle_level = (pkt.flags & SITL_INPUT_FLAG_IDLE_HIGH) ? 1 : 0;
+        stats.frames++;
+        // capture not armed, reply TX on the wire, or RX DMA still
+        // waiting for the last edge: frame is lost, as on a real wire
+        if (!cap_armed || out_put || dma_done_ns != 0) {
+            stats.dropped++;
+            continue;
+        }
+        synth_frame(pkt.type, pkt.data);
+        if (cap_index >= cap_count) {
+            cap_armed = false;
+            // complete at the last edge (or immediately if already past)
+            dma_done_ns = last_edge_ns ? last_edge_ns : sitl_time_ns();
+            service_deferred_dma();
+        }
     }
 }
 

--- a/Mcu/SITL/Src/sitl_input.c
+++ b/Mcu/SITL/Src/sitl_input.c
@@ -102,7 +102,7 @@ void sitl_input_init(void)
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons((uint16_t)sitl_cfg.input_port);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr.s_addr = htonl(sitl_cfg.bind_any ? INADDR_ANY : INADDR_LOOPBACK);
     if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
         perror("SITL: input bind");
         close(fd);
@@ -277,7 +277,8 @@ void sitl_input_poll(void)
     if (ret < 0) {
         return;
     }
-    if (ret < (ssize_t)sizeof(pkt) || pkt.magic != SITL_INPUT_MAGIC || pkt.type > SITL_INPUT_DSHOT600) {
+    if (ret < (ssize_t)sizeof(pkt) || pkt.magic != SITL_INPUT_MAGIC || pkt.type > SITL_INPUT_DSHOT600
+        || pkt.len != 4) {
         return;
     }
     last_sender = src;

--- a/Mcu/SITL/Src/sitl_input.c
+++ b/Mcu/SITL/Src/sitl_input.c
@@ -96,8 +96,8 @@ void sitl_input_init(void)
         perror("SITL: input socket");
         return;
     }
-    const int one = 1;
-    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    // no SO_REUSEADDR: a second instance on the same port must fail
+    // loudly instead of silently stealing datagrams
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;

--- a/Mcu/SITL/Src/sitl_it.c
+++ b/Mcu/SITL/Src/sitl_it.c
@@ -1,0 +1,75 @@
+/*
+  sitl_it.c - the SITL "vector table", dispatching emulated interrupts to
+  the firmware handlers. Mirrors Mcu/g431/Src/stm32g4xx_it.c
+ */
+
+#include "sitl.h"
+#include "targets.h"
+
+extern void PeriodElapsedCallback(void);
+extern void interruptRoutine(void);
+extern void tenKhzRoutine(void);
+extern void processDshot(void);
+
+// provided by sys_can_SITL.c when DroneCAN is compiled in
+void sitl_can_irq(void) __attribute__((weak));
+void sitl_can_irq(void) { }
+
+// CAN statistics for --verbose, overridden by sys_can_SITL.c
+void sitl_can_stats(uint32_t stats[4]) __attribute__((weak));
+void sitl_can_stats(uint32_t stats[4])
+{
+    stats[0] = stats[1] = stats[2] = stats[3] = 0;
+}
+
+extern volatile uint32_t commutation_interval;
+
+/*
+  comparator EXTI interrupt with the same blanking gate as the g431
+  handler: ignore zero crossings in the first half of the expected
+  commutation interval
+ */
+extern void motor_log_event(int kind, uint32_t a, uint32_t b, uint32_t c);
+
+static void comp_irq(void)
+{
+    const uint32_t lines = SITL_EXTI_LINE_21 | SITL_EXTI_LINE_22;
+    const uint32_t cnt = sitl_interval_timer_count();
+    if (cnt > (uint32_t)(commutation_interval >> 1)) {
+        if (sitl_exti.PR & lines) {
+            sitl_exti.PR &= ~lines;
+            motor_log_event(3 /*MEV_COMP_RUN*/, cnt, 0, 0);
+            interruptRoutine();
+        } else {
+            // pend delivered with no pending line: the edge was consumed
+            // by an earlier handler
+            motor_log_event(3 /*MEV_COMP_RUN*/, cnt, 1, 0);
+        }
+    } else {
+        motor_log_event(2 /*MEV_COMP_BLANKED*/, cnt, commutation_interval >> 1, 0);
+        sitl_exti.PR &= ~lines;
+    }
+}
+
+void sitl_irq_handler(int irq)
+{
+    switch (irq) {
+    case SITL_IRQ_COMP:
+        comp_irq();
+        break;
+    case SITL_IRQ_COM:
+        PeriodElapsedCallback();
+        break;
+    case SITL_IRQ_TENKHZ:
+        tenKhzRoutine();
+        break;
+    case SITL_IRQ_EXTI15:
+        processDshot();
+        break;
+    case SITL_IRQ_CAN:
+        sitl_can_irq();
+        break;
+    default:
+        break;
+    }
+}

--- a/Mcu/SITL/Src/sitl_it.c
+++ b/Mcu/SITL/Src/sitl_it.c
@@ -63,6 +63,9 @@ void sitl_irq_handler(int irq)
     case SITL_IRQ_TENKHZ:
         tenKhzRoutine();
         break;
+    case SITL_IRQ_DMA:
+        sitl_input_dma_irq();
+        break;
     case SITL_IRQ_EXTI15:
         processDshot();
         break;

--- a/Mcu/SITL/Src/sitl_main.c
+++ b/Mcu/SITL/Src/sitl_main.c
@@ -24,13 +24,21 @@ extern int am32_main(void);
 extern void save_flash_nolib(uint8_t* data, int length, uint32_t add);
 extern void read_flash_bin(uint8_t* data, uint32_t add, int out_buff_len);
 
-// force the DroneCAN node ID in the eeprom backing file
-static void apply_node_id(void)
+// force settings in the eeprom backing file from the command line
+static void apply_eeprom_overrides(void)
 {
     EEprom_t buf;
     read_flash_bin(buf.buffer, EEPROM_START_ADD, sizeof(buf.buffer));
-    if (buf.can.can_node != (uint8_t)sitl_cfg.node_id) {
+    bool changed = false;
+    if (sitl_cfg.node_id >= 0 && buf.can.can_node != (uint8_t)sitl_cfg.node_id) {
         buf.can.can_node = (uint8_t)sitl_cfg.node_id;
+        changed = true;
+    }
+    if (sitl_cfg.input_type >= 0 && buf.input_type != (uint8_t)sitl_cfg.input_type) {
+        buf.input_type = (uint8_t)sitl_cfg.input_type;
+        changed = true;
+    }
+    if (changed) {
         save_flash_nolib(buf.buffer, sizeof(buf.buffer), EEPROM_START_ADD);
     }
 }
@@ -69,13 +77,14 @@ int main(int argc, char** argv)
     sitl_config_init(argc, argv);
     lock_instance();
     motor_init();
-    if (sitl_cfg.node_id >= 0) {
-        apply_node_id();
+    if (sitl_cfg.node_id >= 0 || sitl_cfg.input_type >= 0) {
+        apply_eeprom_overrides();
     }
 
     fprintf(stderr, "AM32 SITL: eeprom=%s can=%s speedup=%.1f\n",
         sitl_cfg.eeprom_path, sitl_cfg.can_uri, (double)sitl_cfg.speedup);
 
+    sitl_input_init();
     sitl_start_sim_thread();
     return am32_main();
 }

--- a/Mcu/SITL/Src/sitl_main.c
+++ b/Mcu/SITL/Src/sitl_main.c
@@ -5,6 +5,7 @@
  */
 
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/file.h>
@@ -73,6 +74,11 @@ static void lock_instance(void)
 
 int main(int argc, char** argv)
 {
+    // Connected UDP send() can raise SIGPIPE on macOS/BSD when multicast
+    // is unavailable (e.g. GitHub Actions runners). Ignore it so the
+    // caller gets EPIPE/ECONNREFUSED instead of a silent death.
+    signal(SIGPIPE, SIG_IGN);
+
     sitl_saved_argv = argv;
     sitl_config_init(argc, argv);
     lock_instance();

--- a/Mcu/SITL/Src/sitl_main.c
+++ b/Mcu/SITL/Src/sitl_main.c
@@ -1,0 +1,81 @@
+/*
+  sitl_main.c - entry point for the AM32 SITL build. Sets up the
+  simulation and then runs the firmware's main() (renamed to am32_main by
+  targets.h)
+ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/file.h>
+
+#include "sitl.h"
+#include "sitl_config.h"
+#include "motor.h"
+
+#include "eeprom.h"
+#include "targets.h"
+
+// targets.h renames the firmware main() to am32_main; this file provides
+// the real process main()
+#undef main
+
+extern int am32_main(void);
+extern void save_flash_nolib(uint8_t* data, int length, uint32_t add);
+extern void read_flash_bin(uint8_t* data, uint32_t add, int out_buff_len);
+
+// force the DroneCAN node ID in the eeprom backing file
+static void apply_node_id(void)
+{
+    EEprom_t buf;
+    read_flash_bin(buf.buffer, EEPROM_START_ADD, sizeof(buf.buffer));
+    if (buf.can.can_node != (uint8_t)sitl_cfg.node_id) {
+        buf.can.can_node = (uint8_t)sitl_cfg.node_id;
+        save_flash_nolib(buf.buffer, sizeof(buf.buffer), EEPROM_START_ADD);
+    }
+}
+
+/*
+  hold an exclusive lock on the eeprom file for the life of the process. A
+  second instance sharing the eeprom (and therefore node ID) would corrupt
+  the DroneCAN traffic with interleaved transfers, which shows up as
+  erratic telemetry. The fd is CLOEXEC so a reset (re-exec) drops and
+  immediately re-acquires it
+ */
+static void lock_instance(void)
+{
+    // a separate lock file, so the eeprom file itself is only created by
+    // the firmware writing it (a missing eeprom triggers default seeding)
+    char lockpath[512];
+    snprintf(lockpath, sizeof(lockpath), "%s.lock", sitl_cfg.eeprom_path);
+    const int fd = open(lockpath, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+    if (fd < 0) {
+        perror("SITL: lock file open");
+        exit(1);
+    }
+    if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
+        fprintf(stderr,
+            "SITL: %s is in use by another SITL instance. Use --eeprom and "
+            "--node-id to run multiple instances\n",
+            sitl_cfg.eeprom_path);
+        exit(1);
+    }
+    // fd deliberately left open to hold the lock
+}
+
+int main(int argc, char** argv)
+{
+    sitl_saved_argv = argv;
+    sitl_config_init(argc, argv);
+    lock_instance();
+    motor_init();
+    if (sitl_cfg.node_id >= 0) {
+        apply_node_id();
+    }
+
+    fprintf(stderr, "AM32 SITL: eeprom=%s can=%s speedup=%.1f\n",
+        sitl_cfg.eeprom_path, sitl_cfg.can_uri, (double)sitl_cfg.speedup);
+
+    sitl_start_sim_thread();
+    return am32_main();
+}

--- a/Mcu/SITL/Src/sitl_main.c
+++ b/Mcu/SITL/Src/sitl_main.c
@@ -85,6 +85,7 @@ int main(int argc, char** argv)
         sitl_cfg.eeprom_path, sitl_cfg.can_uri, (double)sitl_cfg.speedup);
 
     sitl_input_init();
+    sitl_state_init();
     sitl_start_sim_thread();
     return am32_main();
 }

--- a/Mcu/SITL/Src/sitl_sched.c
+++ b/Mcu/SITL/Src/sitl_sched.c
@@ -44,7 +44,49 @@ static volatile uint32_t irq_enabled;
 static volatile uint8_t irq_prio[SITL_IRQ_MAX];
 
 
-static sem_t park_sem, resume_sem;
+/*
+  park/resume semaphores. macOS has no unnamed POSIX semaphores or
+  sem_timedwait, so it uses GCD semaphores instead
+ */
+#ifdef __APPLE__
+#include <dispatch/dispatch.h>
+typedef dispatch_semaphore_t sitl_sem_t;
+static void sitl_sem_init(sitl_sem_t* s) { *s = dispatch_semaphore_create(0); }
+static void sitl_sem_post(sitl_sem_t* s) { dispatch_semaphore_signal(*s); }
+static void sitl_sem_wait(sitl_sem_t* s)
+{
+    dispatch_semaphore_wait(*s, DISPATCH_TIME_FOREVER);
+}
+static bool sitl_sem_wait_2s(sitl_sem_t* s)
+{
+    return dispatch_semaphore_wait(*s, dispatch_time(DISPATCH_TIME_NOW, 2LL * NSEC_PER_SEC)) == 0;
+}
+#else
+typedef sem_t sitl_sem_t;
+static void sitl_sem_init(sitl_sem_t* s) { sem_init(s, 0, 0); }
+static void sitl_sem_post(sitl_sem_t* s) { sem_post(s); }
+static void sitl_sem_wait(sitl_sem_t* s)
+{
+    while (sem_wait(s) == -1 && errno == EINTR) {
+    }
+}
+static bool sitl_sem_wait_2s(sitl_sem_t* s)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 2;
+    for (;;) {
+        if (sem_timedwait(s, &ts) == 0) {
+            return true;
+        }
+        if (errno != EINTR) {
+            return false;
+        }
+    }
+}
+#endif
+
+static sitl_sem_t park_sem, resume_sem;
 
 static volatile uint64_t watchdog_last_reload_ns;
 static volatile bool watchdog_running;
@@ -142,9 +184,8 @@ static void sigusr1_handler(int sig)
 {
     (void)sig;
     const int saved_errno = errno;
-    sem_post(&park_sem);
-    while (sem_wait(&resume_sem) == -1 && errno == EINTR) {
-    }
+    sitl_sem_post(&park_sem);
+    sitl_sem_wait(&resume_sem);
     errno = saved_errno;
 }
 
@@ -153,23 +194,12 @@ static bool suspend_firmware(void)
     pthread_kill(fw_thread_id, SIGUSR1);
     // a timed wait so a firmware thread that is exiting or execing
     // (NVIC_SystemReset) cannot deadlock the simulation
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    ts.tv_sec += 2;
-    for (;;) {
-        if (sem_timedwait(&park_sem, &ts) == 0) {
-            return true;
-        }
-        if (errno == EINTR) {
-            continue;
-        }
-        return false;
-    }
+    return sitl_sem_wait_2s(&park_sem);
 }
 
 static void resume_firmware(void)
 {
-    sem_post(&resume_sem);
+    sitl_sem_post(&resume_sem);
 }
 
 // priority of the currently executing handler, NVIC style (lower value
@@ -299,7 +329,11 @@ void sitl_system_reset(void)
     sigaddset(&set, SIGUSR1);
     pthread_sigmask(SIG_BLOCK, &set, NULL);
     fprintf(stderr, "SITL: reset at t=%.3fs\n", sim_time_ns_v * 1.0e-9);
+#ifdef __APPLE__
+    execv(sitl_saved_argv[0], sitl_saved_argv);
+#else
     execv("/proc/self/exe", sitl_saved_argv);
+#endif
     fprintf(stderr, "SITL: execv failed: %s\n", strerror(errno));
     _exit(1);
 }
@@ -470,8 +504,16 @@ static void* sim_thread_main(void* arg)
                 while (wallclock_ns() < target_wall) {
                 }
             } else if (target_wall > wall + 100000) {
+#ifdef __APPLE__
+                // no clock_nanosleep on macOS: relative sleep. Drift free
+                // because the absolute target is recomputed each pass
+                const uint64_t delta = target_wall - wall;
+                struct timespec ts = { delta / 1000000000ULL, delta % 1000000000ULL };
+                nanosleep(&ts, NULL);
+#else
                 struct timespec ts = { target_wall / 1000000000ULL, target_wall % 1000000000ULL };
                 clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, NULL);
+#endif
             }
         }
 
@@ -494,8 +536,8 @@ void sitl_start_sim_thread(void)
     // timer slack is per thread and defaults to 50us
     prctl(PR_SET_TIMERSLACK, 1UL);
 #endif
-    sem_init(&park_sem, 0, 0);
-    sem_init(&resume_sem, 0, 0);
+    sitl_sem_init(&park_sem);
+    sitl_sem_init(&resume_sem);
 
     // sitl_system_reset blocks SIGUSR1 on the way into execv; both the
     // mask and a possibly pending SIGUSR1 survive exec. Discard any

--- a/Mcu/SITL/Src/sitl_sched.c
+++ b/Mcu/SITL/Src/sitl_sched.c
@@ -165,6 +165,11 @@ void sitl_primask_set(void)
     __atomic_store_n(&primask, 1, __ATOMIC_SEQ_CST);
 }
 
+uint32_t sitl_primask_get(void)
+{
+    return (uint32_t)__atomic_load_n(&primask, __ATOMIC_SEQ_CST);
+}
+
 void sitl_primask_clear(void)
 {
     if (!sitl_in_sim_thread()) {
@@ -178,7 +183,10 @@ void sitl_primask_clear(void)
 
 /*
   firmware thread suspension. SIGUSR1 parks the firmware thread on
-  resume_sem; sem_post/sem_wait are async-signal-safe
+  resume_sem. Blocking in a handler is not formally async-signal-safe,
+  but these are bare syscall wrappers taking no library locks; the one
+  real hazard is parking this thread inside a locked stdio call while
+  the sim thread also prints, so diagnostics prints are kept rare
  */
 static void sigusr1_handler(int sig)
 {

--- a/Mcu/SITL/Src/sitl_sched.c
+++ b/Mcu/SITL/Src/sitl_sched.c
@@ -439,6 +439,7 @@ static void* sim_thread_main(void* arg)
         if (now >= next_can_poll_ns) {
             next_can_poll_ns = now + 100000; // 100us
             sitl_can_poll();
+            sitl_input_poll();
         }
         watchdog_check();
         sitl_dispatch();

--- a/Mcu/SITL/Src/sitl_sched.c
+++ b/Mcu/SITL/Src/sitl_sched.c
@@ -20,7 +20,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
 #include <time.h>
 #include <unistd.h>
 
@@ -400,8 +402,10 @@ static void* sim_thread_main(void* arg)
 {
     (void)arg;
     set_realtime("sim");
+#ifdef __linux__
     // timer slack defaults to 50us which ruins short pacing sleeps
     prctl(PR_SET_TIMERSLACK, 1UL);
+#endif
     const uint64_t wall0 = wallclock_ns();
     uint64_t next_can_poll_ns = 0;
     uint64_t next_pace_check_ns = 0;
@@ -486,8 +490,10 @@ void sitl_start_sim_thread(void)
 {
     fw_thread_id = pthread_self();
     set_realtime("firmware");
+#ifdef __linux__
     // timer slack is per thread and defaults to 50us
     prctl(PR_SET_TIMERSLACK, 1UL);
+#endif
     sem_init(&park_sem, 0, 0);
     sem_init(&resume_sem, 0, 0);
 

--- a/Mcu/SITL/Src/sitl_sched.c
+++ b/Mcu/SITL/Src/sitl_sched.c
@@ -313,6 +313,7 @@ static void sim_step_once(void)
     motor_step(sim_time_ns_v, dt);
     sim_time_ns_v += dt;
     sitl_timers_step(sim_time_ns_v);
+    sitl_state_step(sim_time_ns_v);
 
     // dispatch block tracer: classify this step if a priority 0 interrupt
     // has been pending for a while
@@ -406,6 +407,9 @@ static void* sim_thread_main(void* arg)
     uint64_t next_pace_check_ns = 0;
     uint64_t verbose_last_ns = 0;
     uint64_t verbose_last_wall = wall0;
+    uint64_t pace_wall_ref = wall0;
+    uint64_t pace_sim_ref = 0;
+    float pace_speedup = sitl_cfg.speedup;
 
     uint32_t grant_accum_ns = 0;
     for (;;) {
@@ -440,15 +444,23 @@ static void* sim_thread_main(void* arg)
             next_can_poll_ns = now + 100000; // 100us
             sitl_can_poll();
             sitl_input_poll();
+            sitl_state_poll();
         }
         watchdog_check();
         sitl_dispatch();
 
         // pace simulated time against the wall clock, sleeping to an
-        // absolute deadline so overshoot does not accumulate
-        if (sitl_cfg.speedup > 0 && now >= next_pace_check_ns) {
+        // absolute deadline so overshoot does not accumulate. The
+        // references rebase when the speedup changes at runtime (GUI
+        // slow motion control) so the mapping stays continuous
+        if (sitl_cfg.speedup != pace_speedup) {
+            pace_speedup = sitl_cfg.speedup;
+            pace_wall_ref = wallclock_ns();
+            pace_sim_ref = now;
+        }
+        if (pace_speedup > 0 && now >= next_pace_check_ns) {
             next_pace_check_ns = now + 50000; // check every 50us of sim time
-            const uint64_t target_wall = wall0 + (uint64_t)((double)now / sitl_cfg.speedup);
+            const uint64_t target_wall = pace_wall_ref + (uint64_t)((double)(now - pace_sim_ref) / pace_speedup);
             const uint64_t wall = wallclock_ns();
             if (sitl_cfg.nosleep) {
                 while (wallclock_ns() < target_wall) {

--- a/Mcu/SITL/Src/sitl_sched.c
+++ b/Mcu/SITL/Src/sitl_sched.c
@@ -486,10 +486,12 @@ static void* sim_thread_main(void* arg)
         sim_step_once();
         const uint64_t now = sim_time_ns_v;
 
+        // input every physics step so deferred DMA matches frame edges and
+        // UDP bursts drain without waiting for the 100us CAN/state cadence
+        sitl_input_poll();
         if (now >= next_can_poll_ns) {
             next_can_poll_ns = now + 100000; // 100us
             sitl_can_poll();
-            sitl_input_poll();
             sitl_state_poll();
         }
         watchdog_check();

--- a/Mcu/SITL/Src/sitl_sched.c
+++ b/Mcu/SITL/Src/sitl_sched.c
@@ -1,0 +1,497 @@
+/*
+  sitl_sched.c - simulated time, interrupt delivery and pacing for AM32 SITL
+
+  The sim thread advances simulated time in fixed physics steps. Emulated
+  interrupts are delivered by suspending the firmware thread with SIGUSR1
+  (parking it on a semaphore) and running the handler in the sim thread,
+  which reproduces the run-to-completion, mainline-frozen semantics of real
+  interrupts. __disable_irq()/__enable_irq() map onto an atomic PRIMASK
+  flag; while set, events stay pending exactly as on hardware.
+ */
+
+#include "sitl.h"
+#include "sitl_config.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <semaphore.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "motor.h"
+
+static volatile uint64_t sim_time_ns_v;
+static pthread_t sim_thread_id;
+static pthread_t fw_thread_id;
+
+static volatile int primask; // 1 = interrupts disabled, atomic stores only
+
+// simulated time granted by firmware-thread timer reads while it holds
+// PRIMASK (a startup tune busy-waits on the utility timer under
+// __disable_irq, so time must still advance for it). Reset when the
+// critical section ends
+static volatile uint64_t fw_grant_ns;
+static volatile uint32_t irq_pending;
+static volatile uint32_t irq_enabled;
+static volatile uint8_t irq_prio[SITL_IRQ_MAX];
+
+
+static sem_t park_sem, resume_sem;
+
+static volatile uint64_t watchdog_last_reload_ns;
+static volatile bool watchdog_running;
+#define WATCHDOG_TIMEOUT_NS 2000000000ULL
+
+char** sitl_saved_argv;
+
+// implemented in sitl_it.c
+extern void sitl_irq_handler(int irq);
+// implemented in sys_can_SITL.c when DroneCAN is compiled in
+void sitl_can_poll(void) __attribute__((weak));
+void sitl_can_poll(void) { }
+
+uint64_t sitl_time_ns(void)
+{
+    return sim_time_ns_v;
+}
+
+bool sitl_in_sim_thread(void)
+{
+    return pthread_equal(pthread_self(), sim_thread_id);
+}
+
+static uint64_t wallclock_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+/*
+  NVIC emulation
+ */
+void sitl_nvic_set_priority(int irq, uint32_t prio)
+{
+    irq_prio[irq] = prio;
+}
+
+void sitl_nvic_enable_irq(int irq)
+{
+    __atomic_fetch_or(&irq_enabled, 1U << irq, __ATOMIC_SEQ_CST);
+}
+
+void sitl_nvic_disable_irq(int irq)
+{
+    __atomic_fetch_and(&irq_enabled, ~(1U << irq), __ATOMIC_SEQ_CST);
+}
+
+/*
+  dispatch block diagnostic: records why a pending COMP/COM interrupt is
+  not being delivered, classified per simulation step, reported when the
+  delivery latency exceeds 20us (bounded number of reports)
+ */
+static uint64_t irq_pend_ns[SITL_IRQ_MAX];
+static int current_irq = -1;
+static struct {
+    uint32_t steps_primask;
+    uint32_t steps_active[SITL_IRQ_MAX];
+    uint32_t steps_disabled;
+    uint32_t steps_free;
+} blocked;
+
+void sitl_irq_pend(int irq)
+{
+    const uint32_t old = __atomic_fetch_or(&irq_pending, 1U << irq, __ATOMIC_SEQ_CST);
+    if ((old & (1U << irq)) == 0) {
+        irq_pend_ns[irq] = sim_time_ns_v;
+    }
+}
+
+void sitl_primask_set(void)
+{
+    // plain atomic store: the dispatcher re-checks primask after parking
+    // the firmware thread, so no lock is needed. Critical sections are
+    // extremely frequent (micros64 runs one per call) and must be cheap
+    __atomic_store_n(&primask, 1, __ATOMIC_SEQ_CST);
+}
+
+void sitl_primask_clear(void)
+{
+    if (!sitl_in_sim_thread()) {
+        // grants are per critical section: unconsumed ones must not
+        // accumulate into a reservoir that lets the simulation run
+        // through a later, host-stretched critical section
+        __atomic_store_n(&fw_grant_ns, 0, __ATOMIC_SEQ_CST);
+    }
+    __atomic_store_n(&primask, 0, __ATOMIC_SEQ_CST);
+}
+
+/*
+  firmware thread suspension. SIGUSR1 parks the firmware thread on
+  resume_sem; sem_post/sem_wait are async-signal-safe
+ */
+static void sigusr1_handler(int sig)
+{
+    (void)sig;
+    const int saved_errno = errno;
+    sem_post(&park_sem);
+    while (sem_wait(&resume_sem) == -1 && errno == EINTR) {
+    }
+    errno = saved_errno;
+}
+
+static bool suspend_firmware(void)
+{
+    pthread_kill(fw_thread_id, SIGUSR1);
+    // a timed wait so a firmware thread that is exiting or execing
+    // (NVIC_SystemReset) cannot deadlock the simulation
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 2;
+    for (;;) {
+        if (sem_timedwait(&park_sem, &ts) == 0) {
+            return true;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        return false;
+    }
+}
+
+static void resume_firmware(void)
+{
+    sem_post(&resume_sem);
+}
+
+// priority of the currently executing handler, NVIC style (lower value
+// is higher priority). 1000 = thread level, nothing active
+static int active_irq_prio = 1000;
+
+
+// run any pending interrupt with higher priority than the active one.
+// Called from the dispatch loop and re-entrantly from sitl_isr_read_tick
+// so a long running handler (eg tenKhzRoutine busy waiting on a timer)
+// can be preempted by the comparator, as the NVIC does on real hardware
+static void run_pending_irqs(void)
+{
+    for (;;) {
+        if (primask) {
+            return;
+        }
+        const uint32_t active = irq_pending & irq_enabled;
+        if (active == 0) {
+            return;
+        }
+        int best = -1;
+        for (int irq = 0; irq < SITL_IRQ_MAX; irq++) {
+            if ((active & (1U << irq)) == 0) {
+                continue;
+            }
+            if (best < 0 || irq_prio[irq] < irq_prio[best]) {
+                best = irq;
+            }
+        }
+        if (irq_prio[best] >= active_irq_prio) {
+            // equal or lower priority does not preempt
+            return;
+        }
+        __atomic_fetch_and(&irq_pending, ~(1U << best), __ATOMIC_SEQ_CST);
+        if (best == SITL_IRQ_COMP || best == SITL_IRQ_COM) {
+            const uint64_t lat = sim_time_ns_v - irq_pend_ns[best];
+            static int prints;
+            if (lat > 20000 && prints < 12) {
+                prints++;
+                fprintf(stderr,
+                    "SITL: irq %d blocked %.1fus at t=%.4f: primask=%u dis=%u free=%u"
+                    " act=[%u,%u,%u,%u,%u,%u]\n",
+                    best, lat * 1e-3, sim_time_ns_v * 1e-9,
+                    blocked.steps_primask, blocked.steps_disabled, blocked.steps_free,
+                    blocked.steps_active[0], blocked.steps_active[1],
+                    blocked.steps_active[2], blocked.steps_active[3],
+                    blocked.steps_active[4], blocked.steps_active[5]);
+            }
+            memset(&blocked, 0, sizeof(blocked));
+        }
+        const int saved_prio = active_irq_prio;
+        const int saved_irq = current_irq;
+        active_irq_prio = irq_prio[best];
+        current_irq = best;
+        sitl_irq_handler(best);
+        current_irq = saved_irq;
+        active_irq_prio = saved_prio;
+    }
+}
+
+/*
+  deliver pending enabled interrupts, called from the sim thread between
+  physics steps
+ */
+static void sitl_dispatch(void)
+{
+    if ((irq_pending & irq_enabled) == 0 || primask) {
+        return;
+    }
+    if (!suspend_firmware()) {
+        return;
+    }
+    // the firmware may have entered a critical section between our check
+    // and it parking; if so it is now parked inside the section and we
+    // must not run handlers (an IRQ arriving just after cpsid is held
+    // pending on real hardware too)
+    if (!primask) {
+        run_pending_irqs();
+    }
+    resume_firmware();
+}
+
+/*
+  watchdog
+ */
+void sitl_watchdog_reload(void)
+{
+    extern void motor_log_mainloop(void);
+    motor_log_mainloop();
+    watchdog_last_reload_ns = sim_time_ns_v;
+    if (!sitl_in_sim_thread() && sitl_cfg.sim.loop_time_ns > 0 && sitl_cfg.speedup > 0) {
+        // approximate the real main loop execution time so the firmware
+        // thread does not spin flat out
+        const uint64_t delay_ns = (uint64_t)(sitl_cfg.sim.loop_time_ns / sitl_cfg.speedup);
+        if (sitl_cfg.nosleep) {
+            const uint64_t deadline = wallclock_ns() + delay_ns;
+            while (wallclock_ns() < deadline) {
+            }
+        } else {
+            struct timespec ts = { 0, (long)delay_ns };
+            nanosleep(&ts, NULL);
+        }
+    }
+}
+
+void sitl_watchdog_enable(void)
+{
+    watchdog_last_reload_ns = sim_time_ns_v;
+    watchdog_running = sitl_cfg.sim.watchdog_enabled;
+}
+
+static void watchdog_check(void)
+{
+    if (watchdog_running && sim_time_ns_v - watchdog_last_reload_ns > WATCHDOG_TIMEOUT_NS) {
+        fprintf(stderr, "SITL: watchdog reset at t=%.3fs\n", sim_time_ns_v * 1.0e-9);
+        sitl_system_reset();
+    }
+}
+
+void sitl_system_reset(void)
+{
+    // block the suspension signal so a concurrent interrupt delivery
+    // cannot park this thread on the way into exec
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
+    fprintf(stderr, "SITL: reset at t=%.3fs\n", sim_time_ns_v * 1.0e-9);
+    execv("/proc/self/exe", sitl_saved_argv);
+    fprintf(stderr, "SITL: execv failed: %s\n", strerror(errno));
+    _exit(1);
+}
+
+/*
+  advance simulation by one physics step. Called from the sim thread main
+  loop and re-entrantly from interrupt handlers that busy wait on time
+  (delayMicros, comparator filter reads)
+ */
+static void sim_step_once(void)
+{
+    const uint32_t dt = sitl_cfg.sim.physics_dt_ns;
+    motor_step(sim_time_ns_v, dt);
+    sim_time_ns_v += dt;
+    sitl_timers_step(sim_time_ns_v);
+
+    // dispatch block tracer: classify this step if a priority 0 interrupt
+    // has been pending for a while
+    for (int irq = SITL_IRQ_COMP; irq <= SITL_IRQ_COM; irq++) {
+        if ((irq_pending & (1U << irq)) == 0) {
+            continue;
+        }
+        if (sim_time_ns_v - irq_pend_ns[irq] <= 20000) {
+            continue;
+        }
+        if (current_irq >= 0) {
+            // a handler is executing (possibly holding primask itself)
+            blocked.steps_active[current_irq]++;
+        } else if (primask) {
+            blocked.steps_primask++;
+        } else if ((irq_enabled & (1U << irq)) == 0) {
+            blocked.steps_disabled++;
+        } else {
+            blocked.steps_free++;
+        }
+        break;
+    }
+}
+
+void sitl_step_from_isr(void)
+{
+    sim_step_once();
+}
+
+void sitl_fw_read_tick(void)
+{
+    if (primask && !sitl_in_sim_thread()) {
+        __atomic_fetch_add(&fw_grant_ns, sitl_cfg.sim.isr_read_ns, __ATOMIC_SEQ_CST);
+    }
+}
+
+void sitl_isr_read_tick(void)
+{
+    // only called from the sim thread (interrupt context), no locking
+    // needed. Advancing a full physics step per register read would make
+    // handler busy loops take ~10x longer in simulated time than on real
+    // hardware, which breaks the comparator filter in interruptRoutine()
+    static uint32_t accum_ns;
+    accum_ns += sitl_cfg.sim.isr_read_ns;
+    while (accum_ns >= sitl_cfg.sim.physics_dt_ns) {
+        accum_ns -= sitl_cfg.sim.physics_dt_ns;
+        sim_step_once();
+        // let higher priority interrupts preempt the current handler
+        run_pending_irqs();
+    }
+}
+
+// try to switch the calling thread to SCHED_FIFO, warning on failure
+static void set_realtime(const char* what)
+{
+    if (!sitl_cfg.realtime) {
+        return;
+    }
+    struct sched_param sp = { .sched_priority = 50 };
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp) != 0) {
+        fprintf(stderr, "SITL: SCHED_FIFO failed for %s thread: %s\n",
+            what, strerror(errno));
+        return;
+    }
+    // with --nosleep the threads never block, so default RT throttling
+    // (kernel.sched_rt_runtime_us=950000) would stall them 50ms/second
+    if (sitl_cfg.nosleep) {
+        FILE* f = fopen("/proc/sys/kernel/sched_rt_runtime_us", "r");
+        if (f) {
+            long v = 0;
+            if (fscanf(f, "%ld", &v) == 1 && v != -1) {
+                fprintf(stderr,
+                    "SITL: WARNING: RT throttling is enabled and will stall "
+                    "--nosleep --realtime; run "
+                    "'sysctl -w kernel.sched_rt_runtime_us=-1'\n");
+            }
+            fclose(f);
+        }
+    }
+    fprintf(stderr, "SITL: %s thread using SCHED_FIFO\n", what);
+}
+
+static void* sim_thread_main(void* arg)
+{
+    (void)arg;
+    set_realtime("sim");
+    // timer slack defaults to 50us which ruins short pacing sleeps
+    prctl(PR_SET_TIMERSLACK, 1UL);
+    const uint64_t wall0 = wallclock_ns();
+    uint64_t next_can_poll_ns = 0;
+    uint64_t next_pace_check_ns = 0;
+    uint64_t verbose_last_ns = 0;
+    uint64_t verbose_last_wall = wall0;
+
+    uint32_t grant_accum_ns = 0;
+    for (;;) {
+        /*
+          while the firmware thread holds PRIMASK outside of interrupt
+          context, simulated time may only advance as granted by the
+          firmware's own timer reads. On the real MCU a critical section
+          lasts nanoseconds; if the host deschedules the firmware thread
+          inside one (OS preemption, hard/soft irqs on its core), a free
+          running clock would block interrupt delivery for hundreds of
+          microseconds of simulated time and lose commutation timing.
+          current_irq is only ever set by this thread, so the check does
+          not race: ISR-context PRIMASK always has current_irq >= 0
+         */
+        if (primask && current_irq < 0) {
+            const uint64_t g = fw_grant_ns;
+            if (g > 0) {
+                __atomic_fetch_sub(&fw_grant_ns, g, __ATOMIC_SEQ_CST);
+                grant_accum_ns += (uint32_t)g;
+            }
+            if (grant_accum_ns < sitl_cfg.sim.physics_dt_ns) {
+                continue;
+            }
+            grant_accum_ns -= sitl_cfg.sim.physics_dt_ns;
+        } else {
+            grant_accum_ns = 0;
+        }
+        sim_step_once();
+        const uint64_t now = sim_time_ns_v;
+
+        if (now >= next_can_poll_ns) {
+            next_can_poll_ns = now + 100000; // 100us
+            sitl_can_poll();
+        }
+        watchdog_check();
+        sitl_dispatch();
+
+        // pace simulated time against the wall clock, sleeping to an
+        // absolute deadline so overshoot does not accumulate
+        if (sitl_cfg.speedup > 0 && now >= next_pace_check_ns) {
+            next_pace_check_ns = now + 50000; // check every 50us of sim time
+            const uint64_t target_wall = wall0 + (uint64_t)((double)now / sitl_cfg.speedup);
+            const uint64_t wall = wallclock_ns();
+            if (sitl_cfg.nosleep) {
+                while (wallclock_ns() < target_wall) {
+                }
+            } else if (target_wall > wall + 100000) {
+                struct timespec ts = { target_wall / 1000000000ULL, target_wall % 1000000000ULL };
+                clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, NULL);
+            }
+        }
+
+        if (sitl_cfg.verbose && now - verbose_last_ns >= 1000000000ULL) {
+            const uint64_t wall = wallclock_ns();
+            const float ratio = (float)(now - verbose_last_ns) / (float)(wall - verbose_last_wall);
+            verbose_last_ns = now;
+            verbose_last_wall = wall;
+            motor_print_state(now, ratio);
+        }
+    }
+    return NULL;
+}
+
+void sitl_start_sim_thread(void)
+{
+    fw_thread_id = pthread_self();
+    set_realtime("firmware");
+    // timer slack is per thread and defaults to 50us
+    prctl(PR_SET_TIMERSLACK, 1UL);
+    sem_init(&park_sem, 0, 0);
+    sem_init(&resume_sem, 0, 0);
+
+    // sitl_system_reset blocks SIGUSR1 on the way into execv; both the
+    // mask and a possibly pending SIGUSR1 survive exec. Discard any
+    // pending instance and unblock before installing the real handler
+    signal(SIGUSR1, SIG_IGN);
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    pthread_sigmask(SIG_UNBLOCK, &set, NULL);
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigusr1_handler;
+    sa.sa_flags = SA_RESTART;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    pthread_create(&sim_thread_id, NULL, sim_thread_main, NULL);
+}

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -93,7 +93,7 @@ void sitl_state_init(void)
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons((uint16_t)sitl_cfg.state_port);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr.s_addr = htonl(sitl_cfg.bind_any ? INADDR_ANY : INADDR_LOOPBACK);
     if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
         perror("SITL: state bind");
         close(fd);
@@ -171,6 +171,15 @@ void sitl_state_poll(void)
         memcpy(&period_req_ns, pkt + 4, 4);
         averaged = (pkt[3] & 1) != 0;
         apply_period();
+        // a new subscriber must not receive samples batched for the
+        // previous one
+        if (!have_sub || src.sin_addr.s_addr != sub_addr.sin_addr.s_addr
+            || src.sin_port != sub_addr.sin_port) {
+            batch.count = 0;
+            memset(sig_acc, 0, sizeof(sig_acc));
+            sig_n = 0;
+            next_sample_ns = 0;
+        }
         sub_addr = src;
         have_sub = true;
         sub_expire = time(NULL) + 2;

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -82,7 +82,7 @@ void sitl_state_init(void)
     if (sitl_cfg.state_port <= 0) {
         return;
     }
-    fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    fd = sitl_udp_socket();
     if (fd < 0) {
         perror("SITL: state socket");
         return;

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -1,0 +1,249 @@
+/*
+  sitl_state.c - high rate simulation state streaming and runtime model
+  control over UDP, for GUI graphs and animations
+
+  A client subscribes by sending a SUBSCRIBE packet with the desired
+  sample period in simulated nanoseconds; the simulation thread then
+  streams batched state samples (rotor angle/speed, phase currents, bus
+  voltage/current, bridge modes, comparator) to the subscriber. The
+  subscription expires two seconds after the last refresh.
+
+  A LOAD_MODEL packet carries the path of a motor/battery/esc JSON file
+  (same format as --config, sim section ignored) which is applied to the
+  running simulation.
+
+  client -> SITL (little endian):
+    u16 magic 0x5353, u8 cmd, u8 pad, payload
+      cmd 0 SUBSCRIBE: u32 period_ns; flags byte bit0 = averaged
+        sampling (currents/voltages are the mean over each sample
+        period instead of instantaneous, avoiding PWM aliasing at
+        coarse periods)
+      cmd 1 LOAD_MODEL: JSON file path (rest of packet)
+      cmd 2 SET_SPEEDUP: float speedup (0 = free run)
+  SITL -> client:
+    u16 magic 0x5354, u8 version=1, u8 count, count * sample
+    u16 magic 0x5355, u8 ok, u8 pad, message   (LOAD_MODEL reply)
+*/
+
+#include "sitl.h"
+#include "sitl_config.h"
+#include "motor.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#define STATE_MAGIC_CMD 0x5353
+#define STATE_MAGIC_DATA 0x5354
+#define STATE_MAGIC_REPLY 0x5355
+
+struct __attribute__((packed)) state_sample {
+    uint64_t t_ns;
+    float omega; // mechanical rad/s
+    float theta; // mechanical angle, rad [0,2pi)
+    float theta_e; // electrical angle, rad [0,2pi)
+    float iu, iv, iw; // phase currents, A
+    float vu, vv, vw; // phase terminal voltages, V
+    float vbus, ibus;
+    uint8_t modes[3]; // sitl_phase_mode per phase
+    uint8_t comp_phase; // floating phase
+    uint8_t comp_out;
+    uint8_t pad[3];
+};
+
+#define STATE_BATCH 16
+
+static int fd = -1;
+static struct sockaddr_in sub_addr;
+static bool have_sub;
+static time_t sub_expire;
+static uint32_t period_req_ns = 50000; // requested by the subscriber
+static uint32_t period_ns = 50000; // effective, wall rate limited
+static bool averaged; // mean over the period instead of point samples
+static double sig_acc[8];
+static uint32_t sig_n;
+static uint64_t next_sample_ns;
+static uint64_t last_flush_ns;
+
+static struct __attribute__((packed)) {
+    uint16_t magic;
+    uint8_t version;
+    uint8_t count;
+    struct state_sample s[STATE_BATCH];
+} batch = { .magic = STATE_MAGIC_DATA, .version = 2 };
+
+void sitl_state_init(void)
+{
+    if (sitl_cfg.state_port <= 0) {
+        return;
+    }
+    fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        perror("SITL: state socket");
+        return;
+    }
+    // no SO_REUSEADDR: a second instance on the same port must fail
+    // loudly instead of silently stealing datagrams
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)sitl_cfg.state_port);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+        perror("SITL: state bind");
+        close(fd);
+        fd = -1;
+        return;
+    }
+    fprintf(stderr, "SITL: state/model port udp %d\n", sitl_cfg.state_port);
+}
+
+static void load_model(const char* path, struct sockaddr_in* src)
+{
+    char msg[256];
+    const bool ok = sitl_config_reload(path);
+    if (ok) {
+        motor_config_changed();
+        snprintf(msg, sizeof(msg), "loaded %.200s", path);
+        fprintf(stderr, "SITL: %s\n", msg);
+    } else {
+        snprintf(msg, sizeof(msg), "failed to load %.200s", path);
+        fprintf(stderr, "SITL: %s\n", msg);
+    }
+    struct __attribute__((packed)) {
+        uint16_t magic;
+        uint8_t ok;
+        uint8_t pad;
+        char msg[256];
+    } reply = { .magic = STATE_MAGIC_REPLY, .ok = ok, .pad = 0 };
+    strncpy(reply.msg, msg, sizeof(reply.msg) - 1);
+    sendto(fd, &reply, 4 + strlen(reply.msg) + 1, 0, (struct sockaddr*)src, sizeof(*src));
+}
+
+/*
+  effective sample period: the subscriber's request, floored to the
+  physics step and rate limited to about 200k samples per second of
+  wall clock so fine sampling does not overload the sim thread at high
+  speedups. Slowing the simulation down automatically allows finer
+  sampling
+ */
+static void apply_period(void)
+{
+    uint32_t period = period_req_ns;
+    if (period < sitl_cfg.sim.physics_dt_ns) {
+        period = sitl_cfg.sim.physics_dt_ns;
+    }
+    const uint32_t wall_floor = (uint32_t)(5000.0f * sitl_cfg.speedup);
+    if (sitl_cfg.speedup > 0 && period < wall_floor) {
+        period = wall_floor;
+    }
+    period_ns = period;
+}
+
+// called from the sim thread every 100us
+void sitl_state_poll(void)
+{
+    if (fd < 0) {
+        return;
+    }
+    if (have_sub && time(NULL) > sub_expire) {
+        have_sub = false;
+    }
+    uint8_t pkt[512];
+    struct sockaddr_in src;
+    socklen_t srclen = sizeof(src);
+    const ssize_t ret = recvfrom(fd, pkt, sizeof(pkt) - 1, MSG_DONTWAIT, (struct sockaddr*)&src, &srclen);
+    if (ret < 4) {
+        return;
+    }
+    uint16_t magic;
+    memcpy(&magic, pkt, 2);
+    if (magic != STATE_MAGIC_CMD) {
+        return;
+    }
+    const uint8_t cmd = pkt[2];
+    if (cmd == 0 && ret >= 8) {
+        memcpy(&period_req_ns, pkt + 4, 4);
+        averaged = (pkt[3] & 1) != 0;
+        apply_period();
+        sub_addr = src;
+        have_sub = true;
+        sub_expire = time(NULL) + 2;
+    } else if (cmd == 1) {
+        pkt[ret] = 0;
+        load_model((const char*)(pkt + 4), &src);
+    } else if (cmd == 2 && ret >= 8) {
+        float speedup;
+        memcpy(&speedup, pkt + 4, 4);
+        if (speedup >= 0 && speedup <= 100) {
+            // the pacing loop rebases its references on change
+            sitl_cfg.speedup = speedup;
+            apply_period();
+            fprintf(stderr, "SITL: speedup %.3f\n", (double)speedup);
+        }
+    }
+}
+
+// called from the sim thread on every physics step
+void sitl_state_step(uint64_t now_ns)
+{
+    if (!have_sub) {
+        return;
+    }
+    if (averaged) {
+        motor_add_signals(sig_acc);
+        sig_n++;
+    }
+    if (now_ns < next_sample_ns) {
+        return;
+    }
+    next_sample_ns = now_ns + period_ns;
+
+    struct state_sample* s = &batch.s[batch.count];
+    memset(s, 0, sizeof(*s));
+    s->t_ns = now_ns;
+    float omega, theta, theta_e, i[3], v[3], vbus, ibus;
+    motor_get_live_state(&omega, &theta, &theta_e, i, v, &vbus, &ibus);
+    s->omega = omega;
+    s->theta = theta;
+    s->theta_e = theta_e;
+    if (averaged && sig_n > 0) {
+        s->iu = (float)(sig_acc[0] / sig_n);
+        s->iv = (float)(sig_acc[1] / sig_n);
+        s->iw = (float)(sig_acc[2] / sig_n);
+        s->vu = (float)(sig_acc[3] / sig_n);
+        s->vv = (float)(sig_acc[4] / sig_n);
+        s->vw = (float)(sig_acc[5] / sig_n);
+        s->vbus = (float)(sig_acc[6] / sig_n);
+        s->ibus = (float)(sig_acc[7] / sig_n);
+        memset(sig_acc, 0, sizeof(sig_acc));
+        sig_n = 0;
+    } else {
+        s->iu = i[0];
+        s->iv = i[1];
+        s->iw = i[2];
+        s->vu = v[0];
+        s->vv = v[1];
+        s->vw = v[2];
+        s->vbus = vbus;
+        s->ibus = ibus;
+    }
+    for (int p = 0; p < 3; p++) {
+        s->modes[p] = sitl_phase_mode[p];
+    }
+    s->comp_phase = sitl_comp_phase;
+    s->comp_out = sitl_comp_out;
+    batch.count++;
+
+    if (batch.count >= STATE_BATCH || now_ns - last_flush_ns > 5000000ULL) {
+        sendto(fd, &batch, 4 + batch.count * sizeof(struct state_sample), 0,
+               (struct sockaddr*)&sub_addr, sizeof(sub_addr));
+        batch.count = 0;
+        last_flush_ns = now_ns;
+    }
+}

--- a/Mcu/SITL/Src/sitl_timers.c
+++ b/Mcu/SITL/Src/sitl_timers.c
@@ -12,6 +12,7 @@
  */
 
 #include "sitl.h"
+#include <stdio.h>
 
 static SITL_TIM_TypeDef tims[SITL_NUM_TIMS];
 
@@ -76,6 +77,37 @@ static uint32_t tim1_cnt(uint64_t now_ns)
 bool sitl_tim1_pwm_out(int chan, uint64_t now_ns)
 {
     return tim1_cnt(now_ns) < tim1.ccr_act[chan];
+}
+
+/*
+  dead time from the DTG field of the emulated TIM1 BDTR, decoded with
+  the STM32 encoding at t_DTS = one 160MHz CPU tick (CKD is never
+  changed by the firmware). The firmware sets this the same way as on
+  hardware: DEAD_TIME at init plus dead_time_override ORed in from
+  loadEEpromSettings
+ */
+uint32_t sitl_tim1_dead_time_ns(void)
+{
+    static uint32_t last_bdtr = 0xffffffff;
+    static uint32_t dead_ns;
+    const uint32_t bdtr = tims[SITL_TIM1_IDX].BDTR;
+    if (bdtr != last_bdtr) {
+        last_bdtr = bdtr;
+        const uint32_t dtg = bdtr & 0xFF;
+        uint32_t ticks;
+        if ((dtg & 0x80) == 0) {
+            ticks = dtg;
+        } else if ((dtg & 0xC0) == 0x80) {
+            ticks = (64 + (dtg & 0x3F)) * 2;
+        } else if ((dtg & 0xE0) == 0xC0) {
+            ticks = (32 + (dtg & 0x1F)) * 8;
+        } else {
+            ticks = (32 + (dtg & 0x1F)) * 16;
+        }
+        dead_ns = (ticks * CPU_TICK_NS_NUM) / CPU_TICK_NS_DEN;
+        fprintf(stderr, "SITL: dead time %uns (BDTR 0x%02x)\n", dead_ns, dtg);
+    }
+    return dead_ns;
 }
 
 void sitl_tim1_set_duty_all(uint16_t duty)

--- a/Mcu/SITL/Src/sitl_timers.c
+++ b/Mcu/SITL/Src/sitl_timers.c
@@ -1,0 +1,231 @@
+/*
+  sitl_timers.c - emulation of the timers AM32 uses on a G431:
+    TIM1  PWM generation, 160MHz, ARR/CCR preloaded
+    TIM2  INTERVAL_TIMER, 2MHz, 32 bit free running
+    TIM6  TEN_KHZ_TIMER, periodic update interrupt (20kHz loop)
+    TIM16 COM_TIMER, 2MHz, one-shot style update interrupt
+    TIM17 UTILITY_TIMER, 1MHz, 16 bit free running
+
+  Counters are derived from simulated time. Field writes from the firmware
+  thread are plain volatile stores; consistency relies on x86 store
+  ordering plus enable-last write order in the arm helpers.
+ */
+
+#include "sitl.h"
+
+static SITL_TIM_TypeDef tims[SITL_NUM_TIMS];
+
+// nanoseconds per CPU clock tick numerator/denominator: 160MHz = 6.25ns
+#define CPU_TICK_NS_NUM 25
+#define CPU_TICK_NS_DEN 4
+
+static struct {
+    // active (shadow) registers, only updated at update events
+    uint32_t psc_act, arr_act, ccr_act[3];
+    // preload values written by the firmware
+    volatile uint32_t psc_pre, arr_pre, ccr_pre[3];
+    volatile uint64_t period_start_ns;
+} tim1;
+
+static struct {
+    volatile uint64_t base_ns;
+    volatile uint32_t cnt_base;
+} tim2, tim16;
+
+static struct {
+    volatile uint64_t next_due_ns;
+    volatile bool enabled;
+} tim6;
+
+static uint64_t tim1_period_ns(void)
+{
+    const uint64_t ticks = (uint64_t)(tim1.psc_act + 1) * (tim1.arr_act + 1);
+    return (ticks * CPU_TICK_NS_NUM) / CPU_TICK_NS_DEN;
+}
+
+static void tim1_latch(void)
+{
+    tim1.psc_act = tim1.psc_pre;
+    tim1.arr_act = tim1.arr_pre;
+    for (int i = 0; i < 3; i++) {
+        tim1.ccr_act[i] = tim1.ccr_pre[i];
+    }
+}
+
+void sitl_timers_init(void)
+{
+    tim1.psc_pre = 0;
+    tim1.arr_pre = 1999; // overwritten by MX_TIM1_Init
+    for (int i = 0; i < 3; i++) {
+        tim1.ccr_pre[i] = 0;
+    }
+    tim1_latch();
+    tim1.period_start_ns = 0;
+    tims[SITL_TIM6_IDX].ARR = 50;
+}
+
+// current TIM1 counter position in timer ticks
+static uint32_t tim1_cnt(uint64_t now_ns)
+{
+    const uint64_t elapsed = now_ns - tim1.period_start_ns;
+    const uint64_t tick_ns_num = (uint64_t)CPU_TICK_NS_NUM * (tim1.psc_act + 1);
+    // elapsed ticks = elapsed_ns * DEN / (NUM*(psc+1))
+    return (uint32_t)((elapsed * CPU_TICK_NS_DEN) / tick_ns_num);
+}
+
+bool sitl_tim1_pwm_out(int chan, uint64_t now_ns)
+{
+    return tim1_cnt(now_ns) < tim1.ccr_act[chan];
+}
+
+void sitl_tim1_set_duty_all(uint16_t duty)
+{
+    tim1.ccr_pre[0] = duty;
+    tim1.ccr_pre[1] = duty;
+    tim1.ccr_pre[2] = duty;
+}
+
+void sitl_tim1_set_duty(int chan, uint16_t duty)
+{
+    tim1.ccr_pre[chan] = duty;
+}
+
+void sitl_tim1_set_psc(uint16_t psc)
+{
+    tim1.psc_pre = psc;
+}
+
+void sitl_tim1_set_arr(uint16_t arr)
+{
+    tim1.arr_pre = arr;
+}
+
+void sitl_tim1_force_update(void)
+{
+    tim1_latch();
+    tim1.period_start_ns = sitl_time_ns();
+}
+
+/*
+  INTERVAL_TIMER (TIM2), 2MHz
+ */
+static uint32_t interval_ticks_since(uint64_t now_ns, uint64_t base_ns)
+{
+    return (uint32_t)((now_ns - base_ns) / 500U);
+}
+
+uint32_t sitl_interval_timer_count(void)
+{
+    if (sitl_in_sim_thread()) {
+        // interrupt context: busy waits on the timer must see time advance
+        sitl_isr_read_tick();
+    } else {
+        sitl_fw_read_tick();
+    }
+    return tim2.cnt_base + interval_ticks_since(sitl_time_ns(), tim2.base_ns);
+}
+
+void sitl_interval_timer_set(uint32_t cnt)
+{
+    tim2.base_ns = sitl_time_ns();
+    tim2.cnt_base = cnt;
+}
+
+/*
+  COM_TIMER (TIM16), 2MHz, update interrupt used to time commutation
+ */
+void sitl_com_int_arm(uint32_t time)
+{
+    extern void motor_log_event(int kind, uint32_t a, uint32_t b, uint32_t c);
+    motor_log_event(4 /*MEV_ZC_ACCEPT*/, time, 0, 0);
+    SITL_TIM_TypeDef* t = &tims[SITL_TIM16_IDX];
+    tim16.base_ns = sitl_time_ns();
+    tim16.cnt_base = 0;
+    t->ARR = time;
+    t->SR = 0;
+    // enable last: the sim thread only evaluates when DIER is set
+    t->DIER |= 1;
+}
+
+void sitl_com_int_disable(void)
+{
+    tims[SITL_TIM16_IDX].DIER &= ~1U;
+}
+
+void sitl_com_int_enable(void)
+{
+    tims[SITL_TIM16_IDX].DIER |= 1;
+}
+
+void sitl_tenkhz_enable(void)
+{
+    tim6.next_due_ns = sitl_time_ns() + (tims[SITL_TIM6_IDX].ARR + 1) * 1000ULL;
+    tim6.enabled = true;
+}
+
+/*
+  called by the sim thread after each physics step
+ */
+void sitl_timers_step(uint64_t now_ns)
+{
+    // TIM1 update events latch the preload registers
+    uint64_t period = tim1_period_ns();
+    while (now_ns - tim1.period_start_ns >= period) {
+        tim1.period_start_ns += period;
+        tim1_latch();
+        period = tim1_period_ns();
+    }
+
+    // 20kHz loop timer
+    if (tim6.enabled && now_ns >= tim6.next_due_ns) {
+        tim6.next_due_ns += (tims[SITL_TIM6_IDX].ARR + 1) * 1000ULL;
+        sitl_irq_pend(SITL_IRQ_TENKHZ);
+    }
+
+    // commutation timer
+    SITL_TIM_TypeDef* t16 = &tims[SITL_TIM16_IDX];
+    if (t16->DIER & 1) {
+        const uint32_t cnt = tim16.cnt_base + interval_ticks_since(now_ns, tim16.base_ns);
+        if (cnt >= t16->ARR) {
+            // counter wraps to zero and keeps running
+            tim16.base_ns = now_ns;
+            tim16.cnt_base = 0;
+            t16->SR |= 1;
+            sitl_irq_pend(SITL_IRQ_COM);
+        }
+    }
+}
+
+/*
+  register style dereference, syncing CNT with simulated time
+ */
+SITL_TIM_TypeDef* sitl_tim_deref(int idx)
+{
+    SITL_TIM_TypeDef* t = &tims[idx];
+    if (sitl_in_sim_thread()) {
+        // interrupt context: firmware busy waiting on a timer (delayMicros
+        // inside an IRQ handler) must still see time advance, as on real
+        // hardware where the timers keep counting during an interrupt
+        sitl_isr_read_tick();
+    } else {
+        sitl_fw_read_tick();
+    }
+    const uint64_t now = sitl_time_ns();
+    switch (idx) {
+    case SITL_TIM1_IDX:
+        t->CNT = tim1_cnt(now);
+        break;
+    case SITL_TIM2_IDX:
+        t->CNT = tim2.cnt_base + interval_ticks_since(now, tim2.base_ns);
+        break;
+    case SITL_TIM16_IDX:
+        t->CNT = tim16.cnt_base + interval_ticks_since(now, tim16.base_ns);
+        break;
+    case SITL_TIM17_IDX:
+        t->CNT = (uint32_t)((now / 1000U) & 0xffff);
+        break;
+    default:
+        break;
+    }
+    return t;
+}

--- a/Mcu/SITL/dshot_test.py
+++ b/Mcu/SITL/dshot_test.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+'''
+headless PWM/DShot input test for the AM32 SITL
+
+streams frames to the SITL UDP input port, handles zero-throttle arming,
+then applies throttle and reports BDShot replies and rates.
+
+note that the ESC must have INPUT_SIGNAL_TYPE set away from DRONECAN_IN
+(5) or the input interrupts are disabled; use --input-type to set it over
+DroneCAN first (1=DSHOT_IN, 2=SERVO_IN, 0=AUTO_IN)
+
+examples:
+  dshot_test.py --input-type 1 --type dshot300 --throttle 500
+  dshot_test.py --type dshot600 --bidir --throttle 800 --edt
+  dshot_test.py --input-type 2 --type pwm --throttle 1500
+'''
+
+import argparse
+import sys
+import time
+
+import sitl_dshot as sd
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--host', default='127.0.0.1')
+    ap.add_argument('--port', type=int, default=57733)
+    ap.add_argument('--type', default='dshot300', choices=sorted(sd.TYPE_NAMES.keys()))
+    ap.add_argument('--bidir', action='store_true', help='bidirectional DShot (idle high, inverted CRC)')
+    ap.add_argument('--edt', action='store_true', help='enable extended DShot telemetry after arming')
+    ap.add_argument('--rate', type=float, default=500, help='frame rate Hz')
+    ap.add_argument('--throttle', type=float, default=500,
+                    help='DShot value 48..2047, or PWM pulse width in us')
+    ap.add_argument('--arm-time', type=float, default=1.6, help='zero throttle arming time')
+    ap.add_argument('--duration', type=float, default=10, help='run time at throttle')
+    ap.add_argument('--poles', type=int, default=14)
+    ap.add_argument('--bad-crc', type=float, default=0, help='fraction of frames sent with corrupted CRC')
+    ap.add_argument('--input-type', type=int, default=None,
+                    help='first set INPUT_SIGNAL_TYPE over DroneCAN (0=auto 1=dshot 2=servo 5=dronecan), save and restart')
+    ap.add_argument('--can-uri', default='mcast:0')
+    args = ap.parse_args()
+
+    if args.input_type is not None:
+        print('setting INPUT_SIGNAL_TYPE=%d over DroneCAN...' % args.input_type)
+        node = sd.set_dronecan_param('INPUT_SIGNAL_TYPE', args.input_type, uri=args.can_uri)
+        print('set on node %d, restarted' % node)
+        time.sleep(1.0)
+
+    ptype = sd.TYPE_NAMES[args.type]
+    port = sd.InputPort(args.host, args.port)
+    period = 1.0 / args.rate
+
+    zero = 1000 if ptype == sd.TYPE_PWM else 0
+
+    def send(value, telem=False, corrupt=False):
+        if ptype == sd.TYPE_PWM:
+            port.send_pwm(int(value))
+        else:
+            port.send_dshot(int(value), ptype=ptype, telem=telem,
+                            bidir=args.bidir, corrupt=corrupt)
+
+    def stream(value, duration, label):
+        t0 = time.time()
+        next_send = t0
+        last_report = t0
+        nsent = 0
+        erpm_period = None
+        edt = {}
+        badcrc = 0
+        while time.time() - t0 < duration:
+            now = time.time()
+            if now >= next_send:
+                next_send += period
+                corrupt = args.bad_crc > 0 and (nsent % max(1, int(1 / args.bad_crc))) == 0
+                send(value, corrupt=corrupt)
+                nsent += 1
+            for r in port.get_replies():
+                kind, val = sd.decode_reply(r[3], edt_expected=args.edt)
+                if kind == 'erpm':
+                    erpm_period = val
+                elif kind == 'badcrc':
+                    badcrc += 1
+                else:
+                    edt[kind] = val
+            if now - last_report >= 1.0:
+                last_report = now
+                rpm = sd.erpm_period_to_rpm(erpm_period, args.poles) if erpm_period else 0
+                extra = ' '.join('%s=%s' % kv for kv in sorted(edt.items()))
+                print('%s: sent=%u replies=%u rpm=%.0f badcrc=%u %s'
+                      % (label, port.sent_count, port.reply_count, rpm, badcrc, extra))
+                sys.stdout.flush()
+            time.sleep(0.0005)
+
+    print('arming with zero throttle for %.1fs...' % args.arm_time)
+    stream(zero, args.arm_time, 'arm')
+
+    if args.edt and ptype != sd.TYPE_PWM:
+        print('enabling extended DShot telemetry (cmd 13)...')
+        for _ in range(8):
+            send(sd.DSHOT_CMD_EDT_ENABLE, telem=True)
+            time.sleep(period)
+
+    print('throttle %g for %.1fs...' % (args.throttle, args.duration))
+    stream(args.throttle, args.duration, 'run')
+
+    print('back to zero...')
+    stream(zero, 1.0, 'stop')
+    port.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/Mcu/SITL/dshot_test.py
+++ b/Mcu/SITL/dshot_test.py
@@ -71,11 +71,19 @@ def main():
         badcrc = 0
         while time.time() - t0 < duration:
             now = time.time()
-            if now >= next_send:
+            # catch-up burst: coarse sleep granularity (VMs, CI runners)
+            # must not lower the average frame rate - the firmware's
+            # bidirectional auto-detect needs >100 frames before arming
+            # completes
+            burst = 0
+            while now >= next_send and burst < 10:
                 next_send += period
                 corrupt = args.bad_crc > 0 and (nsent % max(1, int(1 / args.bad_crc))) == 0
                 send(value, corrupt=corrupt)
                 nsent += 1
+                burst += 1
+            if now - next_send > 0.25:
+                next_send = now  # fell too far behind, resync
             for r in port.get_replies():
                 kind, val = sd.decode_reply(r[3], edt_expected=args.edt)
                 if kind == 'erpm':

--- a/Mcu/SITL/example.json
+++ b/Mcu/SITL/example.json
@@ -5,10 +5,10 @@
     "resistance": 0.045,
     "inductance": 2.1e-5,
     "mutual_inductance": 0.0,
-    "inertia": 2.0e-5,
+    "inertia": 3.0e-5,
     "damping": 1.0e-6,
     "static_friction": 0.003,
-    "load_k_omega2": 2.0e-9
+    "load_k_omega2": 1.0e-7
   },
   "battery": {
     "voltage": 16.8,

--- a/Mcu/SITL/example.json
+++ b/Mcu/SITL/example.json
@@ -1,0 +1,30 @@
+{
+  "motor": {
+    "kv": 900,
+    "poles": 14,
+    "resistance": 0.045,
+    "inductance": 2.1e-5,
+    "mutual_inductance": 0.0,
+    "inertia": 2.0e-5,
+    "damping": 1.0e-6,
+    "static_friction": 0.003,
+    "load_k_omega2": 2.0e-9
+  },
+  "battery": {
+    "voltage": 16.8,
+    "resistance": 0.012
+  },
+  "esc": {
+    "rds_on": 0.004,
+    "diode_vf": 0.7,
+    "temperature_c": 25
+  },
+  "sim": {
+    "physics_dt_ns": 500,
+    "loop_time_ns": 2000,
+    "isr_read_ns": 100,
+    "comparator_noise_mv": 5,
+    "comparator_hysteresis_mv": 15,
+    "watchdog_enabled": true
+  }
+}

--- a/Mcu/SITL/gui_ci_test.py
+++ b/Mcu/SITL/gui_ci_test.py
@@ -40,10 +40,25 @@ def main():
              '--port', str(INPUT_PORT), '--state-port', str(STATE_PORT),
              '--can-uri', 'mcast:7'],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
-        time.sleep(6.0)
 
+        # first launch can be slow (Qt font cache); retry the connection
         responses = []
-        s = socket.create_connection(('127.0.0.1', CONTROL_PORT), timeout=10)
+        s = None
+        deadline = time.time() + 45
+        while time.time() < deadline:
+            try:
+                s = socket.create_connection(('127.0.0.1', CONTROL_PORT), timeout=5)
+                break
+            except OSError:
+                if gui.poll() is not None:
+                    print(gui.stdout.read() if gui.stdout else '')
+                    print('gui exited before control port came up')
+                    sys.exit(1)
+                time.sleep(1.0)
+        if s is None:
+            gui.kill()
+            print('control port never came up')
+            sys.exit(1)
         f = s.makefile('r')
 
         def reader():

--- a/Mcu/SITL/gui_ci_test.py
+++ b/Mcu/SITL/gui_ci_test.py
@@ -8,6 +8,7 @@ usage: gui_ci_test.py --gui-python Mcu/SITL/venv/bin/python3
 '''
 
 import argparse
+import glob
 import os
 import re
 import socket
@@ -26,8 +27,10 @@ CONTROL_PORT = 57899
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('--gui-python', required=True)
-    default_sitl = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_2.20.elf')
-    ap.add_argument('--sitl', default=os.path.normpath(default_sitl))
+    # don't hardcode the firmware version in the default binary path
+    pat = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_*.elf')
+    hits = sorted(glob.glob(pat))
+    ap.add_argument('--sitl', default=os.path.normpath(hits[0]) if hits else None)
     args = ap.parse_args()
 
     env = dict(os.environ)

--- a/Mcu/SITL/gui_ci_test.py
+++ b/Mcu/SITL/gui_ci_test.py
@@ -54,13 +54,15 @@ def main():
     control_port = sprobe.getsockname()[1]
     sprobe.close()
 
+    # BDShot/EDT path only — keep CAN off so the GUI does not block on
+    # mcast/SocketCAN bring-up (DroneCAN is covered by other tests).
     with Sitl(sitl_path, ['--input-type', '1'], can_uri='none') as sitl:
         gui = subprocess.Popen(
             [args.gui_python, os.path.join(HERE, 'sitl_gui.py'),
              '--control-port', str(control_port),
              '--port', str(sitl.input_port),
              '--state-port', str(sitl.state_port),
-             '--can-uri', 'mcast:7'],
+             '--can-uri', 'none'],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
 
         # first launch can be slow (Qt font cache); retry the connection
@@ -80,19 +82,27 @@ def main():
             gui.kill()
             print('control port never came up')
             sys.exit(1)
+        # connect() timeout must not apply to the long idle gaps between
+        # scripted commands (arm + EDT hold is several seconds).
+        s.settimeout(None)
         f = s.makefile('r')
         responses = []
 
         def reader():
-            for line in f:
-                responses.append(line.rstrip())
+            try:
+                for line in f:
+                    responses.append(line.rstrip())
+            except OSError:
+                pass
 
         threading.Thread(target=reader, daemon=True).start()
 
+        # Hold zero throttle long enough for bidir auto-detect, arming, and
+        # EDT enable (firmware needs 6 identical DShot cmds while stopped).
         for delay, cmd in [
                 (0.1, 'ds_type dshot600'), (0.1, 'ds_bidir 1'),
-                (0.1, 'ds_enable 1'), (0.3, 'ds_edt 1'),
-                (2.5, 'ds_value 900'),
+                (0.1, 'ds_enable 1'), (0.5, 'ds_edt 1'),
+                (4.0, 'ds_value 900'),
                 (1.0, 'graph_i 1'), (0.2, 'graph_v 1'), (0.2, 'motorview 1'),
                 (4.0, 'status'),
                 (1.0, 'quit')]:

--- a/Mcu/SITL/gui_ci_test.py
+++ b/Mcu/SITL/gui_ci_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+'''
+CI test for the SITL GUI: runs the real GUI under Qt's offscreen
+platform, drives it through the control port (arming, EDT, throttle,
+scopes, motor view) and asserts on the telemetry it reports.
+
+usage: gui_ci_test.py --gui-python Mcu/SITL/venv/bin/python3
+'''
+
+import argparse
+import os
+import re
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from run_ci_tests import Sitl, check, failures, INPUT_PORT, STATE_PORT
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CONTROL_PORT = 57899
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--gui-python', required=True)
+    default_sitl = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_2.20.elf')
+    ap.add_argument('--sitl', default=os.path.normpath(default_sitl))
+    args = ap.parse_args()
+
+    env = dict(os.environ)
+    env['QT_QPA_PLATFORM'] = 'offscreen'
+
+    with Sitl(args.sitl, ['--can-uri', 'none', '--input-type', '1']):
+        gui = subprocess.Popen(
+            [args.gui_python, os.path.join(HERE, 'sitl_gui.py'),
+             '--control-port', str(CONTROL_PORT),
+             '--port', str(INPUT_PORT), '--state-port', str(STATE_PORT),
+             '--can-uri', 'mcast:7'],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
+        time.sleep(6.0)
+
+        responses = []
+        s = socket.create_connection(('127.0.0.1', CONTROL_PORT), timeout=10)
+        f = s.makefile('r')
+
+        def reader():
+            for line in f:
+                responses.append(line.rstrip())
+
+        threading.Thread(target=reader, daemon=True).start()
+
+        for delay, cmd in [
+                (0.1, 'ds_type dshot600'), (0.1, 'ds_bidir 1'),
+                (0.1, 'ds_enable 1'), (0.3, 'ds_edt 1'),
+                (2.5, 'ds_value 900'),
+                (1.0, 'graph_i 1'), (0.2, 'graph_v 1'), (0.2, 'motorview 1'),
+                (4.0, 'status'),
+                (1.0, 'quit')]:
+            time.sleep(delay)
+            s.sendall((cmd + '\n').encode())
+
+        try:
+            gui.wait(timeout=20)
+            check('gui exits cleanly', gui.returncode == 0,
+                  'exit=%s' % gui.returncode)
+        except subprocess.TimeoutExpired:
+            gui.kill()
+            check('gui exits cleanly', False, 'hung')
+
+        bds = [r for r in responses if r.startswith('STATUS BDShot')]
+        check('gui got BDShot status', len(bds) > 0, '%d lines' % len(bds))
+        if bds:
+            m = re.search(r'rpm=(\d+)\s+(\w+)\s+EDT:(\w+)', bds[-1])
+            check('gui status parses', m is not None, bds[-1])
+            if m:
+                rpm, spin, edt = int(m.group(1)), m.group(2), m.group(3)
+                check('gui rpm', 4000 <= rpm <= 7000, 'rpm=%d' % rpm)
+                check('gui spinning', spin == 'spinning', spin)
+                check('gui edt on', edt == 'on', 'EDT:%s' % edt)
+        out = gui.stdout.read() if gui.stdout else ''
+        check('gui no tracebacks', 'Traceback' not in out,
+              (out[-300:] if 'Traceback' in out else 'clean'))
+
+    if failures:
+        print('\n%d FAILED' % len(failures))
+        sys.exit(1)
+    print('\ngui test passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/Mcu/SITL/gui_ci_test.py
+++ b/Mcu/SITL/gui_ci_test.py
@@ -7,8 +7,9 @@ scopes, motor view) and asserts on the telemetry it reports.
 usage: gui_ci_test.py --gui-python Mcu/SITL/venv/bin/python3
 '''
 
+from __future__ import annotations
+
 import argparse
-import glob
 import os
 import re
 import socket
@@ -18,39 +19,56 @@ import threading
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from run_ci_tests import Sitl, check, failures, INPUT_PORT, STATE_PORT
+from sitl_harness import Sitl, find_sitl_binary, free_udp_port  # noqa: E402
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-CONTROL_PORT = 57899
+failures = []
+
+
+def check(name, cond, detail):
+    status = 'PASS' if cond else 'FAIL'
+    print('%s: %s (%s)' % (status, name, detail))
+    sys.stdout.flush()
+    if not cond:
+        failures.append(name)
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('--gui-python', required=True)
-    # don't hardcode the firmware version in the default binary path
-    pat = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_*.elf')
-    hits = sorted(glob.glob(pat))
-    ap.add_argument('--sitl', default=os.path.normpath(hits[0]) if hits else None)
+    ap.add_argument('--sitl', default=None)
     args = ap.parse_args()
+
+    sitl_path = find_sitl_binary(args.sitl)
+    if not sitl_path or not os.path.exists(sitl_path):
+        print('SITL binary not found: %s' % sitl_path)
+        sys.exit(2)
 
     env = dict(os.environ)
     env['QT_QPA_PLATFORM'] = 'offscreen'
+    control_port = free_udp_port()
+    # free_udp_port returns a UDP port; TCP control port needs its own bind.
+    # Re-bind via TCP to get a free TCP port.
+    sprobe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sprobe.bind(('127.0.0.1', 0))
+    control_port = sprobe.getsockname()[1]
+    sprobe.close()
 
-    with Sitl(args.sitl, ['--can-uri', 'none', '--input-type', '1']):
+    with Sitl(sitl_path, ['--input-type', '1'], can_uri='none') as sitl:
         gui = subprocess.Popen(
             [args.gui_python, os.path.join(HERE, 'sitl_gui.py'),
-             '--control-port', str(CONTROL_PORT),
-             '--port', str(INPUT_PORT), '--state-port', str(STATE_PORT),
+             '--control-port', str(control_port),
+             '--port', str(sitl.input_port),
+             '--state-port', str(sitl.state_port),
              '--can-uri', 'mcast:7'],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
 
         # first launch can be slow (Qt font cache); retry the connection
-        responses = []
         s = None
         deadline = time.time() + 45
         while time.time() < deadline:
             try:
-                s = socket.create_connection(('127.0.0.1', CONTROL_PORT), timeout=5)
+                s = socket.create_connection(('127.0.0.1', control_port), timeout=5)
                 break
             except OSError:
                 if gui.poll() is not None:
@@ -63,6 +81,7 @@ def main():
             print('control port never came up')
             sys.exit(1)
         f = s.makefile('r')
+        responses = []
 
         def reader():
             for line in f:

--- a/Mcu/SITL/make_gui_env.py
+++ b/Mcu/SITL/make_gui_env.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+'''
+create a self-contained python environment for the SITL GUI in
+Mcu/SITL/venv and install the GUI dependencies (PySide6, pyqtgraph,
+dronecan) into it. Works the same on Linux, Windows and macOS.
+
+usage: python3 make_gui_env.py
+then run the GUI with the interpreter this prints.
+'''
+
+import os
+import subprocess
+import sys
+import venv
+
+here = os.path.dirname(os.path.abspath(__file__))
+env_dir = os.path.join(here, 'venv')
+requirements = os.path.join(here, 'requirements-gui.txt')
+
+if sys.platform == 'win32':
+    python = os.path.join(env_dir, 'Scripts', 'python.exe')
+else:
+    python = os.path.join(env_dir, 'bin', 'python3')
+
+if not os.path.exists(python):
+    print('creating %s ...' % env_dir)
+    venv.EnvBuilder(with_pip=True).create(env_dir)
+
+print('installing GUI dependencies ...')
+subprocess.check_call([python, '-m', 'pip', 'install', '--upgrade',
+                       '-r', requirements])
+
+print('\nGUI environment ready. Run the GUI with:')
+print('  %s %s' % (python, os.path.join(here, 'sitl_gui.py')))

--- a/Mcu/SITL/make_gui_env.py
+++ b/Mcu/SITL/make_gui_env.py
@@ -22,9 +22,58 @@ if sys.platform == 'win32':
 else:
     python = os.path.join(env_dir, 'bin', 'python3')
 
+
+def has_pip(py):
+    try:
+        subprocess.check_call([py, '-m', 'pip', '--version'],
+                              stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL)
+        return True
+    except (subprocess.CalledProcessError, OSError):
+        return False
+
+
+def bootstrap_pip(py):
+    '''Ubuntu/Debian venvs sometimes lack pip even with with_pip=True
+    (missing ensurepip package, or a half-created venv).'''
+    print('bootstrapping pip into the venv ...')
+    try:
+        subprocess.check_call([py, '-m', 'ensurepip', '--upgrade'])
+    except subprocess.CalledProcessError:
+        # last resort: get-pip.py style via pip from the host
+        if has_pip(sys.executable):
+            subprocess.check_call(
+                [sys.executable, '-m', 'pip', 'install', '--upgrade',
+                 'pip', '--target',
+                 os.path.join(env_dir,
+                              'Lib' if sys.platform == 'win32' else
+                              'lib/python%d.%d/site-packages' % sys.version_info[:2])])
+        else:
+            raise SystemExit(
+                'venv has no pip and ensurepip failed.\n'
+                'On Ubuntu/Debian install:  sudo apt install python3-venv python3-pip\n'
+                'Then:  rm -rf Mcu/SITL/venv && python3 Mcu/SITL/make_gui_env.py')
+
+
 if not os.path.exists(python):
     print('creating %s ...' % env_dir)
-    venv.EnvBuilder(with_pip=True).create(env_dir)
+    # with_pip can still fail silently on some distros; we check below
+    try:
+        venv.EnvBuilder(with_pip=True).create(env_dir)
+    except Exception as e:
+        print('venv create with_pip failed (%s), retrying without ...' % e)
+        venv.EnvBuilder(with_pip=False).create(env_dir)
+
+if not os.path.exists(python):
+    raise SystemExit('venv python not found at %s' % python)
+
+if not has_pip(python):
+    bootstrap_pip(python)
+if not has_pip(python):
+    raise SystemExit(
+        'still no pip in %s after bootstrap.\n'
+        'Try:  sudo apt install python3-venv python3-pip\n'
+        '      rm -rf Mcu/SITL/venv && python3 Mcu/SITL/make_gui_env.py' % env_dir)
 
 print('installing GUI dependencies ...')
 subprocess.check_call([python, '-m', 'pip', 'install', '--upgrade',

--- a/Mcu/SITL/models/default_7inch.json
+++ b/Mcu/SITL/models/default_7inch.json
@@ -1,0 +1,13 @@
+{
+  "motor": {
+    "kv": 900,
+    "poles": 14,
+    "resistance": 0.045,
+    "inductance": 2.1e-5,
+    "inertia": 3.0e-5,
+    "damping": 1.0e-6,
+    "static_friction": 0.003,
+    "load_k_omega2": 1.0e-7
+  },
+  "battery": { "voltage": 16.8, "resistance": 0.012 }
+}

--- a/Mcu/SITL/models/heavy_13inch.json
+++ b/Mcu/SITL/models/heavy_13inch.json
@@ -1,0 +1,13 @@
+{
+  "motor": {
+    "kv": 360,
+    "poles": 22,
+    "resistance": 0.09,
+    "inductance": 4.5e-5,
+    "inertia": 2.5e-4,
+    "damping": 3.0e-6,
+    "static_friction": 0.006,
+    "load_k_omega2": 1.0e-6
+  },
+  "battery": { "voltage": 25.2, "resistance": 0.015 }
+}

--- a/Mcu/SITL/models/racer_5inch.json
+++ b/Mcu/SITL/models/racer_5inch.json
@@ -1,0 +1,13 @@
+{
+  "motor": {
+    "kv": 1750,
+    "poles": 14,
+    "resistance": 0.025,
+    "inductance": 8.0e-6,
+    "inertia": 8.0e-6,
+    "damping": 5.0e-7,
+    "static_friction": 0.002,
+    "load_k_omega2": 2.0e-8
+  },
+  "battery": { "voltage": 25.2, "resistance": 0.010 }
+}

--- a/Mcu/SITL/models/unloaded.json
+++ b/Mcu/SITL/models/unloaded.json
@@ -1,0 +1,13 @@
+{
+  "motor": {
+    "kv": 900,
+    "poles": 14,
+    "resistance": 0.045,
+    "inductance": 2.1e-5,
+    "inertia": 2.0e-5,
+    "damping": 1.0e-6,
+    "static_friction": 0.003,
+    "load_k_omega2": 2.0e-9
+  },
+  "battery": { "voltage": 16.8, "resistance": 0.012 }
+}

--- a/Mcu/SITL/requirements-ci.txt
+++ b/Mcu/SITL/requirements-ci.txt
@@ -1,0 +1,3 @@
+# Headless SITL CI dependencies (no GUI)
+dronecan
+pytest>=7.0

--- a/Mcu/SITL/requirements-gui.txt
+++ b/Mcu/SITL/requirements-gui.txt
@@ -1,0 +1,4 @@
+# python dependencies for the SITL control GUI (sitl_gui.py)
+PySide6
+pyqtgraph
+dronecan

--- a/Mcu/SITL/run_ci_tests.py
+++ b/Mcu/SITL/run_ci_tests.py
@@ -1,31 +1,36 @@
 #!/usr/bin/env python3
 '''
-CI test runner for the AM32 SITL: starts the simulator, drives it
-through the PWM/DShot and DroneCAN input paths and asserts on the
-results. Only needs the python standard library; the DroneCAN test runs
-when the dronecan package is importable and is skipped otherwise.
+CI entry point for the AM32 SITL test suite.
 
-usage: run_ci_tests.py [--sitl path/to/elf]
+Prefers pytest (Mcu/SITL/tests/). Falls back to a small inline suite when
+pytest is not installed, so the script stays usable with only the stdlib
+plus optional pydronecan.
+
+usage:
+  python3 Mcu/SITL/run_ci_tests.py [--sitl path/to/elf] [-- pytest-args...]
 exits non-zero if any test fails.
 '''
 
+from __future__ import annotations
+
 import argparse
-import glob
 import os
-import struct
-import subprocess
 import sys
-import threading
 import time
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import sitl_dshot as sd
-from sitl_gui_backend import SimStream
-
 HERE = os.path.dirname(os.path.abspath(__file__))
-INPUT_PORT = 57833
-STATE_PORT = 57834
-CAN_URI = 'mcast:7'
+sys.path.insert(0, HERE)
+
+from sitl_harness import (  # noqa: E402
+    Sender,
+    Sitl,
+    find_sitl_binary,
+    free_mcast_group,
+    open_state,
+    rpm_from_state,
+    wait_for_state,
+)
+import sitl_dshot as sd  # noqa: E402
 
 failures = []
 
@@ -38,85 +43,12 @@ def check(name, cond, detail):
         failures.append(name)
 
 
-class Sitl(object):
-    def __init__(self, sitl_path, extra_args=()):
-        args = [sitl_path, '--input-port', str(INPUT_PORT),
-                '--state-port', str(STATE_PORT), '--nosleep'] + list(extra_args)
-        self.log = open('sitl_ci.log', 'ab')
-        self.proc = subprocess.Popen(args, stdout=self.log, stderr=self.log)
-        time.sleep(0.5)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        self.proc.kill()
-        self.proc.wait()
-        self.log.close()
-        for f in os.listdir('.'):
-            if f.startswith('am32_eeprom.bin'):
-                os.unlink(f)
-
-
-class Sender(object):
-    '''background frame sender with rate catch-up, like the GUI'''
-
-    def __init__(self, ptype, bidir=False, rate=500.0):
-        self.port = sd.InputPort('127.0.0.1', INPUT_PORT)
-        self.ptype = ptype
-        self.bidir = bidir
-        self.rate = rate
-        self.value = 1000 if ptype == sd.TYPE_PWM else 0
-        self.cmds = []
-        self.running = True
-        threading.Thread(target=self._loop, daemon=True).start()
-
-    def _loop(self):
-        nxt = time.time()
-        try:
-            self._run()
-        except OSError:
-            pass  # socket closed by stop()
-
-    def _run(self):
-        nxt = time.time()
-        while self.running:
-            now = time.time()
-            burst = 0
-            while now >= nxt and burst < 10:
-                nxt += 1.0 / self.rate
-                if self.cmds:
-                    self.port.send_dshot(self.cmds.pop(0), ptype=self.ptype,
-                                         telem=True, bidir=self.bidir)
-                elif self.ptype == sd.TYPE_PWM:
-                    self.port.send_pwm(int(self.value))
-                else:
-                    self.port.send_dshot(int(self.value), ptype=self.ptype,
-                                         bidir=self.bidir)
-                burst += 1
-            if now - nxt > 0.25:
-                nxt = now
-            time.sleep(0.0005)
-
-    def stop(self):
-        self.running = False
-        self.port.close()
-
-
-def rpm_from_state(sim, window=1.0):
-    w = sim.window(window)
-    if not w:
-        return -1
-    return sum(s[1] for s in w) / len(w) * 60.0 / 6.28318
-
-
 def test_dshot(sitl_path, name, ptype, bidir, edt, value, rpm_lo, rpm_hi, input_type=1):
-    with Sitl(sitl_path, ['--can-uri', 'none', '--input-type', str(input_type)]):
-        sim = SimStream('127.0.0.1', STATE_PORT, period_us=200)
-        sim.enabled = True
-        tx = Sender(ptype, bidir=bidir)
+    with Sitl(sitl_path, ['--input-type', str(input_type)], can_uri='none') as sitl:
+        sim = open_state('127.0.0.1', sitl.state_port, period_us=200)
+        tx = Sender('127.0.0.1', sitl.input_port, ptype, bidir=bidir)
         try:
-            time.sleep(2.2)                    # arm at zero throttle
+            time.sleep(2.2)
             if edt:
                 tx.cmds = [sd.DSHOT_CMD_EDT_ENABLE] * 8
                 time.sleep(0.5)
@@ -142,7 +74,6 @@ def test_dshot(sitl_path, name, ptype, bidir, edt, value, rpm_lo, rpm_hi, input_
                     check(name + ' edt values',
                           edt_vals.get('temp') == 25 and 14 < edt_vals.get('volt', 0) < 18,
                           'edt=%s' % edt_vals)
-            # motor must stop again at zero throttle
             tx.value = 1000 if ptype == sd.TYPE_PWM else 0
             time.sleep(3.0)
             rpm = rpm_from_state(sim, 0.3)
@@ -158,23 +89,17 @@ def test_dronecan(sitl_path):
     except ImportError:
         print('SKIP: dronecan not installed, DroneCAN test skipped')
         return
-    with Sitl(sitl_path, ['--can-uri', CAN_URI, '--node-id', '10']):
-        sim = SimStream('127.0.0.1', STATE_PORT, period_us=200)
-        sim.enabled = True
-        # some CI runners (github macos) have no multicast capable route
-        # and the SITL cannot bring CAN up: skip rather than fail, with
-        # the SITL log for diagnosis
-        deadline = time.time() + 5
-        while time.time() < deadline and not sim.samples:
-            time.sleep(0.2)
-        if not sim.samples:
+    can_uri = 'mcast:%d' % free_mcast_group()
+    with Sitl(sitl_path, ['--node-id', '10'], can_uri=can_uri, wait_s=1.0) as sitl:
+        sim = open_state('127.0.0.1', sitl.state_port, period_us=200)
+        if not wait_for_state(sim, timeout=5.0):
             print('SKIP: SITL state stream never started with CAN enabled, '
                   'multicast is probably unavailable on this host. SITL log tail:')
             sys.stdout.flush()
-            os.system('tail -5 sitl_ci.log')
+            print(sitl.log_tail(5))
             sim.close()
             return
-        node = dronecan.make_node(CAN_URI, node_id=100, bitrate=1000000)
+        node = dronecan.make_node(can_uri, node_id=100, bitrate=1000000)
         status = {}
 
         def on_esc(e):
@@ -202,31 +127,57 @@ def test_dronecan(sitl_path):
         sim.close()
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__)
-    # don't hardcode the firmware version in the default binary path
-    pat = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_*.elf')
-    hits = sorted(glob.glob(pat))
-    ap.add_argument('--sitl', default=os.path.normpath(hits[0]) if hits else None)
-    args = ap.parse_args()
-
-    if not os.path.exists(args.sitl):
-        print('SITL binary not found: %s' % args.sitl)
-        sys.exit(2)
-
-    test_dshot(args.sitl, 'dshot600 bidir edt', sd.TYPE_DSHOT600,
+def run_legacy(sitl_path):
+    test_dshot(sitl_path, 'dshot600 bidir edt', sd.TYPE_DSHOT600,
                bidir=True, edt=True, value=800, rpm_lo=4000, rpm_hi=7000)
-    test_dshot(args.sitl, 'dshot300', sd.TYPE_DSHOT300,
+    test_dshot(sitl_path, 'dshot300', sd.TYPE_DSHOT300,
                bidir=False, edt=False, value=600, rpm_lo=3000, rpm_hi=6000)
-    test_dshot(args.sitl, 'pwm', sd.TYPE_PWM,
+    test_dshot(sitl_path, 'pwm', sd.TYPE_PWM,
                bidir=False, edt=False, value=1500, rpm_lo=4000, rpm_hi=9000,
                input_type=2)
-    test_dronecan(args.sitl)
-
+    test_dronecan(sitl_path)
     if failures:
         print('\n%d FAILED: %s' % (len(failures), ', '.join(failures)))
-        sys.exit(1)
+        return 1
     print('\nall tests passed')
+    return 0
+
+
+def run_pytest(sitl_path, extra):
+    import pytest
+    args = [
+        os.path.join(HERE, 'tests'),
+        '-v',
+        '--tb=short',
+        '--sitl', sitl_path,
+    ]
+    args += extra
+    return pytest.main(args)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--sitl', default=None, help='path to SITL binary')
+    ap.add_argument('--legacy', action='store_true',
+                    help='run the small stdlib suite instead of pytest')
+    args, rest = ap.parse_known_args()
+
+    sitl_path = find_sitl_binary(args.sitl)
+    if not sitl_path or not os.path.exists(sitl_path):
+        print('SITL binary not found: %s' % sitl_path)
+        sys.exit(2)
+
+    if not args.legacy:
+        try:
+            import pytest  # noqa: F401
+        except ImportError:
+            print('pytest not installed; falling back to legacy suite '
+                  '(pip install -r Mcu/SITL/requirements-ci.txt)')
+            args.legacy = True
+
+    if args.legacy:
+        sys.exit(run_legacy(sitl_path))
+    sys.exit(run_pytest(sitl_path, rest))
 
 
 if __name__ == '__main__':

--- a/Mcu/SITL/run_ci_tests.py
+++ b/Mcu/SITL/run_ci_tests.py
@@ -10,6 +10,7 @@ exits non-zero if any test fails.
 '''
 
 import argparse
+import glob
 import os
 import struct
 import subprocess
@@ -203,8 +204,10 @@ def test_dronecan(sitl_path):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    default_sitl = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_2.20.elf')
-    ap.add_argument('--sitl', default=os.path.normpath(default_sitl))
+    # don't hardcode the firmware version in the default binary path
+    pat = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_*.elf')
+    hits = sorted(glob.glob(pat))
+    ap.add_argument('--sitl', default=os.path.normpath(hits[0]) if hits else None)
     args = ap.parse_args()
 
     if not os.path.exists(args.sitl):

--- a/Mcu/SITL/run_ci_tests.py
+++ b/Mcu/SITL/run_ci_tests.py
@@ -160,6 +160,19 @@ def test_dronecan(sitl_path):
     with Sitl(sitl_path, ['--can-uri', CAN_URI, '--node-id', '10']):
         sim = SimStream('127.0.0.1', STATE_PORT, period_us=200)
         sim.enabled = True
+        # some CI runners (github macos) have no multicast capable route
+        # and the SITL cannot bring CAN up: skip rather than fail, with
+        # the SITL log for diagnosis
+        deadline = time.time() + 5
+        while time.time() < deadline and not sim.samples:
+            time.sleep(0.2)
+        if not sim.samples:
+            print('SKIP: SITL state stream never started with CAN enabled, '
+                  'multicast is probably unavailable on this host. SITL log tail:')
+            sys.stdout.flush()
+            os.system('tail -5 sitl_ci.log')
+            sim.close()
+            return
         node = dronecan.make_node(CAN_URI, node_id=100, bitrate=1000000)
         status = {}
 

--- a/Mcu/SITL/run_ci_tests.py
+++ b/Mcu/SITL/run_ci_tests.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+'''
+CI test runner for the AM32 SITL: starts the simulator, drives it
+through the PWM/DShot and DroneCAN input paths and asserts on the
+results. Only needs the python standard library; the DroneCAN test runs
+when the dronecan package is importable and is skipped otherwise.
+
+usage: run_ci_tests.py [--sitl path/to/elf]
+exits non-zero if any test fails.
+'''
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sitl_dshot as sd
+from sitl_gui_backend import SimStream
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+INPUT_PORT = 57833
+STATE_PORT = 57834
+CAN_URI = 'mcast:7'
+
+failures = []
+
+
+def check(name, cond, detail):
+    status = 'PASS' if cond else 'FAIL'
+    print('%s: %s (%s)' % (status, name, detail))
+    sys.stdout.flush()
+    if not cond:
+        failures.append(name)
+
+
+class Sitl(object):
+    def __init__(self, sitl_path, extra_args=()):
+        args = [sitl_path, '--input-port', str(INPUT_PORT),
+                '--state-port', str(STATE_PORT), '--nosleep'] + list(extra_args)
+        self.log = open('sitl_ci.log', 'ab')
+        self.proc = subprocess.Popen(args, stdout=self.log, stderr=self.log)
+        time.sleep(0.5)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.proc.kill()
+        self.proc.wait()
+        self.log.close()
+        for f in os.listdir('.'):
+            if f.startswith('am32_eeprom.bin'):
+                os.unlink(f)
+
+
+class Sender(object):
+    '''background frame sender with rate catch-up, like the GUI'''
+
+    def __init__(self, ptype, bidir=False, rate=500.0):
+        self.port = sd.InputPort('127.0.0.1', INPUT_PORT)
+        self.ptype = ptype
+        self.bidir = bidir
+        self.rate = rate
+        self.value = 1000 if ptype == sd.TYPE_PWM else 0
+        self.cmds = []
+        self.running = True
+        threading.Thread(target=self._loop, daemon=True).start()
+
+    def _loop(self):
+        nxt = time.time()
+        try:
+            self._run()
+        except OSError:
+            pass  # socket closed by stop()
+
+    def _run(self):
+        nxt = time.time()
+        while self.running:
+            now = time.time()
+            burst = 0
+            while now >= nxt and burst < 10:
+                nxt += 1.0 / self.rate
+                if self.cmds:
+                    self.port.send_dshot(self.cmds.pop(0), ptype=self.ptype,
+                                         telem=True, bidir=self.bidir)
+                elif self.ptype == sd.TYPE_PWM:
+                    self.port.send_pwm(int(self.value))
+                else:
+                    self.port.send_dshot(int(self.value), ptype=self.ptype,
+                                         bidir=self.bidir)
+                burst += 1
+            if now - nxt > 0.25:
+                nxt = now
+            time.sleep(0.0005)
+
+    def stop(self):
+        self.running = False
+        self.port.close()
+
+
+def rpm_from_state(sim, window=1.0):
+    w = sim.window(window)
+    if not w:
+        return -1
+    return sum(s[1] for s in w) / len(w) * 60.0 / 6.28318
+
+
+def test_dshot(sitl_path, name, ptype, bidir, edt, value, rpm_lo, rpm_hi, input_type=1):
+    with Sitl(sitl_path, ['--can-uri', 'none', '--input-type', str(input_type)]):
+        sim = SimStream('127.0.0.1', STATE_PORT, period_us=200)
+        sim.enabled = True
+        tx = Sender(ptype, bidir=bidir)
+        try:
+            time.sleep(2.2)                    # arm at zero throttle
+            if edt:
+                tx.cmds = [sd.DSHOT_CMD_EDT_ENABLE] * 8
+                time.sleep(0.5)
+            tx.value = value
+            time.sleep(4.0)
+            rpm = rpm_from_state(sim)
+            check(name + ' rpm', rpm_lo <= rpm <= rpm_hi,
+                  'rpm=%.0f expected %d..%d' % (rpm, rpm_lo, rpm_hi))
+            if bidir:
+                replies = tx.port.reply_count
+                check(name + ' bdshot replies', replies > 500,
+                      'replies=%d' % replies)
+                erpm = [sd.decode_reply(r[3], edt_expected=edt)
+                        for r in tx.port.get_replies()]
+                rpms = [sd.erpm_period_to_rpm(v) for k, v in erpm if k == 'erpm']
+                if rpms:
+                    check(name + ' bdshot rpm agrees',
+                          abs(rpms[-1] - rpm) < max(200, rpm * 0.05),
+                          'bdshot=%.0f state=%.0f' % (rpms[-1], rpm))
+                if edt:
+                    edt_vals = dict((k, v) for k, v in erpm
+                                    if k in ('temp', 'volt', 'current'))
+                    check(name + ' edt values',
+                          edt_vals.get('temp') == 25 and 14 < edt_vals.get('volt', 0) < 18,
+                          'edt=%s' % edt_vals)
+            # motor must stop again at zero throttle
+            tx.value = 1000 if ptype == sd.TYPE_PWM else 0
+            time.sleep(3.0)
+            rpm = rpm_from_state(sim, 0.3)
+            check(name + ' stops', rpm < 500, 'rpm=%.0f' % rpm)
+        finally:
+            tx.stop()
+            sim.close()
+
+
+def test_dronecan(sitl_path):
+    try:
+        import dronecan
+    except ImportError:
+        print('SKIP: dronecan not installed, DroneCAN test skipped')
+        return
+    with Sitl(sitl_path, ['--can-uri', CAN_URI, '--node-id', '10']):
+        sim = SimStream('127.0.0.1', STATE_PORT, period_us=200)
+        sim.enabled = True
+        node = dronecan.make_node(CAN_URI, node_id=100, bitrate=1000000)
+        status = {}
+
+        def on_esc(e):
+            status['rpm'] = e.message.rpm
+            status['voltage'] = e.message.voltage
+
+        node.add_handler(dronecan.uavcan.equipment.esc.Status, on_esc)
+        t0 = time.time()
+        nxt = t0
+        while time.time() - t0 < 10:
+            node.spin(0)
+            now = time.time()
+            if now >= nxt:
+                nxt += 0.02
+                thr = 0.35 if now - t0 > 2.5 else 0.0
+                node.broadcast(dronecan.uavcan.equipment.safety.ArmingStatus(status=255))
+                node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=[int(8191 * thr)]))
+            time.sleep(0.001)
+        rpm = rpm_from_state(sim)
+        check('dronecan rpm', 3500 <= rpm <= 6500, 'rpm=%.0f' % rpm)
+        check('dronecan telemetry', 3500 <= status.get('rpm', -1) <= 6500
+              and 15 < status.get('voltage', 0) < 18,
+              'esc.Status=%s' % status)
+        node.close()
+        sim.close()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    default_sitl = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_2.20.elf')
+    ap.add_argument('--sitl', default=os.path.normpath(default_sitl))
+    args = ap.parse_args()
+
+    if not os.path.exists(args.sitl):
+        print('SITL binary not found: %s' % args.sitl)
+        sys.exit(2)
+
+    test_dshot(args.sitl, 'dshot600 bidir edt', sd.TYPE_DSHOT600,
+               bidir=True, edt=True, value=800, rpm_lo=4000, rpm_hi=7000)
+    test_dshot(args.sitl, 'dshot300', sd.TYPE_DSHOT300,
+               bidir=False, edt=False, value=600, rpm_lo=3000, rpm_hi=6000)
+    test_dshot(args.sitl, 'pwm', sd.TYPE_PWM,
+               bidir=False, edt=False, value=1500, rpm_lo=4000, rpm_hi=9000,
+               input_type=2)
+    test_dronecan(args.sitl)
+
+    if failures:
+        print('\n%d FAILED: %s' % (len(failures), ', '.join(failures)))
+        sys.exit(1)
+    print('\nall tests passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/Mcu/SITL/sim/jsmn.c
+++ b/Mcu/SITL/sim/jsmn.c
@@ -1,0 +1,311 @@
+#include "jsmn.h"
+
+/**
+ * Allocates a fresh unused token from the token pull.
+ */
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser,
+		jsmntok_t *tokens, size_t num_tokens) {
+	jsmntok_t *tok;
+	if (parser->toknext >= num_tokens) {
+		return NULL;
+	}
+	tok = &tokens[parser->toknext++];
+	tok->start = tok->end = -1;
+	tok->size = 0;
+#ifdef JSMN_PARENT_LINKS
+	tok->parent = -1;
+#endif
+	return tok;
+}
+
+/**
+ * Fills token type and boundaries.
+ */
+static void jsmn_fill_token(jsmntok_t *token, jsmntype_t type,
+                            int start, int end) {
+	token->type = type;
+	token->start = start;
+	token->end = end;
+	token->size = 0;
+}
+
+/**
+ * Fills next available token with JSON primitive.
+ */
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+		size_t len, jsmntok_t *tokens, size_t num_tokens) {
+	jsmntok_t *token;
+	int start;
+
+	start = parser->pos;
+
+	for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+		switch (js[parser->pos]) {
+#ifndef JSMN_STRICT
+			/* In strict mode primitive must be followed by "," or "}" or "]" */
+			case ':':
+#endif
+			case '\t' : case '\r' : case '\n' : case ' ' :
+			case ','  : case ']'  : case '}' :
+				goto found;
+		}
+		if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+			parser->pos = start;
+			return JSMN_ERROR_INVAL;
+		}
+	}
+#ifdef JSMN_STRICT
+	/* In strict mode primitive must be followed by a comma/object/array */
+	parser->pos = start;
+	return JSMN_ERROR_PART;
+#endif
+
+found:
+	if (tokens == NULL) {
+		parser->pos--;
+		return 0;
+	}
+	token = jsmn_alloc_token(parser, tokens, num_tokens);
+	if (token == NULL) {
+		parser->pos = start;
+		return JSMN_ERROR_NOMEM;
+	}
+	jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+	token->parent = parser->toksuper;
+#endif
+	parser->pos--;
+	return 0;
+}
+
+/**
+ * Fills next token with JSON string.
+ */
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+		size_t len, jsmntok_t *tokens, size_t num_tokens) {
+	jsmntok_t *token;
+
+	int start = parser->pos;
+
+	parser->pos++;
+
+	/* Skip starting quote */
+	for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+		char c = js[parser->pos];
+
+		/* Quote: end of string */
+		if (c == '\"') {
+			if (tokens == NULL) {
+				return 0;
+			}
+			token = jsmn_alloc_token(parser, tokens, num_tokens);
+			if (token == NULL) {
+				parser->pos = start;
+				return JSMN_ERROR_NOMEM;
+			}
+			jsmn_fill_token(token, JSMN_STRING, start+1, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+			token->parent = parser->toksuper;
+#endif
+			return 0;
+		}
+
+		/* Backslash: Quoted symbol expected */
+		if (c == '\\' && parser->pos + 1 < len) {
+			int i;
+			parser->pos++;
+			switch (js[parser->pos]) {
+				/* Allowed escaped symbols */
+				case '\"': case '/' : case '\\' : case 'b' :
+				case 'f' : case 'r' : case 'n'  : case 't' :
+					break;
+				/* Allows escaped symbol \uXXXX */
+				case 'u':
+					parser->pos++;
+					for(i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0'; i++) {
+						/* If it isn't a hex character we have an error */
+						if(!((js[parser->pos] >= 48 && js[parser->pos] <= 57) || /* 0-9 */
+									(js[parser->pos] >= 65 && js[parser->pos] <= 70) || /* A-F */
+									(js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+							parser->pos = start;
+							return JSMN_ERROR_INVAL;
+						}
+						parser->pos++;
+					}
+					parser->pos--;
+					break;
+				/* Unexpected symbol */
+				default:
+					parser->pos = start;
+					return JSMN_ERROR_INVAL;
+			}
+		}
+	}
+	parser->pos = start;
+	return JSMN_ERROR_PART;
+}
+
+/**
+ * Parse JSON string and fill tokens.
+ */
+int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+		jsmntok_t *tokens, unsigned int num_tokens) {
+	int r;
+	int i;
+	jsmntok_t *token;
+	int count = parser->toknext;
+
+	for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+		char c;
+		jsmntype_t type;
+
+		c = js[parser->pos];
+		switch (c) {
+			case '{': case '[':
+				count++;
+				if (tokens == NULL) {
+					break;
+				}
+				token = jsmn_alloc_token(parser, tokens, num_tokens);
+				if (token == NULL)
+					return JSMN_ERROR_NOMEM;
+				if (parser->toksuper != -1) {
+					tokens[parser->toksuper].size++;
+#ifdef JSMN_PARENT_LINKS
+					token->parent = parser->toksuper;
+#endif
+				}
+				token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+				token->start = parser->pos;
+				parser->toksuper = parser->toknext - 1;
+				break;
+			case '}': case ']':
+				if (tokens == NULL)
+					break;
+				type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+				if (parser->toknext < 1) {
+					return JSMN_ERROR_INVAL;
+				}
+				token = &tokens[parser->toknext - 1];
+				for (;;) {
+					if (token->start != -1 && token->end == -1) {
+						if (token->type != type) {
+							return JSMN_ERROR_INVAL;
+						}
+						token->end = parser->pos + 1;
+						parser->toksuper = token->parent;
+						break;
+					}
+					if (token->parent == -1) {
+						break;
+					}
+					token = &tokens[token->parent];
+				}
+#else
+				for (i = parser->toknext - 1; i >= 0; i--) {
+					token = &tokens[i];
+					if (token->start != -1 && token->end == -1) {
+						if (token->type != type) {
+							return JSMN_ERROR_INVAL;
+						}
+						parser->toksuper = -1;
+						token->end = parser->pos + 1;
+						break;
+					}
+				}
+				/* Error if unmatched closing bracket */
+				if (i == -1) return JSMN_ERROR_INVAL;
+				for (; i >= 0; i--) {
+					token = &tokens[i];
+					if (token->start != -1 && token->end == -1) {
+						parser->toksuper = i;
+						break;
+					}
+				}
+#endif
+				break;
+			case '\"':
+				r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+				if (r < 0) return r;
+				count++;
+				if (parser->toksuper != -1 && tokens != NULL)
+					tokens[parser->toksuper].size++;
+				break;
+			case '\t' : case '\r' : case '\n' : case ' ':
+				break;
+			case ':':
+				parser->toksuper = parser->toknext - 1;
+				break;
+			case ',':
+				if (tokens != NULL && parser->toksuper != -1 &&
+						tokens[parser->toksuper].type != JSMN_ARRAY &&
+						tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+					parser->toksuper = tokens[parser->toksuper].parent;
+#else
+					for (i = parser->toknext - 1; i >= 0; i--) {
+						if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+							if (tokens[i].start != -1 && tokens[i].end == -1) {
+								parser->toksuper = i;
+								break;
+							}
+						}
+					}
+#endif
+				}
+				break;
+#ifdef JSMN_STRICT
+			/* In strict mode primitives are: numbers and booleans */
+			case '-': case '0': case '1' : case '2': case '3' : case '4':
+			case '5': case '6': case '7' : case '8': case '9':
+			case 't': case 'f': case 'n' :
+				/* And they must not be keys of the object */
+				if (tokens != NULL && parser->toksuper != -1) {
+					jsmntok_t *t = &tokens[parser->toksuper];
+					if (t->type == JSMN_OBJECT ||
+							(t->type == JSMN_STRING && t->size != 0)) {
+						return JSMN_ERROR_INVAL;
+					}
+				}
+#else
+			/* In non-strict mode every unquoted value is a primitive */
+			default:
+#endif
+				r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+				if (r < 0) return r;
+				count++;
+				if (parser->toksuper != -1 && tokens != NULL)
+					tokens[parser->toksuper].size++;
+				break;
+
+#ifdef JSMN_STRICT
+			/* Unexpected char in strict mode */
+			default:
+				return JSMN_ERROR_INVAL;
+#endif
+		}
+	}
+
+	if (tokens != NULL) {
+		for (i = parser->toknext - 1; i >= 0; i--) {
+			/* Unmatched opened object or array */
+			if (tokens[i].start != -1 && tokens[i].end == -1) {
+				return JSMN_ERROR_PART;
+			}
+		}
+	}
+
+	return count;
+}
+
+/**
+ * Creates a new parser based over a given  buffer with an array of tokens
+ * available.
+ */
+void jsmn_init(jsmn_parser *parser) {
+	parser->pos = 0;
+	parser->toknext = 0;
+	parser->toksuper = -1;
+}
+

--- a/Mcu/SITL/sim/jsmn.h
+++ b/Mcu/SITL/sim/jsmn.h
@@ -1,0 +1,76 @@
+#ifndef __JSMN_H_
+#define __JSMN_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * JSON type identifier. Basic types are:
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
+ */
+typedef enum {
+	JSMN_UNDEFINED = 0,
+	JSMN_OBJECT = 1,
+	JSMN_ARRAY = 2,
+	JSMN_STRING = 3,
+	JSMN_PRIMITIVE = 4
+} jsmntype_t;
+
+enum jsmnerr {
+	/* Not enough tokens were provided */
+	JSMN_ERROR_NOMEM = -1,
+	/* Invalid character inside JSON string */
+	JSMN_ERROR_INVAL = -2,
+	/* The string is not a full JSON packet, more bytes expected */
+	JSMN_ERROR_PART = -3
+};
+
+/**
+ * JSON token description.
+ * @param		type	type (object, array, string etc.)
+ * @param		start	start position in JSON data string
+ * @param		end		end position in JSON data string
+ */
+typedef struct {
+	jsmntype_t type;
+	int start;
+	int end;
+	int size;
+#ifdef JSMN_PARENT_LINKS
+	int parent;
+#endif
+} jsmntok_t;
+
+/**
+ * JSON parser. Contains an array of token blocks available. Also stores
+ * the string being parsed now and current position in that string
+ */
+typedef struct {
+	unsigned int pos; /* offset in the JSON string */
+	unsigned int toknext; /* next token to allocate */
+	int toksuper; /* superior token node, e.g parent object or array */
+} jsmn_parser;
+
+/**
+ * Create JSON parser over an array of tokens
+ */
+void jsmn_init(jsmn_parser *parser);
+
+/**
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each describing
+ * a single JSON object.
+ */
+int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+		jsmntok_t *tokens, unsigned int num_tokens);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __JSMN_H_ */

--- a/Mcu/SITL/sim/motor.c
+++ b/Mcu/SITL/sim/motor.c
@@ -4,11 +4,32 @@
 
   The electrical model follows the approach of open-bldc-csim
   (https://github.com/open-bldc/open-bldc-csim, GPLv3+, Piotr
-  Esden-Tempski): per phase currents with a solved star point voltage so
-  the floating phase terminal voltage (and therefore the BEMF zero
-  crossing seen by the comparator) is physical. Extended with fet Rds_on,
-  body diode clamping of a floating phase that still carries current, and
-  battery internal resistance.
+  Esden-Tempski), which in turn implements Kang & Yoo, "Switching
+  Pattern-Independent Simulation Model for Brushless DC Motors", Journal
+  of Power Electronics 11-2, 2011:
+  https://jpels.org/digital-library/manuscript/file/17706/8_JPE-10238.pdf
+
+  As in the paper, each step finds the conducting phases from the switch
+  and diode states, computes the motor neutral as the average of (v - e)
+  over the conducting phases (paper eq 10) and integrates
+  v = R*i + (L-M)*di/dt + e + v_m for each of them (paper eq 1), so the
+  floating phase terminal voltage (and therefore the BEMF zero crossing
+  seen by the comparator) is physical for any switching pattern.
+
+  Differences from the paper:
+   - gate states come from the emulated TIM1 compare outputs and the AM32
+     phase modes rather than switching functions, which adds dead time
+     windows with body diode conduction
+   - fets have Rds_on, and the diode Vf appears in the clamped terminal
+     voltage, not only in the diode on/off conditions
+   - the battery has internal resistance, so Vdc sags with load instead
+     of being stiff
+   - the load model adds a k*omega^2 propeller torque and static friction
+     to the paper's viscous damping
+   - torque uses the flux linkage form kt*sum(shape*i) (the second form
+     of paper eq 2), which is valid at omega = 0
+   - integration is forward euler at 500ns steps rather than ode45 at
+     2.5us
 
   Conventions:
    - phase currents are positive INTO the motor terminal
@@ -231,9 +252,10 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
         }
     }
 
-    // terminal voltages. A driven phase is tied to the rail through the
-    // fet; an undriven phase carrying current is clamped by a body diode;
-    // an undriven phase without current floats at e + v_star
+    // terminal voltages (paper eq 9); conducting[] is the excited set of
+    // paper eq 8. A driven phase is tied to the rail through the fet; an
+    // undriven phase carrying current is clamped by a body diode; an
+    // undriven phase without current floats at e + v_star
     double v[3];
     double r_eff[3];
     bool conducting[3];
@@ -248,7 +270,7 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
             r_eff[p] += rds;
             conducting[p] = true;
         } else if (fabs(m.i[p]) > i_eps) {
-            // body diode freewheeling
+            // body diode freewheeling (paper eq 7, current condition)
             v[p] = m.i[p] < 0 ? vbus + vf : -vf;
             conducting[p] = true;
         } else {
@@ -258,8 +280,9 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
         }
     }
 
-    // star point voltage from the conducting phases (sum of currents is
-    // zero and impedances are equal)
+    // star point voltage from the conducting phases (paper eq 10; sum of
+    // currents is zero and impedances are equal). With nothing conducting
+    // the network floats; centre it on the bus as a symmetric bridge does
     double v_star = 0;
     int n_cond = 0;
     for (int p = 0; p < 3; p++) {
@@ -268,18 +291,45 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
             n_cond++;
         }
     }
-    if (n_cond > 0) {
-        v_star /= n_cond;
-    }
-    // a single conducting phase cannot drive current into the star point
-    if (n_cond == 1) {
+    v_star = n_cond > 0 ? v_star / n_cond : 0.5 * vbus;
+
+    // paper eq 7 second condition / fig 2(e): a body diode also turns on
+    // when the floating terminal voltage e + v_m would exceed the rails,
+    // even with no phase current. This clamps the floating phase at high
+    // BEMF and lets a windmilling motor rectify into the battery. Each
+    // new clamp moves the star point, so iterate
+    for (int pass = 0; pass < 3; pass++) {
+        bool changed = false;
         for (int p = 0; p < 3; p++) {
-            if (conducting[p] && !hi[p] && !lo[p]) {
-                // lone diode phase: current decays through the diode
+            if (conducting[p]) {
+                continue;
+            }
+            const double vt = e[p] + v_star;
+            if (vt > vbus + vf) {
+                v[p] = vbus + vf;
+            } else if (vt < -vf) {
+                v[p] = -vf;
+            } else {
+                continue;
+            }
+            conducting[p] = true;
+            changed = true;
+        }
+        if (!changed) {
+            break;
+        }
+        v_star = 0;
+        n_cond = 0;
+        for (int p = 0; p < 3; p++) {
+            if (conducting[p]) {
+                v_star += v[p] - e[p];
+                n_cond++;
             }
         }
+        v_star /= n_cond;
     }
 
+    // an open phase floats at e + v_m (paper eq 9)
     for (int p = 0; p < 3; p++) {
         if (!conducting[p]) {
             v[p] = e[p] + v_star;
@@ -290,7 +340,7 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
         m.v_term[p] = v[p];
     }
 
-    // phase current derivatives, semi-implicit euler
+    // phase current derivatives (paper eq 1), forward euler
     for (int p = 0; p < 3; p++) {
         if (!conducting[p]) {
             continue;
@@ -320,13 +370,14 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
         }
     }
 
-    // electromagnetic torque: tau = ke * sum(shape_p * i_p)
+    // electromagnetic torque: tau = ke * sum(shape_p * i_p) (paper eq 2)
     double tau = 0;
     for (int p = 0; p < 3; p++) {
         tau += m.ke * shape[p] * m.i[p];
     }
 
-    // load torques
+    // load torques and motion (paper eq 3, plus k*omega^2 propeller
+    // load and static friction)
     const double w = m.omega;
     double tau_load = sitl_cfg.motor.damping * w + sitl_cfg.motor.load_k_omega2 * w * fabs(w);
     double tau_net = tau - tau_load;

--- a/Mcu/SITL/sim/motor.c
+++ b/Mcu/SITL/sim/motor.c
@@ -1,0 +1,485 @@
+/*
+  motor.c - trapezoidal BEMF BLDC motor, 3 phase bridge and battery model
+  for AM32 SITL.
+
+  The electrical model follows the approach of open-bldc-csim
+  (https://github.com/open-bldc/open-bldc-csim, GPLv3+, Piotr
+  Esden-Tempski): per phase currents with a solved star point voltage so
+  the floating phase terminal voltage (and therefore the BEMF zero
+  crossing seen by the comparator) is physical. Extended with fet Rds_on,
+  body diode clamping of a floating phase that still carries current, and
+  battery internal resistance.
+
+  Conventions:
+   - phase currents are positive INTO the motor terminal
+   - terminal voltages are referenced to battery negative
+   - theta is the mechanical rotor angle in radians
+ */
+
+#include "motor.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sitl.h"
+#include "sitl_config.h"
+#include "eeprom.h"
+
+#define TWO_PI 6.283185307179586
+
+// which EXTI line the active comparator drives, owned by comparator.c
+extern uint32_t current_EXTI_LINE;
+
+static void check_desync_dump(void);
+static void dump_ring(void);
+
+static struct {
+    double theta; // mechanical angle, rad
+    double omega; // mechanical speed, rad/s
+    double i[3]; // phase currents, A
+    double ke; // V/(rad/s) mechanical
+    double vbus; // battery terminal voltage after sag
+    double ibus; // battery current, previous step (breaks the loop)
+    // sensor averaging accumulators
+    double acc_v, acc_i;
+    uint32_t acc_n;
+    unsigned rand_seed;
+    // seqlock for the sensor snapshot
+    volatile uint32_t seq;
+    sitl_sensors_t sensors;
+} m;
+
+void motor_init(void)
+{
+    memset(&m, 0, sizeof(m));
+    // per phase BEMF constant [V s/rad] from Kv [rpm/V]. Kv is defined
+    // line to line and two phases conduct in series, so halve it
+    m.ke = 0.5 * 60.0 / (TWO_PI * sitl_cfg.motor.kv);
+    m.vbus = sitl_cfg.battery.voltage;
+    m.rand_seed = 12345;
+    m.sensors.bus_voltage = m.vbus;
+    m.sensors.temperature_c = sitl_cfg.esc.temperature_c;
+}
+
+/*
+  normalised trapezoidal BEMF shape over one electrical revolution.
+  Rising zero crossing at 0, falling at pi, flat top from pi/6..5pi/6
+ */
+static double trap_shape(double thetae)
+{
+    thetae = fmod(thetae, TWO_PI);
+    if (thetae < 0) {
+        thetae += TWO_PI;
+    }
+    const double s = M_PI / 6; // 30 degree ramp
+    if (thetae < s) {
+        return thetae / s;
+    }
+    if (thetae < M_PI - s) {
+        return 1.0;
+    }
+    if (thetae < M_PI + s) {
+        return (M_PI - thetae) / s;
+    }
+    if (thetae < TWO_PI - s) {
+        return -1.0;
+    }
+    return (thetae - TWO_PI) / s;
+}
+
+void sitl_sensors_write(const sitl_sensors_t* in)
+{
+    m.seq++;
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    m.sensors = *in;
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    m.seq++;
+}
+
+void sitl_sensors_read(sitl_sensors_t* out)
+{
+    for (;;) {
+        const uint32_t s1 = m.seq;
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        *out = m.sensors;
+        __atomic_thread_fence(__ATOMIC_SEQ_CST);
+        if (s1 == m.seq && (s1 & 1) == 0) {
+            return;
+        }
+    }
+}
+
+void motor_step(uint64_t now_ns, uint32_t dt_ns)
+{
+    const double dt = dt_ns * 1e-9;
+    const int pole_pairs = sitl_cfg.motor.poles / 2;
+    const double R = sitl_cfg.motor.resistance;
+    const double L_eff = sitl_cfg.motor.inductance - sitl_cfg.motor.mutual_inductance;
+    const double rds = sitl_cfg.esc.rds_on;
+    const double vf = sitl_cfg.esc.diode_vf;
+    const double i_eps = 0.01; // A, diode turn off threshold
+
+    // battery sag from last step's bus current
+    double vbus = sitl_cfg.battery.voltage - m.ibus * sitl_cfg.battery.resistance;
+    if (vbus < 0) {
+        vbus = 0;
+    }
+    m.vbus = vbus;
+
+    // BEMF per phase
+    // phase order such that the AM32 comStep sequence 1..6 advances the
+    // field by +60 degrees electrical per step (verified by detent test)
+    const double thetae = m.theta * pole_pairs;
+    double e[3], shape[3];
+    for (int p = 0; p < 3; p++) {
+        shape[p] = trap_shape(thetae + p * (TWO_PI / 3.0));
+        e[p] = m.ke * m.omega * shape[p];
+    }
+
+    // gate states from the phase mode and the emulated PWM timer
+    bool hi[3], lo[3];
+    for (int p = 0; p < 3; p++) {
+        const bool pwm = sitl_tim1_pwm_out(p, now_ns);
+        switch (sitl_phase_mode[p]) {
+        case SITL_PHASE_PWM:
+            hi[p] = pwm;
+            lo[p] = !pwm;
+            break;
+        case SITL_PHASE_PWM_NOCOMP:
+            hi[p] = pwm;
+            lo[p] = false;
+            break;
+        case SITL_PHASE_LOW:
+            hi[p] = false;
+            lo[p] = true;
+            break;
+        case SITL_PHASE_BRAKE_PWM:
+            hi[p] = false;
+            lo[p] = !pwm;
+            break;
+        case SITL_PHASE_FLOAT:
+        default:
+            hi[p] = false;
+            lo[p] = false;
+            break;
+        }
+    }
+
+    // terminal voltages. A driven phase is tied to the rail through the
+    // fet; an undriven phase carrying current is clamped by a body diode;
+    // an undriven phase without current floats at e + v_star
+    double v[3];
+    double r_eff[3];
+    bool conducting[3];
+    for (int p = 0; p < 3; p++) {
+        r_eff[p] = R;
+        if (hi[p]) {
+            v[p] = vbus;
+            r_eff[p] += rds;
+            conducting[p] = true;
+        } else if (lo[p]) {
+            v[p] = 0;
+            r_eff[p] += rds;
+            conducting[p] = true;
+        } else if (fabs(m.i[p]) > i_eps) {
+            // body diode freewheeling
+            v[p] = m.i[p] < 0 ? vbus + vf : -vf;
+            conducting[p] = true;
+        } else {
+            m.i[p] = 0;
+            v[p] = 0; // filled in after v_star is known
+            conducting[p] = false;
+        }
+    }
+
+    // star point voltage from the conducting phases (sum of currents is
+    // zero and impedances are equal)
+    double v_star = 0;
+    int n_cond = 0;
+    for (int p = 0; p < 3; p++) {
+        if (conducting[p]) {
+            v_star += v[p] - e[p];
+            n_cond++;
+        }
+    }
+    if (n_cond > 0) {
+        v_star /= n_cond;
+    }
+    // a single conducting phase cannot drive current into the star point
+    if (n_cond == 1) {
+        for (int p = 0; p < 3; p++) {
+            if (conducting[p] && !hi[p] && !lo[p]) {
+                // lone diode phase: current decays through the diode
+            }
+        }
+    }
+
+    for (int p = 0; p < 3; p++) {
+        if (!conducting[p]) {
+            v[p] = e[p] + v_star;
+        }
+    }
+
+    // phase current derivatives, semi-implicit euler
+    for (int p = 0; p < 3; p++) {
+        if (!conducting[p]) {
+            continue;
+        }
+        const double di = (v[p] - r_eff[p] * m.i[p] - e[p] - v_star) / L_eff;
+        m.i[p] += di * dt;
+    }
+    // with exactly two conducting phases KCL forces them equal and
+    // opposite; project out any numerical drift
+    if (n_cond == 2) {
+        int a = -1, b = -1;
+        for (int p = 0; p < 3; p++) {
+            if (conducting[p]) {
+                if (a < 0) {
+                    a = p;
+                } else {
+                    b = p;
+                }
+            }
+        }
+        const double ic = 0.5 * (m.i[a] - m.i[b]);
+        m.i[a] = ic;
+        m.i[b] = -ic;
+    } else if (n_cond < 2) {
+        for (int p = 0; p < 3; p++) {
+            m.i[p] = 0;
+        }
+    }
+
+    // electromagnetic torque: tau = ke * sum(shape_p * i_p)
+    double tau = 0;
+    for (int p = 0; p < 3; p++) {
+        tau += m.ke * shape[p] * m.i[p];
+    }
+
+    // load torques
+    const double w = m.omega;
+    double tau_load = sitl_cfg.motor.damping * w + sitl_cfg.motor.load_k_omega2 * w * fabs(w);
+    double tau_net = tau - tau_load;
+    const double sf = sitl_cfg.motor.static_friction;
+    if (fabs(w) < 0.5) {
+        // static friction dead band
+        if (fabs(tau_net) <= sf) {
+            tau_net = 0;
+            m.omega = 0;
+        } else {
+            tau_net -= (tau_net > 0 ? sf : -sf);
+        }
+    } else {
+        tau_net -= (w > 0 ? sf : -sf);
+    }
+    m.omega += tau_net / sitl_cfg.motor.inertia * dt;
+    m.theta += m.omega * dt;
+    if (m.theta > TWO_PI || m.theta < -TWO_PI) {
+        m.theta = fmod(m.theta, TWO_PI);
+    }
+
+    // battery current: everything sourced from the positive rail
+    double ibus = 0;
+    for (int p = 0; p < 3; p++) {
+        if (conducting[p] && v[p] >= vbus - 1e-9) {
+            ibus += m.i[p];
+        }
+    }
+    m.ibus = ibus;
+
+    // comparator: virtual neutral against the floating phase terminal
+    const double v_neutral = (v[0] + v[1] + v[2]) / 3.0;
+    const double v_float = v[sitl_comp_phase];
+    double diff_mv = (v_neutral - v_float) * 1000.0;
+    if (sitl_cfg.sim.comparator_noise_mv > 0) {
+        const double r = (double)rand_r(&m.rand_seed) / RAND_MAX - 0.5;
+        diff_mv += r * 2.0 * sitl_cfg.sim.comparator_noise_mv;
+    }
+    const double hyst = sitl_cfg.sim.comparator_hysteresis_mv * 0.5;
+    uint8_t out = sitl_comp_out;
+    if (out) {
+        out = diff_mv > -hyst;
+    } else {
+        out = diff_mv > hyst;
+    }
+    if (out != sitl_comp_out) {
+        sitl_comp_out = out;
+        const uint32_t line = current_EXTI_LINE;
+        const bool rising_edge = out != 0;
+        if ((rising_edge && (sitl_exti.RTSR & line)) || (!rising_edge && (sitl_exti.FTSR & line))) {
+            sitl_exti.PR |= line;
+            const bool unmasked = (sitl_exti.IMR & line) != 0;
+            if (unmasked) {
+                sitl_irq_pend(SITL_IRQ_COMP);
+            }
+            motor_log_event(MEV_EDGE, out, unmasked, 0);
+        }
+    }
+
+    check_desync_dump();
+
+    // sensor averaging, snapshot every 64 steps
+    m.acc_v += m.vbus;
+    m.acc_i += ibus > 0 ? ibus : 0;
+    m.acc_n++;
+    if (m.acc_n >= 64) {
+        sitl_sensors_t s;
+        s.bus_voltage = (float)(m.acc_v / m.acc_n);
+        s.bus_current = (float)(m.acc_i / m.acc_n);
+        s.temperature_c = sitl_cfg.esc.temperature_c;
+        s.rpm = (float)(m.omega * 60.0 / TWO_PI);
+        sitl_sensors_write(&s);
+        m.acc_v = m.acc_i = 0;
+        m.acc_n = 0;
+    }
+}
+
+/*
+  commutation debug ring: comStep calls in here; on a firmware desync the
+  recent history is dumped so the failure can be analysed
+ */
+#define COMM_RING 96
+static struct {
+    uint64_t t_ns;
+    float thetae_deg; // electrical angle
+    float rpm;
+    uint32_t ci;
+    uint32_t a, b, c;
+    uint8_t kind;
+} comm_ring[COMM_RING];
+static unsigned comm_ring_pos;
+
+void motor_log_event(int kind, uint32_t a, uint32_t b, uint32_t c)
+{
+    extern volatile uint32_t commutation_interval;
+    const int pole_pairs = sitl_cfg.motor.poles / 2;
+    double deg = fmod(m.theta * pole_pairs * 180.0 / M_PI, 360.0);
+    if (deg < 0) {
+        deg += 360;
+    }
+    const unsigned idx = __atomic_fetch_add(&comm_ring_pos, 1, __ATOMIC_SEQ_CST) % COMM_RING;
+    comm_ring[idx].t_ns = sitl_time_ns();
+    comm_ring[idx].thetae_deg = (float)deg;
+    comm_ring[idx].rpm = (float)(m.omega * 60.0 / TWO_PI);
+    comm_ring[idx].ci = commutation_interval;
+    comm_ring[idx].a = a;
+    comm_ring[idx].b = b;
+    comm_ring[idx].c = c;
+    comm_ring[idx].kind = (uint8_t)kind;
+
+}
+
+void motor_log_mainloop(void)
+{
+    extern volatile uint32_t average_interval;
+    extern uint32_t last_average_interval;
+    static uint64_t last_ns;
+    const uint64_t now = sitl_time_ns();
+    const uint32_t gap_us = (uint32_t)((now - last_ns) / 1000ULL);
+    last_ns = now;
+    // only log iterations after a gap to avoid flooding the ring
+    if (gap_us >= 50) {
+        motor_log_event(MEV_MAINLOOP, average_interval, last_average_interval, gap_us);
+    }
+}
+
+void motor_log_commutation(int step)
+{
+    extern volatile uint16_t duty_cycle;
+    extern uint16_t duty_cycle_maximum;
+    motor_log_event(MEV_COMMUTATE, (uint32_t)step, duty_cycle, duty_cycle_maximum);
+}
+
+static void check_desync_dump(void)
+{
+    extern uint32_t desync_happened;
+    static uint32_t last_desync;
+    static int dumps;
+    if (desync_happened == last_desync) {
+        return;
+    }
+    last_desync = desync_happened;
+    if (dumps >= 3) {
+        return;
+    }
+    dumps++;
+    extern volatile uint32_t average_interval;
+    extern uint32_t last_average_interval;
+    extern volatile uint32_t zero_crosses;
+    extern int e_com_time;
+    fprintf(stderr,
+        "SITL: desync %u at t=%.4fs avg=%u last_avg=%u zc=%u e_com_time=%d, recent events:\n",
+        (unsigned)desync_happened, sitl_time_ns() * 1e-9,
+        (unsigned)average_interval, (unsigned)last_average_interval,
+        (unsigned)zero_crosses, e_com_time);
+    dump_ring();
+}
+
+static void dump_ring(void)
+{
+    static const char* kinds[] = { "COMMUTATE", "EDGE", "BLANKED", "COMP_RUN", "ZC_ACCEPT", "MAINLOOP" };
+    for (unsigned k = 0; k < COMM_RING; k++) {
+        const unsigned idx = (comm_ring_pos + k) % COMM_RING;
+        if (comm_ring[idx].t_ns == 0) {
+            continue;
+        }
+        fprintf(stderr, "  t=%.6f %-9s thetae=%5.1f rpm=%6.0f ci=%u a=%u b=%u c=%u\n",
+            comm_ring[idx].t_ns * 1e-9, kinds[comm_ring[idx].kind],
+            (double)comm_ring[idx].thetae_deg, (double)comm_ring[idx].rpm,
+            (unsigned)comm_ring[idx].ci,
+            (unsigned)comm_ring[idx].a, (unsigned)comm_ring[idx].b,
+            (unsigned)comm_ring[idx].c);
+    }
+}
+
+void motor_get_state(double* theta, double* omega, double i[3])
+{
+    *theta = m.theta;
+    *omega = m.omega;
+    for (int p = 0; p < 3; p++) {
+        i[p] = m.i[p];
+    }
+}
+
+void motor_print_state(uint64_t now_ns, float time_ratio)
+{
+    // firmware state, for debug output only
+    extern uint16_t input;
+    extern volatile char armed;
+    extern char step;
+    extern volatile uint32_t zero_crosses;
+    extern volatile uint32_t commutation_interval;
+    extern volatile uint16_t duty_cycle;
+    extern uint8_t bemf_timeout_happened;
+    extern uint8_t running;
+    extern char old_routine;
+    extern volatile uint16_t newinput;
+    extern uint16_t adjusted_input;
+    extern EEprom_t eepromBuffer;
+    static bool printed_settings;
+    if (!printed_settings) {
+        printed_settings = true;
+        fprintf(stderr,
+            "SITL settings: bidir=%u dir_rev=%u comp_pwm=%u poles=%u input_type=%u sine=%u brake_on_stop=%u\n",
+            eepromBuffer.bi_direction, eepromBuffer.dir_reversed,
+            eepromBuffer.comp_pwm, eepromBuffer.motor_poles,
+            eepromBuffer.input_type, eepromBuffer.use_sine_start,
+            eepromBuffer.brake_on_stop);
+    }
+
+    extern void sitl_can_stats(uint32_t stats[4]);
+    uint32_t cs[4];
+    sitl_can_stats(cs);
+
+    fprintf(stderr,
+        "SITL t=%.1fs x%.2f rpm=%.0f Vbus=%.2f Ibus=%.2f modes=%d%d%d in=%u newin=%u adj=%u armed=%d duty=%u step=%d zc=%u ci=%u run=%d old=%d bemf_to=%u cmd=%u\n",
+        now_ns * 1e-9, (double)time_ratio, m.omega * 60.0 / TWO_PI,
+        m.vbus, m.ibus,
+        sitl_phase_mode[0], sitl_phase_mode[1], sitl_phase_mode[2],
+        input, newinput, adjusted_input, armed, duty_cycle, step,
+        (unsigned)zero_crosses, (unsigned)commutation_interval,
+        running, old_routine, bemf_timeout_happened,
+        (unsigned)cs[1]);
+}

--- a/Mcu/SITL/sim/motor.c
+++ b/Mcu/SITL/sim/motor.c
@@ -42,6 +42,10 @@ static struct {
     double ke; // V/(rad/s) mechanical
     double vbus; // battery terminal voltage after sag
     double ibus; // battery current, previous step (breaks the loop)
+    // dead time tracking: per phase last PWM level and the end of the
+    // current both-off window
+    bool pwm_last[3];
+    uint64_t dead_until[3];
     // sensor averaging accumulators
     double acc_v, acc_i;
     uint32_t acc_n;
@@ -138,12 +142,25 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
         e[p] = m.ke * m.omega * shape[p];
     }
 
-    // gate states from the phase mode and the emulated PWM timer
+    // gate states from the phase mode and the emulated PWM timer. On a
+    // complementary switched phase both fets are off for the configured
+    // dead time after each PWM edge and the body diode conducts, as on
+    // hardware
+    const uint32_t dead_ns = sitl_tim1_dead_time_ns();
     bool hi[3], lo[3];
     for (int p = 0; p < 3; p++) {
         const bool pwm = sitl_tim1_pwm_out(p, now_ns);
         switch (sitl_phase_mode[p]) {
         case SITL_PHASE_PWM:
+            if (pwm != m.pwm_last[p]) {
+                m.pwm_last[p] = pwm;
+                m.dead_until[p] = now_ns + dead_ns;
+            }
+            if (now_ns < m.dead_until[p]) {
+                hi[p] = false;
+                lo[p] = false;
+                break;
+            }
             hi[p] = pwm;
             lo[p] = !pwm;
             break;
@@ -164,6 +181,10 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
             hi[p] = false;
             lo[p] = false;
             break;
+        }
+        if (sitl_phase_mode[p] != SITL_PHASE_PWM) {
+            m.pwm_last[p] = pwm;
+            m.dead_until[p] = 0;
         }
     }
 

--- a/Mcu/SITL/sim/motor.c
+++ b/Mcu/SITL/sim/motor.c
@@ -46,6 +46,8 @@ static struct {
     // current both-off window
     bool pwm_last[3];
     uint64_t dead_until[3];
+    // last terminal voltages for the state stream
+    double v_term[3];
     // sensor averaging accumulators
     double acc_v, acc_i;
     uint32_t acc_n;
@@ -55,12 +57,53 @@ static struct {
     sitl_sensors_t sensors;
 } m;
 
+void motor_config_changed(void)
+{
+    // per phase BEMF constant [V s/rad] from Kv [rpm/V]. Kv is defined
+    // line to line and two phases conduct in series, so halve it. All
+    // other motor parameters are read from sitl_cfg on every step
+    m.ke = 0.5 * 60.0 / (TWO_PI * sitl_cfg.motor.kv);
+}
+
+void motor_add_signals(double acc[8])
+{
+    for (int p = 0; p < 3; p++) {
+        acc[p] += m.i[p];
+        acc[3 + p] += m.v_term[p];
+    }
+    acc[6] += m.vbus;
+    acc[7] += m.ibus;
+}
+
+void motor_get_live_state(float* omega, float* theta, float* theta_e,
+                          float i[3], float v[3], float* vbus, float* ibus)
+{
+    for (int p = 0; p < 3; p++) {
+        v[p] = (float)m.v_term[p];
+    }
+    const int pole_pairs = sitl_cfg.motor.poles / 2;
+    *omega = (float)m.omega;
+    double th = fmod(m.theta, TWO_PI);
+    if (th < 0) {
+        th += TWO_PI;
+    }
+    *theta = (float)th;
+    double the = fmod(m.theta * pole_pairs, TWO_PI);
+    if (the < 0) {
+        the += TWO_PI;
+    }
+    *theta_e = (float)the;
+    for (int p = 0; p < 3; p++) {
+        i[p] = (float)m.i[p];
+    }
+    *vbus = (float)m.vbus;
+    *ibus = (float)m.ibus;
+}
+
 void motor_init(void)
 {
     memset(&m, 0, sizeof(m));
-    // per phase BEMF constant [V s/rad] from Kv [rpm/V]. Kv is defined
-    // line to line and two phases conduct in series, so halve it
-    m.ke = 0.5 * 60.0 / (TWO_PI * sitl_cfg.motor.kv);
+    motor_config_changed();
     m.vbus = sitl_cfg.battery.voltage;
     m.rand_seed = 12345;
     m.sensors.bus_voltage = m.vbus;
@@ -241,6 +284,10 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
         if (!conducting[p]) {
             v[p] = e[p] + v_star;
         }
+    }
+
+    for (int p = 0; p < 3; p++) {
+        m.v_term[p] = v[p];
     }
 
     // phase current derivatives, semi-implicit euler

--- a/Mcu/SITL/sim/motor.h
+++ b/Mcu/SITL/sim/motor.h
@@ -1,0 +1,36 @@
+/*
+  motor.h - BLDC motor, bridge and battery simulation for AM32 SITL
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+void motor_init(void);
+
+// advance the electrical/mechanical model by dt_ns. Called from the sim
+// thread only
+void motor_step(uint64_t now_ns, uint32_t dt_ns);
+
+// 1Hz state line on stderr for --verbose
+void motor_print_state(uint64_t now_ns, float time_ratio);
+
+// direct state access for offline tests
+void motor_get_state(double* theta, double* omega, double i[3]);
+
+// called from the firmware main loop for debug tracing
+void motor_log_mainloop(void);
+
+// commutation debug logging, called from comStep
+void motor_log_commutation(int step);
+
+// generic event logging into the same debug ring
+enum motor_ev {
+    MEV_COMMUTATE = 0, // a = step
+    MEV_EDGE, // comparator edge: a = new level, b = IMR set, c = pended
+    MEV_COMP_BLANKED, // comp irq discarded by blanking: a = CNT, b = ci/2
+    MEV_COMP_RUN, // comp irq calling interruptRoutine: a = CNT
+    MEV_ZC_ACCEPT, // interruptRoutine armed COM timer: a = waitTime
+    MEV_MAINLOOP, // firmware main loop iteration: a = avg, b = last_avg, c = gap us
+};
+void motor_log_event(int kind, uint32_t a, uint32_t b, uint32_t c);

--- a/Mcu/SITL/sim/motor.h
+++ b/Mcu/SITL/sim/motor.h
@@ -18,6 +18,16 @@ void motor_print_state(uint64_t now_ns, float time_ratio);
 // direct state access for offline tests
 void motor_get_state(double* theta, double* omega, double i[3]);
 
+// snapshot for the state streaming port (sitl_state.c), sim thread only
+void motor_get_live_state(float* omega, float* theta, float* theta_e,
+                          float i[3], float v[3], float* vbus, float* ibus);
+
+// re-derive cached values after a runtime config reload
+void motor_config_changed(void);
+
+// accumulate iu,iv,iw,vu,vv,vw,vbus,ibus for averaged state sampling
+void motor_add_signals(double acc[8]);
+
 // called from the firmware main loop for debug tracing
 void motor_log_mainloop(void);
 

--- a/Mcu/SITL/sim/sitl_config.c
+++ b/Mcu/SITL/sim/sitl_config.c
@@ -1,0 +1,251 @@
+/*
+  sitl_config.c - JSON config file and command line handling for AM32 SITL
+ */
+
+#include "sitl_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+
+#include "jsmn.h"
+
+sitl_config_t sitl_cfg = {
+    .motor = {
+        .kv = 900,
+        .poles = 14,
+        .resistance = 0.045f,
+        .inductance = 2.1e-5f,
+        .mutual_inductance = 0.0f,
+        .inertia = 2.0e-5f, // motor plus a small prop; light rotors accelerate faster than the firmware desync detection allows
+        .damping = 1.0e-6f,
+        .static_friction = 0.003f,
+        .load_k_omega2 = 2.0e-9f,
+    },
+    .battery = {
+        .voltage = 16.8f,
+        .resistance = 0.012f,
+    },
+    .esc = {
+        .rds_on = 0.004f,
+        .diode_vf = 0.7f,
+        .temperature_c = 25.0f,
+    },
+    .sim = {
+        .physics_dt_ns = 500,
+        .loop_time_ns = 2000,
+        .isr_read_ns = 100,
+        .comparator_noise_mv = 5.0f,
+        // enough hysteresis that noise cannot eat a zero crossing edge,
+        // as on a real comparator
+        .comparator_hysteresis_mv = 15.0f,
+        .watchdog_enabled = true,
+    },
+    .speedup = 1.0f,
+    .eeprom_path = "am32_eeprom.bin",
+    .can_uri = "mcast:0",
+    .uid = NULL,
+    .node_id = -1,
+    .verbose = false,
+    .nosleep = false,
+    .realtime = false,
+};
+
+struct cfg_entry {
+    const char* section;
+    const char* key;
+    enum { CFG_FLOAT,
+        CFG_INT,
+        CFG_U32,
+        CFG_BOOL } type;
+    void* ptr;
+};
+
+static const struct cfg_entry cfg_table[] = {
+    { "motor", "kv", CFG_FLOAT, &sitl_cfg.motor.kv },
+    { "motor", "poles", CFG_INT, &sitl_cfg.motor.poles },
+    { "motor", "resistance", CFG_FLOAT, &sitl_cfg.motor.resistance },
+    { "motor", "inductance", CFG_FLOAT, &sitl_cfg.motor.inductance },
+    { "motor", "mutual_inductance", CFG_FLOAT, &sitl_cfg.motor.mutual_inductance },
+    { "motor", "inertia", CFG_FLOAT, &sitl_cfg.motor.inertia },
+    { "motor", "damping", CFG_FLOAT, &sitl_cfg.motor.damping },
+    { "motor", "static_friction", CFG_FLOAT, &sitl_cfg.motor.static_friction },
+    { "motor", "load_k_omega2", CFG_FLOAT, &sitl_cfg.motor.load_k_omega2 },
+    { "battery", "voltage", CFG_FLOAT, &sitl_cfg.battery.voltage },
+    { "battery", "resistance", CFG_FLOAT, &sitl_cfg.battery.resistance },
+    { "esc", "rds_on", CFG_FLOAT, &sitl_cfg.esc.rds_on },
+    { "esc", "diode_vf", CFG_FLOAT, &sitl_cfg.esc.diode_vf },
+    { "esc", "temperature_c", CFG_FLOAT, &sitl_cfg.esc.temperature_c },
+    { "sim", "physics_dt_ns", CFG_U32, &sitl_cfg.sim.physics_dt_ns },
+    { "sim", "loop_time_ns", CFG_U32, &sitl_cfg.sim.loop_time_ns },
+    { "sim", "isr_read_ns", CFG_U32, &sitl_cfg.sim.isr_read_ns },
+    { "sim", "comparator_noise_mv", CFG_FLOAT, &sitl_cfg.sim.comparator_noise_mv },
+    { "sim", "comparator_hysteresis_mv", CFG_FLOAT, &sitl_cfg.sim.comparator_hysteresis_mv },
+    { "sim", "watchdog_enabled", CFG_BOOL, &sitl_cfg.sim.watchdog_enabled },
+};
+
+static void set_value(const char* section, const char* js, const jsmntok_t* key, const jsmntok_t* val, const char* path)
+{
+    char keystr[64], valstr[64];
+    snprintf(keystr, sizeof(keystr), "%.*s", key->end - key->start, js + key->start);
+    snprintf(valstr, sizeof(valstr), "%.*s", val->end - val->start, js + val->start);
+    for (unsigned i = 0; i < sizeof(cfg_table) / sizeof(cfg_table[0]); i++) {
+        const struct cfg_entry* e = &cfg_table[i];
+        if (strcmp(e->section, section) != 0 || strcmp(e->key, keystr) != 0) {
+            continue;
+        }
+        switch (e->type) {
+        case CFG_FLOAT:
+            *(float*)e->ptr = strtof(valstr, NULL);
+            break;
+        case CFG_INT:
+            *(int*)e->ptr = atoi(valstr);
+            break;
+        case CFG_U32:
+            *(uint32_t*)e->ptr = strtoul(valstr, NULL, 0);
+            break;
+        case CFG_BOOL:
+            *(bool*)e->ptr = (strcmp(valstr, "true") == 0 || strcmp(valstr, "1") == 0);
+            break;
+        }
+        return;
+    }
+    fprintf(stderr, "SITL: %s: unknown config key %s.%s\n", path, section, keystr);
+    exit(1);
+}
+
+// count the tokens making up one JSON value, for skipping
+static int value_size(const jsmntok_t* t)
+{
+    int count = 1;
+    if (t->type == JSMN_OBJECT) {
+        const jsmntok_t* p = t + 1;
+        for (int i = 0; i < t->size; i++) {
+            count++; // key
+            const int vs = value_size(p + 1);
+            count += vs;
+            p += 1 + vs;
+        }
+    } else if (t->type == JSMN_ARRAY) {
+        const jsmntok_t* p = t + 1;
+        for (int i = 0; i < t->size; i++) {
+            const int vs = value_size(p);
+            count += vs;
+            p += vs;
+        }
+    }
+    return count;
+}
+
+static void load_json(const char* path)
+{
+    FILE* f = fopen(path, "r");
+    if (!f) {
+        fprintf(stderr, "SITL: failed to open config %s\n", path);
+        exit(1);
+    }
+    static char js[16384];
+    const size_t n = fread(js, 1, sizeof(js) - 1, f);
+    fclose(f);
+    js[n] = 0;
+
+    jsmn_parser parser;
+    static jsmntok_t tokens[512];
+    jsmn_init(&parser);
+    const int ntok = jsmn_parse(&parser, js, n, tokens, 512);
+    if (ntok < 1 || tokens[0].type != JSMN_OBJECT) {
+        fprintf(stderr, "SITL: invalid JSON in %s (err %d)\n", path, ntok);
+        exit(1);
+    }
+
+    const jsmntok_t* t = &tokens[1];
+    for (int i = 0; i < tokens[0].size; i++) {
+        const jsmntok_t* section = t;
+        const jsmntok_t* sec_obj = t + 1;
+        char secstr[64];
+        snprintf(secstr, sizeof(secstr), "%.*s", section->end - section->start, js + section->start);
+        if (sec_obj->type != JSMN_OBJECT) {
+            fprintf(stderr, "SITL: %s: section %s is not an object\n", path, secstr);
+            exit(1);
+        }
+        const jsmntok_t* kt = sec_obj + 1;
+        for (int k = 0; k < sec_obj->size; k++) {
+            const jsmntok_t* val = kt + 1;
+            set_value(secstr, js, kt, val, path);
+            kt += 1 + value_size(val);
+        }
+        t += 1 + value_size(sec_obj);
+    }
+}
+
+static void usage(const char* prog)
+{
+    printf("Usage: %s [options]\n"
+           "  --config FILE    JSON config file for motor/battery/esc/sim\n"
+           "  --eeprom FILE    eeprom backing file (default am32_eeprom.bin)\n"
+           "  --can-uri URI    CAN interface (default mcast:0)\n"
+           "  --speedup X      simulation speed, 0 for free running (default 1.0)\n"
+           "  --node-id N      force DroneCAN node ID\n"
+           "  --uid STR        string used to derive the 16 byte unique ID\n"
+           "  --verbose        1Hz state output on stderr\n"
+           "  --nosleep        busy wait instead of sleeping (uses two full\n"
+           "                   CPU cores but gives the most accurate timing)\n"
+           "  --realtime       SCHED_FIFO scheduling for both threads (needs\n"
+           "                   root or an rtprio rlimit; with --nosleep also\n"
+           "                   set kernel.sched_rt_runtime_us=-1)\n",
+        prog);
+}
+
+void sitl_config_init(int argc, char** argv)
+{
+    static const struct option opts[] = {
+        { "config", required_argument, NULL, 'c' },
+        { "eeprom", required_argument, NULL, 'e' },
+        { "can-uri", required_argument, NULL, 'u' },
+        { "speedup", required_argument, NULL, 's' },
+        { "node-id", required_argument, NULL, 'n' },
+        { "uid", required_argument, NULL, 'U' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "nosleep", no_argument, NULL, 'N' },
+        { "realtime", no_argument, NULL, 'R' },
+        { "help", no_argument, NULL, 'h' },
+        { NULL, 0, NULL, 0 },
+    };
+    int c;
+    while ((c = getopt_long(argc, argv, "c:e:u:s:n:U:vNRh", opts, NULL)) != -1) {
+        switch (c) {
+        case 'c':
+            load_json(optarg);
+            break;
+        case 'e':
+            sitl_cfg.eeprom_path = optarg;
+            break;
+        case 'u':
+            sitl_cfg.can_uri = optarg;
+            break;
+        case 's':
+            sitl_cfg.speedup = strtof(optarg, NULL);
+            break;
+        case 'n':
+            sitl_cfg.node_id = atoi(optarg);
+            break;
+        case 'U':
+            sitl_cfg.uid = optarg;
+            break;
+        case 'v':
+            sitl_cfg.verbose = true;
+            break;
+        case 'N':
+            sitl_cfg.nosleep = true;
+            break;
+        case 'R':
+            sitl_cfg.realtime = true;
+            break;
+        case 'h':
+        default:
+            usage(argv[0]);
+            exit(c == 'h' ? 0 : 1);
+        }
+    }
+}

--- a/Mcu/SITL/sim/sitl_config.c
+++ b/Mcu/SITL/sim/sitl_config.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
+#include <math.h>
 
 #include "jsmn.h"
 
@@ -49,6 +50,7 @@ sitl_config_t sitl_cfg = {
     .speedup = 1.0f,
     .input_port = 57733,
     .state_port = 57734,
+    .bind_any = false,
     .eeprom_path = "am32_eeprom.bin",
     .can_uri = "mcast:0",
     .uid = NULL,
@@ -204,9 +206,53 @@ static void load_json(const char* path)
     }
 }
 
+/*
+  reject config values that would break the physics: motor.c divides by
+  kv, inertia and L - M, and any NaN poisons the whole state. Clamp with
+  a warning rather than exit so a bad runtime LOAD_MODEL cannot wedge a
+  running simulation
+ */
+static void clampf(float* v, float lo, float hi, const char* name)
+{
+    float nv = *v;
+    if (!isfinite(nv) || nv < lo) {
+        nv = lo;
+    } else if (nv > hi) {
+        nv = hi;
+    }
+    if (nv != *v || !isfinite(*v)) {
+        fprintf(stderr, "SITL: config %s=%g clamped to %g\n", name, (double)*v, (double)nv);
+        *v = nv;
+    }
+}
+
+static void config_sanitise(void)
+{
+    clampf(&sitl_cfg.motor.kv, 1.0f, 1e6f, "motor.kv");
+    if (sitl_cfg.motor.poles < 2 || (sitl_cfg.motor.poles & 1)) {
+        fprintf(stderr, "SITL: config motor.poles=%d invalid, using 2\n", sitl_cfg.motor.poles);
+        sitl_cfg.motor.poles = sitl_cfg.motor.poles > 2 ? sitl_cfg.motor.poles & ~1 : 2;
+    }
+    clampf(&sitl_cfg.motor.resistance, 1e-4f, 100.0f, "motor.resistance");
+    clampf(&sitl_cfg.motor.inductance, 1e-8f, 1.0f, "motor.inductance");
+    // keep L - M positive
+    clampf(&sitl_cfg.motor.mutual_inductance, -1.0f,
+        sitl_cfg.motor.inductance * 0.9f, "motor.mutual_inductance");
+    clampf(&sitl_cfg.motor.inertia, 1e-9f, 100.0f, "motor.inertia");
+    clampf(&sitl_cfg.motor.damping, 0.0f, 1.0f, "motor.damping");
+    clampf(&sitl_cfg.motor.static_friction, 0.0f, 10.0f, "motor.static_friction");
+    clampf(&sitl_cfg.motor.load_k_omega2, 0.0f, 1.0f, "motor.load_k_omega2");
+    clampf(&sitl_cfg.battery.voltage, 1.0f, 200.0f, "battery.voltage");
+    clampf(&sitl_cfg.battery.resistance, 0.0f, 10.0f, "battery.resistance");
+    clampf(&sitl_cfg.esc.rds_on, 0.0f, 1.0f, "esc.rds_on");
+    clampf(&sitl_cfg.esc.diode_vf, 0.0f, 5.0f, "esc.diode_vf");
+}
+
 bool sitl_config_reload(const char* path)
 {
-    return load_json_ex(path, true);
+    const bool ok = load_json_ex(path, true);
+    config_sanitise();
+    return ok;
 }
 
 static void usage(const char* prog)
@@ -221,6 +267,9 @@ static void usage(const char* prog)
            "                   runtime model control, 0 to disable\n"
            "                   (default 57734)\n"
            "  --speedup X      simulation speed, 0 for free running (default 1.0)\n"
+           "  --bind-any       bind the input/state UDP ports on all interfaces\n"
+           "                   instead of loopback only, for a GUI on another\n"
+           "                   host\n"
            "  --node-id N      force DroneCAN node ID\n"
            "  --input-type N   force eeprom INPUT_SIGNAL_TYPE (0=auto 1=dshot\n"
            "                   2=servo 5=dronecan)\n"
@@ -243,6 +292,7 @@ void sitl_config_init(int argc, char** argv)
         { "input-port", required_argument, NULL, 'p' },
         { "state-port", required_argument, NULL, 'P' },
         { "speedup", required_argument, NULL, 's' },
+        { "bind-any", no_argument, NULL, 'A' },
         { "node-id", required_argument, NULL, 'n' },
         { "input-type", required_argument, NULL, 'I' },
         { "uid", required_argument, NULL, 'U' },
@@ -253,7 +303,7 @@ void sitl_config_init(int argc, char** argv)
         { NULL, 0, NULL, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "c:e:u:p:P:s:n:I:U:vNRh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "c:e:u:p:P:s:An:I:U:vNRh", opts, NULL)) != -1) {
         switch (c) {
         case 'c':
             load_json(optarg);
@@ -272,6 +322,9 @@ void sitl_config_init(int argc, char** argv)
             break;
         case 's':
             sitl_cfg.speedup = strtof(optarg, NULL);
+            break;
+        case 'A':
+            sitl_cfg.bind_any = true;
             break;
         case 'n':
             sitl_cfg.node_id = atoi(optarg);
@@ -297,4 +350,5 @@ void sitl_config_init(int argc, char** argv)
             exit(c == 'h' ? 0 : 1);
         }
     }
+    config_sanitise();
 }

--- a/Mcu/SITL/sim/sitl_config.c
+++ b/Mcu/SITL/sim/sitl_config.c
@@ -43,10 +43,12 @@ sitl_config_t sitl_cfg = {
         .watchdog_enabled = true,
     },
     .speedup = 1.0f,
+    .input_port = 57733,
     .eeprom_path = "am32_eeprom.bin",
     .can_uri = "mcast:0",
     .uid = NULL,
     .node_id = -1,
+    .input_type = -1,
     .verbose = false,
     .nosleep = false,
     .realtime = false,
@@ -185,8 +187,12 @@ static void usage(const char* prog)
            "  --config FILE    JSON config file for motor/battery/esc/sim\n"
            "  --eeprom FILE    eeprom backing file (default am32_eeprom.bin)\n"
            "  --can-uri URI    CAN interface (default mcast:0)\n"
+           "  --input-port N   UDP port for PWM/DShot input, 0 to disable\n"
+           "                   (default 57733)\n"
            "  --speedup X      simulation speed, 0 for free running (default 1.0)\n"
            "  --node-id N      force DroneCAN node ID\n"
+           "  --input-type N   force eeprom INPUT_SIGNAL_TYPE (0=auto 1=dshot\n"
+           "                   2=servo 5=dronecan)\n"
            "  --uid STR        string used to derive the 16 byte unique ID\n"
            "  --verbose        1Hz state output on stderr\n"
            "  --nosleep        busy wait instead of sleeping (uses two full\n"
@@ -203,8 +209,10 @@ void sitl_config_init(int argc, char** argv)
         { "config", required_argument, NULL, 'c' },
         { "eeprom", required_argument, NULL, 'e' },
         { "can-uri", required_argument, NULL, 'u' },
+        { "input-port", required_argument, NULL, 'p' },
         { "speedup", required_argument, NULL, 's' },
         { "node-id", required_argument, NULL, 'n' },
+        { "input-type", required_argument, NULL, 'I' },
         { "uid", required_argument, NULL, 'U' },
         { "verbose", no_argument, NULL, 'v' },
         { "nosleep", no_argument, NULL, 'N' },
@@ -213,7 +221,7 @@ void sitl_config_init(int argc, char** argv)
         { NULL, 0, NULL, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "c:e:u:s:n:U:vNRh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "c:e:u:p:s:n:I:U:vNRh", opts, NULL)) != -1) {
         switch (c) {
         case 'c':
             load_json(optarg);
@@ -224,11 +232,17 @@ void sitl_config_init(int argc, char** argv)
         case 'u':
             sitl_cfg.can_uri = optarg;
             break;
+        case 'p':
+            sitl_cfg.input_port = atoi(optarg);
+            break;
         case 's':
             sitl_cfg.speedup = strtof(optarg, NULL);
             break;
         case 'n':
             sitl_cfg.node_id = atoi(optarg);
+            break;
+        case 'I':
+            sitl_cfg.input_type = atoi(optarg);
             break;
         case 'U':
             sitl_cfg.uid = optarg;

--- a/Mcu/SITL/sim/sitl_config.c
+++ b/Mcu/SITL/sim/sitl_config.c
@@ -18,10 +18,14 @@ sitl_config_t sitl_cfg = {
         .resistance = 0.045f,
         .inductance = 2.1e-5f,
         .mutual_inductance = 0.0f,
-        .inertia = 2.0e-5f, // motor plus a small prop; light rotors accelerate faster than the firmware desync detection allows
+        // defaults model a ~7 inch prop on a 900Kv motor at 4S: about
+        // 19A and 13500 rpm at full throttle. Rotors much lighter than
+        // this accelerate faster than the firmware desync detection
+        // allows
+        .inertia = 3.0e-5f,
         .damping = 1.0e-6f,
         .static_friction = 0.003f,
-        .load_k_omega2 = 2.0e-9f,
+        .load_k_omega2 = 1.0e-7f,
     },
     .battery = {
         .voltage = 16.8f,

--- a/Mcu/SITL/sim/sitl_config.c
+++ b/Mcu/SITL/sim/sitl_config.c
@@ -48,6 +48,7 @@ sitl_config_t sitl_cfg = {
     },
     .speedup = 1.0f,
     .input_port = 57733,
+    .state_port = 57734,
     .eeprom_path = "am32_eeprom.bin",
     .can_uri = "mcast:0",
     .uid = NULL,
@@ -91,7 +92,7 @@ static const struct cfg_entry cfg_table[] = {
     { "sim", "watchdog_enabled", CFG_BOOL, &sitl_cfg.sim.watchdog_enabled },
 };
 
-static void set_value(const char* section, const char* js, const jsmntok_t* key, const jsmntok_t* val, const char* path)
+static bool set_value(const char* section, const char* js, const jsmntok_t* key, const jsmntok_t* val, const char* path)
 {
     char keystr[64], valstr[64];
     snprintf(keystr, sizeof(keystr), "%.*s", key->end - key->start, js + key->start);
@@ -115,10 +116,10 @@ static void set_value(const char* section, const char* js, const jsmntok_t* key,
             *(bool*)e->ptr = (strcmp(valstr, "true") == 0 || strcmp(valstr, "1") == 0);
             break;
         }
-        return;
+        return true;
     }
     fprintf(stderr, "SITL: %s: unknown config key %s.%s\n", path, section, keystr);
-    exit(1);
+    return false;
 }
 
 // count the tokens making up one JSON value, for skipping
@@ -144,12 +145,17 @@ static int value_size(const jsmntok_t* t)
     return count;
 }
 
-static void load_json(const char* path)
+/*
+  load a JSON config file. When runtime is true only the motor, battery
+  and esc sections are applied (the sim section cannot change while
+  running) and errors are reported instead of exiting
+ */
+static bool load_json_ex(const char* path, bool runtime)
 {
     FILE* f = fopen(path, "r");
     if (!f) {
         fprintf(stderr, "SITL: failed to open config %s\n", path);
-        exit(1);
+        return false;
     }
     static char js[16384];
     const size_t n = fread(js, 1, sizeof(js) - 1, f);
@@ -162,9 +168,10 @@ static void load_json(const char* path)
     const int ntok = jsmn_parse(&parser, js, n, tokens, 512);
     if (ntok < 1 || tokens[0].type != JSMN_OBJECT) {
         fprintf(stderr, "SITL: invalid JSON in %s (err %d)\n", path, ntok);
-        exit(1);
+        return false;
     }
 
+    bool ok = true;
     const jsmntok_t* t = &tokens[1];
     for (int i = 0; i < tokens[0].size; i++) {
         const jsmntok_t* section = t;
@@ -173,16 +180,33 @@ static void load_json(const char* path)
         snprintf(secstr, sizeof(secstr), "%.*s", section->end - section->start, js + section->start);
         if (sec_obj->type != JSMN_OBJECT) {
             fprintf(stderr, "SITL: %s: section %s is not an object\n", path, secstr);
-            exit(1);
+            return false;
         }
+        const bool skip = runtime && strcmp(secstr, "motor") != 0 &&
+            strcmp(secstr, "battery") != 0 && strcmp(secstr, "esc") != 0;
         const jsmntok_t* kt = sec_obj + 1;
         for (int k = 0; k < sec_obj->size; k++) {
             const jsmntok_t* val = kt + 1;
-            set_value(secstr, js, kt, val, path);
+            if (!skip && !set_value(secstr, js, kt, val, path)) {
+                ok = false;
+            }
             kt += 1 + value_size(val);
         }
         t += 1 + value_size(sec_obj);
     }
+    return ok;
+}
+
+static void load_json(const char* path)
+{
+    if (!load_json_ex(path, false)) {
+        exit(1);
+    }
+}
+
+bool sitl_config_reload(const char* path)
+{
+    return load_json_ex(path, true);
 }
 
 static void usage(const char* prog)
@@ -193,6 +217,9 @@ static void usage(const char* prog)
            "  --can-uri URI    CAN interface (default mcast:0)\n"
            "  --input-port N   UDP port for PWM/DShot input, 0 to disable\n"
            "                   (default 57733)\n"
+           "  --state-port N   UDP port for simulation state streaming and\n"
+           "                   runtime model control, 0 to disable\n"
+           "                   (default 57734)\n"
            "  --speedup X      simulation speed, 0 for free running (default 1.0)\n"
            "  --node-id N      force DroneCAN node ID\n"
            "  --input-type N   force eeprom INPUT_SIGNAL_TYPE (0=auto 1=dshot\n"
@@ -214,6 +241,7 @@ void sitl_config_init(int argc, char** argv)
         { "eeprom", required_argument, NULL, 'e' },
         { "can-uri", required_argument, NULL, 'u' },
         { "input-port", required_argument, NULL, 'p' },
+        { "state-port", required_argument, NULL, 'P' },
         { "speedup", required_argument, NULL, 's' },
         { "node-id", required_argument, NULL, 'n' },
         { "input-type", required_argument, NULL, 'I' },
@@ -225,7 +253,7 @@ void sitl_config_init(int argc, char** argv)
         { NULL, 0, NULL, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "c:e:u:p:s:n:I:U:vNRh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "c:e:u:p:P:s:n:I:U:vNRh", opts, NULL)) != -1) {
         switch (c) {
         case 'c':
             load_json(optarg);
@@ -238,6 +266,9 @@ void sitl_config_init(int argc, char** argv)
             break;
         case 'p':
             sitl_cfg.input_port = atoi(optarg);
+            break;
+        case 'P':
+            sitl_cfg.state_port = atoi(optarg);
             break;
         case 's':
             sitl_cfg.speedup = strtof(optarg, NULL);

--- a/Mcu/SITL/sim/sitl_config.c
+++ b/Mcu/SITL/sim/sitl_config.c
@@ -226,6 +226,20 @@ static void clampf(float* v, float lo, float hi, const char* name)
     }
 }
 
+static void clampu32(uint32_t* v, uint32_t lo, uint32_t hi, const char* name)
+{
+    uint32_t nv = *v;
+    if (nv < lo) {
+        nv = lo;
+    } else if (nv > hi) {
+        nv = hi;
+    }
+    if (nv != *v) {
+        fprintf(stderr, "SITL: config %s=%u clamped to %u\n", name, *v, nv);
+        *v = nv;
+    }
+}
+
 static void config_sanitise(void)
 {
     clampf(&sitl_cfg.motor.kv, 1.0f, 1e6f, "motor.kv");
@@ -246,6 +260,22 @@ static void config_sanitise(void)
     clampf(&sitl_cfg.battery.resistance, 0.0f, 10.0f, "battery.resistance");
     clampf(&sitl_cfg.esc.rds_on, 0.0f, 1.0f, "esc.rds_on");
     clampf(&sitl_cfg.esc.diode_vf, 0.0f, 5.0f, "esc.diode_vf");
+
+    // physics_dt_ns == 0 turns sitl_isr_read_tick() into an infinite loop
+    // (accum_ns -= 0). Keep steps in a sane range for the BLDC model.
+    clampu32(&sitl_cfg.sim.physics_dt_ns, 100U, 10000U, "sim.physics_dt_ns");
+    // isr_read_ns == 0 freezes progress under PRIMASK (startup tunes /
+    // micros64 critical sections never complete). Cap at a few physics steps.
+    clampu32(&sitl_cfg.sim.isr_read_ns, 1U, sitl_cfg.sim.physics_dt_ns * 10U, "sim.isr_read_ns");
+    clampu32(&sitl_cfg.sim.loop_time_ns, 100U, 1000000U, "sim.loop_time_ns");
+
+    // match SET_SPEEDUP on the state port: [0, 100], 0 = free run
+    if (!isfinite(sitl_cfg.speedup) || sitl_cfg.speedup < 0.0f || sitl_cfg.speedup > 100.0f) {
+        const float nv = (!isfinite(sitl_cfg.speedup) || sitl_cfg.speedup < 0.0f) ? 0.0f : 100.0f;
+        fprintf(stderr, "SITL: config speedup=%g clamped to %g\n",
+            (double)sitl_cfg.speedup, (double)nv);
+        sitl_cfg.speedup = nv;
+    }
 }
 
 bool sitl_config_reload(const char* path)
@@ -320,9 +350,17 @@ void sitl_config_init(int argc, char** argv)
         case 'P':
             sitl_cfg.state_port = atoi(optarg);
             break;
-        case 's':
-            sitl_cfg.speedup = strtof(optarg, NULL);
+        case 's': {
+            char* end = NULL;
+            const float v = strtof(optarg, &end);
+            if (end == optarg || (end && *end != '\0') || !isfinite(v)) {
+                fprintf(stderr, "SITL: invalid --speedup '%s' (need a finite number)\n", optarg);
+                exit(1);
+            }
+            // range clamped in config_sanitise() to [0, 100]
+            sitl_cfg.speedup = v;
             break;
+        }
         case 'A':
             sitl_cfg.bind_any = true;
             break;

--- a/Mcu/SITL/sim/sitl_config.h
+++ b/Mcu/SITL/sim/sitl_config.h
@@ -40,6 +40,7 @@ typedef struct {
     // runtime options
     float speedup; // 0 = free run
     int input_port; // UDP port for PWM/DShot input, 0 disables
+    int state_port; // UDP port for state streaming/model control, 0 disables
     const char* eeprom_path;
     const char* can_uri;
     const char* uid; // optional fixed unique ID string
@@ -54,3 +55,7 @@ extern sitl_config_t sitl_cfg;
 
 // parse CLI and optional JSON config, exits on error
 void sitl_config_init(int argc, char** argv);
+
+// runtime reload of the motor/battery/esc sections from a JSON file
+// (sim section ignored). Returns false on error, never exits
+bool sitl_config_reload(const char* path);

--- a/Mcu/SITL/sim/sitl_config.h
+++ b/Mcu/SITL/sim/sitl_config.h
@@ -41,6 +41,7 @@ typedef struct {
     float speedup; // 0 = free run
     int input_port; // UDP port for PWM/DShot input, 0 disables
     int state_port; // UDP port for state streaming/model control, 0 disables
+    bool bind_any; // bind input/state ports on all interfaces, not loopback
     const char* eeprom_path;
     const char* can_uri;
     const char* uid; // optional fixed unique ID string

--- a/Mcu/SITL/sim/sitl_config.h
+++ b/Mcu/SITL/sim/sitl_config.h
@@ -1,0 +1,54 @@
+/*
+  sitl_config.h - JSON file + command line configuration for AM32 SITL
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct {
+    struct {
+        float kv; // rpm per volt
+        int poles; // magnetic poles (not pole pairs)
+        float resistance; // phase resistance, ohm
+        float inductance; // phase self inductance, henry
+        float mutual_inductance; // henry (negative or zero)
+        float inertia; // rotor+prop inertia, kg m^2
+        float damping; // Nm/(rad/s)
+        float static_friction; // Nm
+        float load_k_omega2; // propeller load: Nm/(rad/s)^2
+    } motor;
+    struct {
+        float voltage; // open circuit volts
+        float resistance; // internal resistance, ohm
+    } battery;
+    struct {
+        float rds_on; // fet on resistance, ohm
+        float diode_vf; // body diode forward voltage
+        float temperature_c; // reported temperature
+    } esc;
+    struct {
+        uint32_t physics_dt_ns; // integration step
+        uint32_t loop_time_ns; // firmware main loop pacing sleep
+        uint32_t isr_read_ns; // cost of a register read in interrupt context
+        float comparator_noise_mv;
+        float comparator_hysteresis_mv;
+        bool watchdog_enabled;
+    } sim;
+
+    // runtime options
+    float speedup; // 0 = free run
+    const char* eeprom_path;
+    const char* can_uri;
+    const char* uid; // optional fixed unique ID string
+    int node_id; // -1 = leave to eeprom/DNA
+    bool verbose;
+    bool nosleep; // busy wait instead of sleeping, for timing accuracy
+    bool realtime; // SCHED_FIFO for both threads
+} sitl_config_t;
+
+extern sitl_config_t sitl_cfg;
+
+// parse CLI and optional JSON config, exits on error
+void sitl_config_init(int argc, char** argv);

--- a/Mcu/SITL/sim/sitl_config.h
+++ b/Mcu/SITL/sim/sitl_config.h
@@ -39,10 +39,12 @@ typedef struct {
 
     // runtime options
     float speedup; // 0 = free run
+    int input_port; // UDP port for PWM/DShot input, 0 disables
     const char* eeprom_path;
     const char* can_uri;
     const char* uid; // optional fixed unique ID string
     int node_id; // -1 = leave to eeprom/DNA
+    int input_type; // eeprom INPUT_SIGNAL_TYPE override, -1 = leave
     bool verbose;
     bool nosleep; // busy wait instead of sleeping, for timing accuracy
     bool realtime; // SCHED_FIFO for both threads

--- a/Mcu/SITL/sitl_can_test.py
+++ b/Mcu/SITL/sitl_can_test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+'''
+test AM32 SITL over DroneCAN multicast UDP
+
+runs a throttle ramp via esc.RawCommand and reports esc.Status
+telemetry. Needs the SITL binary already running on the same mcast bus,
+eg:
+  obj/AM32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
+  python3 Mcu/SITL/sitl_can_test.py --throttle 0.5 --duration 20
+'''
+
+import argparse
+import time
+
+import dronecan
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--uri', default='mcast:0')
+parser.add_argument('--node-id', type=int, default=100, help='our node ID')
+parser.add_argument('--esc-index', type=int, default=0)
+parser.add_argument('--throttle', type=float, default=0.5, help='peak throttle 0..1')
+parser.add_argument('--ramp-time', type=float, default=3.0, help='seconds to reach peak')
+parser.add_argument('--duration', type=float, default=15.0)
+parser.add_argument('--rate', type=float, default=50.0, help='RawCommand rate Hz')
+args = parser.parse_args()
+
+
+def main():
+    node = dronecan.make_node(args.uri, node_id=args.node_id, bitrate=1000000)
+
+    state = {'nodes': set(), 'status': None, 'nstatus': 0}
+
+    def on_node_status(e):
+        nid = e.transfer.source_node_id
+        if nid not in state['nodes']:
+            state['nodes'].add(nid)
+            print('found node %u (mode %u health %u)' % (
+                nid, e.message.mode, e.message.health))
+
+    def on_esc_status(e):
+        state['status'] = e.message
+        state['nstatus'] += 1
+
+    node.add_handler(dronecan.uavcan.protocol.NodeStatus, on_node_status)
+    node.add_handler(dronecan.uavcan.equipment.esc.Status, on_esc_status)
+
+    # wait for the ESC to appear
+    deadline = time.time() + 10
+    while not state['nodes'] and time.time() < deadline:
+        node.spin(0.1)
+    if not state['nodes']:
+        print('FAIL: no DroneCAN node seen')
+        return 1
+
+    print('arming and ramping to %.0f%% throttle' % (args.throttle * 100))
+    t0 = time.time()
+    next_cmd = t0
+    last_print = t0
+    while time.time() - t0 < args.duration:
+        node.spin(0)
+        now = time.time()
+        if now >= next_cmd:
+            next_cmd += 1.0 / args.rate
+            # arming plus raw command
+            arming = dronecan.uavcan.equipment.safety.ArmingStatus(
+                status=dronecan.uavcan.equipment.safety.ArmingStatus().STATUS_FULLY_ARMED)
+            node.broadcast(arming)
+            ramp = min(1.0, (now - t0) / args.ramp_time)
+            value = int(8191 * args.throttle * ramp)
+            commands = [0] * (args.esc_index + 1)
+            commands[args.esc_index] = value
+            node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=commands))
+        if now - last_print >= 1.0 and state['status'] is not None:
+            last_print = now
+            s = state['status']
+            print('rpm=%6d volts=%.2f amps=%.2f temp=%.0fC err=%u (%u pkts)' % (
+                s.rpm, s.voltage, s.current,
+                s.temperature - 273.15, s.error_count, state['nstatus']))
+        time.sleep(0.001)
+
+    # stop the motor
+    for _ in range(10):
+        node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=[0]))
+        node.spin(0.02)
+
+    if state['nstatus'] == 0:
+        print('FAIL: no esc.Status telemetry received')
+        return 1
+    s = state['status']
+    print('final: rpm=%d volts=%.2f amps=%.2f' % (s.rpm, s.voltage, s.current))
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/Mcu/SITL/sitl_dshot.py
+++ b/Mcu/SITL/sitl_dshot.py
@@ -1,0 +1,250 @@
+'''
+protocol library for AM32 SITL PWM/DShot input over UDP
+
+packet format (little endian):
+  u16 magic 0x4453
+  u8  type: 0=PWM, 1=DSHOT150, 2=DSHOT300, 3=DSHOT600
+  u8  len: payload bytes after the 6 byte header (4)
+  u16 flags: bit0 = line idle level (1 = idle high, inverted/bidir DShot)
+  u16 data: PWM pulse width in microseconds, or the full 16 bit DShot
+            frame (11 bit value, telemetry bit, 4 bit CRC)
+
+replies (bidirectional DShot) use the same format with data being the 16
+bit GCR-decoded frame: 12 bit eRPM/EDT value plus 4 bit CRC
+'''
+
+import socket
+import struct
+import time
+import threading
+
+MAGIC = 0x4453
+TYPE_PWM = 0
+TYPE_DSHOT150 = 1
+TYPE_DSHOT300 = 2
+TYPE_DSHOT600 = 3
+FLAG_IDLE_HIGH = 0x0001
+
+TYPE_NAMES = {
+    'pwm': TYPE_PWM,
+    'dshot150': TYPE_DSHOT150,
+    'dshot300': TYPE_DSHOT300,
+    'dshot600': TYPE_DSHOT600,
+}
+
+# DShot commands (value field 1..47 at zero throttle)
+DSHOT_CMD_EDT_ENABLE = 13
+DSHOT_CMD_EDT_DISABLE = 14
+
+
+def dshot_crc(value12, bidir=False):
+    '''4 bit CRC over the 12 bit value+telemetry field'''
+    csum = value12 ^ (value12 >> 4) ^ (value12 >> 8)
+    if bidir:
+        csum = ~csum
+    return csum & 0xF
+
+
+def dshot_frame(value11, telem=False, bidir=False, corrupt=False):
+    '''compose the full 16 bit DShot frame from an 11 bit value'''
+    v = ((value11 & 0x7FF) << 1) | (1 if telem else 0)
+    crc = dshot_crc(v, bidir)
+    if corrupt:
+        crc ^= 0x5
+    return (v << 4) | crc
+
+
+def check_reply_crc(frame16):
+    '''BDShot reply CRC: xor of the four nibbles must be 0xF'''
+    n = frame16
+    return ((n ^ (n >> 4) ^ (n >> 8) ^ (n >> 12)) & 0xF) == 0xF
+
+
+def decode_reply(frame16, edt_expected=False):
+    '''decode a 16 bit BDShot reply frame.
+    returns (kind, value) where kind is one of:
+      'erpm'    - value is the eRPM period in microseconds (65408 = stopped)
+      'temp'    - degrees C
+      'volt'    - volts
+      'current' - amps
+      'edt'     - other extended frame, value is the raw 12 bits
+      'badcrc'  - CRC failure, value is the raw frame
+    '''
+    if not check_reply_crc(frame16):
+        return ('badcrc', frame16)
+    val = frame16 >> 4
+    # extended telemetry frames have bit 8 clear (eRPM mantissa is
+    # normalised so real eRPM frames have it set)
+    if edt_expected and (val & 0x100) == 0 and val != 0:
+        etype = val >> 8
+        data = val & 0xFF
+        if etype == 0x2:
+            return ('temp', data)
+        if etype == 0x4:
+            return ('volt', data * 0.25)
+        if etype == 0x6:
+            # AM32 encodes centiamps/50, ie 0.5A units
+            return ('current', data * 0.5)
+        return ('edt', val)
+    period_us = (val & 0x1FF) << (val >> 9)
+    return ('erpm', period_us)
+
+
+def erpm_period_to_rpm(period_us, motor_poles=14):
+    '''convert eRPM period in us to mechanical RPM'''
+    if period_us == 0 or period_us >= 65408:
+        return 0.0
+    erpm = 60.0e6 / period_us
+    return erpm / (motor_poles / 2)
+
+
+def pack(ptype, flags, data):
+    return struct.pack('<HBBHH', MAGIC, ptype, 4, flags, data)
+
+
+def unpack(buf):
+    if len(buf) < 8:
+        return None
+    magic, ptype, length, flags, data = struct.unpack('<HBBHH', buf[:8])
+    if magic != MAGIC or length != 4:
+        return None
+    return (ptype, flags, data)
+
+
+class InputPort(object):
+    '''UDP connection to the SITL input port, with a reader thread
+    collecting BDShot replies'''
+
+    def __init__(self, host='127.0.0.1', port=57733):
+        self.addr = (host, port)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.bind(('127.0.0.1', 0))
+        self.sock.settimeout(0.2)
+        self.lock = threading.Lock()
+        self.replies = []          # (time, type, flags, data)
+        self.reply_count = 0
+        self.sent_count = 0
+        self.running = True
+        self.thread = threading.Thread(target=self._reader, daemon=True)
+        self.thread.start()
+
+    def _reader(self):
+        while self.running:
+            try:
+                buf = self.sock.recv(64)
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            p = unpack(buf)
+            if p is None:
+                continue
+            with self.lock:
+                self.replies.append((time.time(),) + p)
+                self.reply_count += 1
+                if len(self.replies) > 1000:
+                    self.replies = self.replies[-500:]
+
+    def close(self):
+        self.running = False
+        self.sock.close()
+
+    def send_pwm(self, width_us, idle_high=False):
+        flags = FLAG_IDLE_HIGH if idle_high else 0
+        self.sock.sendto(pack(TYPE_PWM, flags, width_us), self.addr)
+        self.sent_count += 1
+
+    def send_dshot(self, value11, ptype=TYPE_DSHOT300, telem=False,
+                   bidir=False, corrupt=False):
+        flags = FLAG_IDLE_HIGH if bidir else 0
+        frame = dshot_frame(value11, telem=telem, bidir=bidir, corrupt=corrupt)
+        self.sock.sendto(pack(ptype, flags, frame), self.addr)
+        self.sent_count += 1
+
+    def get_replies(self):
+        with self.lock:
+            r = self.replies
+            self.replies = []
+        return r
+
+
+def set_dronecan_param(name, value, uri='mcast:0', timeout=10.0,
+                       save=True, restart=True, node_id=None):
+    '''set a DroneCAN parameter on the (single) AM32 node, optionally
+    save parameters and restart the node. Needs pydronecan'''
+    import dronecan
+    node = dronecan.make_node(uri, node_id=126, bitrate=1000000)
+    found = {}
+
+    def on_status(e):
+        found[e.transfer.source_node_id] = True
+
+    node.add_handler(dronecan.uavcan.protocol.NodeStatus, on_status)
+    # NodeStatus is 1Hz: collect for a couple of seconds so all bus
+    # participants are seen, not just the first
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        node.spin(0.1)
+        if found and time.time() - t0 > 2.5:
+            break
+    if not found:
+        raise RuntimeError('no DroneCAN node found')
+
+    target = None
+
+    def request_wait(req, timeout=2.0):
+        '''send a service request, spin until the response (or timeout
+        callback, which pydronecan delivers as None)'''
+        result = {}
+
+        def cb(e):
+            result['response'] = e.response if e is not None else None
+            result['done'] = True
+
+        node.request(req, target, cb)
+        deadline = time.time() + timeout
+        while 'done' not in result and time.time() < deadline:
+            node.spin(0.05)
+        return result.get('response')
+
+    # other tools may be on the bus: find the AM32 node by probing for
+    # the parameter itself (a GetSet read of an unknown name returns an
+    # empty response name)
+    candidates = [node_id] if node_id is not None else sorted(found.keys())
+    for cand in candidates:
+        target = cand
+        req = dronecan.uavcan.protocol.param.GetSet.Request()
+        req.name = name
+        rsp = request_wait(req, timeout=1.0)
+        if rsp is not None and len(rsp.name) > 0:
+            break
+    else:
+        raise RuntimeError('no node with parameter %s found' % name)
+
+    req = dronecan.uavcan.protocol.param.GetSet.Request()
+    req.name = name
+    req.value = dronecan.uavcan.protocol.param.Value(integer_value=int(value))
+    for attempt in range(3):
+        rsp = request_wait(req)
+        if rsp is not None and rsp.value.integer_value == int(value):
+            break
+    else:
+        raise RuntimeError('param set of %s failed' % name)
+
+    if save:
+        req = dronecan.uavcan.protocol.param.ExecuteOpcode.Request()
+        req.opcode = req.OPCODE_SAVE
+        for attempt in range(3):
+            rsp = request_wait(req)
+            if rsp is not None and rsp.ok:
+                break
+        else:
+            raise RuntimeError('param save failed')
+
+    if restart:
+        req = dronecan.uavcan.protocol.RestartNode.Request()
+        req.magic_number = req.MAGIC_NUMBER
+        request_wait(req, timeout=1.0)
+
+    node.close()
+    return target

--- a/Mcu/SITL/sitl_gui.py
+++ b/Mcu/SITL/sitl_gui.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+'''
+control GUI for the AM32 SITL: drives PWM/DShot input over UDP and
+DroneCAN input over mcast, with live telemetry from BDShot (including
+extended DShot telemetry) and DroneCAN esc.Status.
+
+each input has an Enable checkbox that instantly starts/stops its stream,
+for exercising failover between inputs. The parameter panel sets
+INPUT_SIGNAL_TYPE etc over DroneCAN (needed because the DRONECAN_IN
+default disables the PWM/DShot input interrupts).
+
+built on PySide6 (Qt): pyqtgraph plots and QGraphicsScene animation
+panels can be added on this foundation. Install the dependencies with
+    python3 Mcu/SITL/make_gui_env.py
+
+usage: sitl_gui.py [--port 57733] [--can-uri mcast:0]
+
+with --control-port N the UI can additionally be driven by commands over
+a localhost TCP connection (one per line), for scripted testing of the
+actual UI paths:
+  ds_enable 0|1, ds_type pwm|dshot300|..., ds_bidir 0|1, ds_value N,
+  ds_rate N, ds_edt 0|1, zero, edt_enable, edt_disable, can_enable 0|1,
+  can_value X, can_rate N, param NAME VALUE, status, quit
+responses go back to the client prefixed with OK/STATUS/ERR. A client
+disconnect leaves the GUI running.
+--log FILE records every UI action with a timestamp; --replay FILE plays
+a recording back with its original timing.
+'''
+
+import argparse
+import os
+import queue
+import signal
+import socket
+import sys
+import threading
+import time
+
+try:
+    from PySide6.QtCore import Qt, QTimer
+    from PySide6.QtGui import QFontDatabase
+    from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox,
+                                   QGridLayout, QGroupBox, QHBoxLayout,
+                                   QLabel, QPushButton, QSlider, QSpinBox,
+                                   QWidget)
+except ImportError:
+    _here = os.path.dirname(os.path.abspath(__file__))
+    if sys.platform == 'win32':
+        _venv_py = os.path.join(_here, 'venv', 'Scripts', 'python.exe')
+    else:
+        _venv_py = os.path.join(_here, 'venv', 'bin', 'python3')
+    _run_cmd = ' '.join([_venv_py, os.path.abspath(__file__)] + sys.argv[1:])
+    if os.path.exists(_venv_py):
+        sys.stderr.write(
+            'PySide6 is required for the SITL GUI. The GUI environment is\n'
+            'already set up, run:\n'
+            '    %s\n' % _run_cmd)
+    else:
+        sys.stderr.write(
+            'PySide6 is required for the SITL GUI. Either install the packages\n'
+            'from %s into the system python,\n'
+            'or create the self-contained environment with:\n'
+            '    python3 %s\n'
+            'and then run:\n'
+            '    %s\n'
+            % (os.path.join(_here, 'requirements-gui.txt'),
+               os.path.join(_here, 'make_gui_env.py'),
+               _run_cmd))
+    sys.exit(1)
+
+import sitl_dshot as sd
+from sitl_gui_backend import DshotPanel, CanPanel, HAVE_DRONECAN
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--host', default='127.0.0.1')
+    ap.add_argument('--port', type=int, default=57733)
+    ap.add_argument('--can-uri', default='mcast:0')
+    ap.add_argument('--poles', type=int, default=14)
+    ap.add_argument('--control-port', type=int, default=0,
+                    help='TCP port on localhost accepting UI control commands '
+                         '(for scripted tests, default off)')
+    ap.add_argument('--log', metavar='FILE',
+                    help='log all UI actions with timestamps, for later --replay')
+    ap.add_argument('--replay', metavar='FILE',
+                    help='replay a --log action file with its original timing')
+    args = ap.parse_args()
+
+    t0 = time.time()
+    logf = open(args.log, 'w') if args.log else None
+
+    def log_action(cmd):
+        if logf is not None:
+            logf.write('%.3f %s\n' % (time.time() - t0, cmd))
+            logf.flush()
+
+    ds = DshotPanel(args.host, args.port)
+    ds.poles = args.poles
+
+    # spawn the DroneCAN node with SIGINT ignored: its multiprocessing IO
+    # child inherits the kernel-level SIG_IGN disposition, so a terminal
+    # Ctrl-C only interrupts this process and the child is shut down
+    # through node.close() instead of dying with a traceback
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    can = CanPanel(args.can_uri) if HAVE_DRONECAN else None
+    if can is not None:
+        can.started.wait(5.0)
+
+    app = QApplication(sys.argv)
+    app.setStyle('Fusion')
+    win = QWidget()
+    win.setWindowTitle('AM32 SITL control')
+    top = QGridLayout(win)
+
+    # ---- PWM/DShot input panel
+    f1 = QGroupBox('PWM/DShot input (udp %s:%u)' % (args.host, args.port))
+    g1 = QGridLayout(f1)
+    top.addWidget(f1, 0, 0)
+
+    ds_enable = QCheckBox('Enable')
+
+    def ds_enable_changed():
+        ds.enabled = ds_enable.isChecked()
+        log_action('ds_enable %d' % int(ds.enabled))
+
+    ds_enable.toggled.connect(ds_enable_changed)
+    g1.addWidget(ds_enable, 0, 0)
+
+    g1.addWidget(QLabel('Type:'), 1, 0)
+    ds_type = QComboBox()
+    ds_type.addItems(sorted(sd.TYPE_NAMES.keys()))
+    ds_type.setCurrentText('dshot300')
+
+    def type_changed(*a):
+        ds.ptype = sd.TYPE_NAMES[ds_type.currentText()]
+        is_pwm = ds.ptype == sd.TYPE_PWM
+        ds_value.setRange(1000 if is_pwm else 0, 2000 if is_pwm else 2047)
+        ds_value.setValue(1000 if is_pwm else 0)
+        if ds.ptype == sd.TYPE_DSHOT150:
+            # checkDshot() only has detection bands for dshot300/600
+            ds.status = 'note: AM32 input detection does not support dshot150, use 300/600'
+        else:
+            ds.status = ''
+        log_action('ds_type %s' % ds_type.currentText())
+        value_changed()
+
+    ds_type.currentTextChanged.connect(type_changed)
+    g1.addWidget(ds_type, 1, 1)
+
+    ds_bidir = QCheckBox('bidir (BDShot)')
+
+    def ds_bidir_changed():
+        ds.bidir = ds_bidir.isChecked()
+        log_action('ds_bidir %d' % int(ds.bidir))
+
+    ds_bidir.toggled.connect(ds_bidir_changed)
+    g1.addWidget(ds_bidir, 1, 2)
+
+    g1.addWidget(QLabel('Throttle:'), 2, 0)
+    ds_value = QSlider(Qt.Horizontal)
+    ds_value.setRange(0, 2047)
+    ds_value.setMinimumWidth(260)
+
+    def value_changed(*a):
+        v = ds_value.value()
+        log_action('ds_value %d' % v)
+        # never stream DShot values 1..47 from the throttle slider: they
+        # are commands (direction, bi_direction, save, programming mode)
+        # and a slider drag dwells long enough to execute them
+        if ds.ptype != sd.TYPE_PWM and 0 < v < 48:
+            v = 0
+        ds.value = v
+
+    # valueChanged fires for both drags and programmatic setValue()
+    ds_value.valueChanged.connect(value_changed)
+    g1.addWidget(ds_value, 2, 1, 1, 2)
+    ds_value_label = QLabel('0')
+    g1.addWidget(ds_value_label, 2, 3)
+
+    g1.addWidget(QLabel('Rate Hz:'), 3, 0)
+    ds_rate = QSpinBox()
+    ds_rate.setRange(10, 4000)
+    ds_rate.setValue(500)
+
+    def rate_changed(*a):
+        ds.rate = float(ds_rate.value())
+        log_action('ds_rate %d' % ds_rate.value())
+
+    ds_rate.valueChanged.connect(rate_changed)
+    g1.addWidget(ds_rate, 3, 1)
+
+    bf = QHBoxLayout()
+    zero_btn = QPushButton('Zero throttle')
+    zero_btn.clicked.connect(
+        lambda: ds_value.setValue(1000 if ds.ptype == sd.TYPE_PWM else 0))
+    bf.addWidget(zero_btn)
+
+    ds_edt = QCheckBox('EDT (extended telemetry)')
+
+    def ds_edt_changed():
+        ds.edt_want = ds_edt.isChecked()
+        log_action('ds_edt %d' % int(ds.edt_want))
+
+    ds_edt.toggled.connect(ds_edt_changed)
+    bf.addWidget(ds_edt)
+    bf.addStretch(1)
+    g1.addLayout(bf, 4, 0, 1, 4)
+
+    ds_status = QLabel('arm: enable + hold zero throttle >1.5s')
+    g1.addWidget(ds_status, 5, 0, 1, 4)
+
+    # ---- DroneCAN input panel
+    f2 = QGroupBox('DroneCAN input (%s)' % args.can_uri)
+    g2 = QGridLayout(f2)
+    top.addWidget(f2, 0, 1)
+
+    if can is not None:
+        can_enable = QCheckBox('Enable')
+
+        def can_enable_changed():
+            can.enabled = can_enable.isChecked()
+            log_action('can_enable %d' % int(can.enabled))
+
+        can_enable.toggled.connect(can_enable_changed)
+        g2.addWidget(can_enable, 0, 0)
+
+        g2.addWidget(QLabel('Throttle:'), 1, 0)
+        # slider in 0..1000 -> throttle 0..1
+        can_value = QSlider(Qt.Horizontal)
+        can_value.setRange(0, 1000)
+        can_value.setMinimumWidth(200)
+
+        def can_value_changed(*a):
+            can.throttle = can_value.value() / 1000.0
+            log_action('can_value %.4f' % can.throttle)
+
+        can_value.valueChanged.connect(can_value_changed)
+        g2.addWidget(can_value, 1, 1, 1, 2)
+        can_value_label = QLabel('0.00')
+        g2.addWidget(can_value_label, 1, 3)
+
+        g2.addWidget(QLabel('Rate Hz:'), 2, 0)
+        can_rate = QSpinBox()
+        can_rate.setRange(1, 1000)
+        can_rate.setValue(50)
+
+        def can_rate_changed(*a):
+            can.rate = float(can_rate.value())
+            log_action('can_rate %d' % can_rate.value())
+
+        can_rate.valueChanged.connect(can_rate_changed)
+        g2.addWidget(can_rate, 2, 1)
+
+        can_zero_btn = QPushButton('Zero throttle')
+        can_zero_btn.clicked.connect(lambda: can_value.setValue(0))
+        g2.addWidget(can_zero_btn, 3, 0)
+
+        # parameter panel
+        pf = QGroupBox('parameters (set + save + restart)')
+        gp = QGridLayout(pf)
+        g2.addWidget(pf, 4, 0, 1, 4)
+        gp.addWidget(QLabel('INPUT_SIGNAL_TYPE:'), 0, 0)
+        ptype_var = QSpinBox()
+        ptype_var.setRange(0, 5)
+        ptype_var.setValue(1)
+        gp.addWidget(ptype_var, 0, 1)
+        gp.addWidget(QLabel('(0=auto 1=dshot 2=servo 5=dronecan)'), 0, 2)
+        param_status = QLabel('')
+        gp.addWidget(param_status, 1, 0, 1, 3)
+
+        def param_apply():
+            log_action('param INPUT_SIGNAL_TYPE %d' % ptype_var.value())
+            can.set_param('INPUT_SIGNAL_TYPE', ptype_var.value())
+
+        apply_btn = QPushButton('Apply')
+        apply_btn.clicked.connect(param_apply)
+        gp.addWidget(apply_btn, 0, 3)
+    else:
+        g2.addWidget(QLabel('pydronecan not available'), 0, 0)
+
+    # ---- telemetry panel
+    f3 = QGroupBox('telemetry')
+    g3 = QGridLayout(f3)
+    top.addWidget(f3, 1, 0, 1, 2)
+    fixed = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+    bds_label = QLabel('BDShot: -')
+    bds_label.setFont(fixed)
+    g3.addWidget(bds_label, 0, 0)
+    can_label = QLabel('DroneCAN: -')
+    can_label.setFont(fixed)
+    g3.addWidget(can_label, 1, 0)
+
+    # ---- optional TCP control interface, driving the same widgets and
+    # handlers as the mouse, so scripted tests cover the UI paths.
+    # Commands are one per line; OK/STATUS/ERR responses go back to the
+    # issuing client. A client disconnect leaves the GUI running; the
+    # quit command closes it
+    cmd_queue = queue.Queue()   # (line, reply function)
+
+    def emit(msg):
+        print(msg)
+        sys.stdout.flush()
+
+    def control_client(conn):
+        def reply(msg):
+            try:
+                conn.sendall((msg + '\n').encode())
+            except OSError:
+                pass
+        f = conn.makefile('r')
+        for line in f:
+            cmd_queue.put((line, reply))
+        conn.close()
+
+    def control_server():
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(('127.0.0.1', args.control_port))
+        srv.listen(4)
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(target=control_client, args=(conn,), daemon=True).start()
+
+    def handle_command(line, reply):
+        parts = line.split()
+        if not parts:
+            return
+        cmd, cargs = parts[0], parts[1:]
+        if cmd == 'ds_enable':
+            ds_enable.setChecked(bool(int(cargs[0])))
+        elif cmd == 'ds_type':
+            ds_type.setCurrentText(cargs[0])
+        elif cmd == 'ds_value':
+            ds_value.setValue(int(cargs[0]))
+        elif cmd == 'ds_bidir':
+            ds_bidir.setChecked(bool(int(cargs[0])))
+        elif cmd == 'ds_rate':
+            ds_rate.setValue(int(cargs[0]))
+        elif cmd == 'zero':
+            ds_value.setValue(1000 if ds.ptype == sd.TYPE_PWM else 0)
+        elif cmd == 'ds_edt':
+            ds_edt.setChecked(bool(int(cargs[0])))
+        elif cmd == 'edt_enable':
+            ds_edt.setChecked(True)
+        elif cmd == 'edt_disable':
+            ds_edt.setChecked(False)
+        elif cmd == 'can_enable' and can is not None:
+            can_enable.setChecked(bool(int(cargs[0])))
+        elif cmd == 'can_value' and can is not None:
+            can_value.setValue(int(float(cargs[0]) * 1000))
+        elif cmd == 'can_rate' and can is not None:
+            can_rate.setValue(int(cargs[0]))
+        elif cmd == 'param' and can is not None:
+            can.set_param(cargs[0], int(cargs[1]))
+        elif cmd == 'status':
+            reply('STATUS %s' % bds_label.text())
+            reply('STATUS %s' % can_label.text())
+            reply('STATUS ds: %s' % (ds.status or '-'))
+            return
+        elif cmd == 'quit':
+            app.quit()
+            return
+        else:
+            reply('ERR unknown command: %s' % line.strip())
+            return
+        reply('OK %s' % line.strip())
+
+    def cmd_poll():
+        while True:
+            try:
+                line, reply = cmd_queue.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                handle_command(line, reply)
+            except Exception as ex:
+                reply('ERR %s: %s' % (line.strip(), ex))
+
+    def replay_reader():
+        with open(args.replay) as f:
+            entries = []
+            for line in f:
+                parts = line.strip().split(None, 1)
+                if len(parts) == 2:
+                    entries.append((float(parts[0]), parts[1]))
+        rt0 = time.time()
+        for when, cmd in entries:
+            delay = rt0 + when - time.time()
+            if delay > 0:
+                time.sleep(delay)
+            cmd_queue.put((cmd + '\n', emit))
+        emit('REPLAY done (%u actions)' % len(entries))
+
+    cmd_timer = QTimer()
+    cmd_timer.timeout.connect(cmd_poll)
+    if args.control_port > 0:
+        threading.Thread(target=control_server, daemon=True).start()
+    if args.replay:
+        threading.Thread(target=replay_reader, daemon=True).start()
+    if args.control_port > 0 or args.replay:
+        cmd_timer.start(50)
+
+    def update():
+        ds_value_label.setText(str(ds_value.value()))
+        ds_status.setText(ds.status or 'arm: enable + hold zero throttle >1.5s')
+        edt = ' '.join('%s=%s' % kv for kv in sorted(ds.edt_fresh().items()))
+        bds_label.setText('BDShot:   rpm=%-6.0f %-8s EDT:%-3s sent=%.0f/s replies=%.0f/s badcrc=%u %s'
+                          % (ds.rpm, 'spinning' if ds.spinning else 'stopped',
+                             'on' if ds.edt_active() else 'off',
+                             ds.sent.hz(), ds.replies.hz(), ds.badcrc, edt))
+        if can is not None:
+            can_value_label.setText('%.2f' % (can_value.value() / 1000.0))
+            if can.error:
+                can_label.setText('DroneCAN: error: %s' % can.error)
+            else:
+                s = can.status
+                can_label.setText(
+                    'DroneCAN: rpm=%-6s volt=%-5s cur=%-5s temp=%-5s err=%-3s '
+                    'esc.Status=%.0f/s cmds=%.0f/s node=%s up=%us'
+                    % (s.get('rpm', '-'),
+                       ('%.1f' % s['voltage']) if 'voltage' in s else '-',
+                       ('%.1f' % s['current']) if 'current' in s else '-',
+                       ('%.0f' % s['temp']) if 'temp' in s else '-',
+                       s.get('errors', '-'),
+                       can.esc_rate.hz(), can.sent.hz(),
+                       can.node_id, can.uptime))
+            try:
+                param_status.setText(can.param_result.get_nowait())
+            except queue.Empty:
+                pass
+
+    update_timer = QTimer()
+    update_timer.timeout.connect(update)
+    update_timer.start(100)
+
+    # graceful Ctrl-C / SIGTERM: quit the event loop. The handler runs
+    # from the 100ms update timer, the next time python bytecode executes
+    signal.signal(signal.SIGINT, lambda *a: app.quit())
+    signal.signal(signal.SIGTERM, lambda *a: app.quit())
+
+    win.show()
+    try:
+        app.exec()
+    finally:
+        ds.running = False
+        if can is not None:
+            can.running = False
+            # let the CAN thread close the node and its IO child
+            can.thread.join(2.0)
+
+
+if __name__ == '__main__':
+    main()

--- a/Mcu/SITL/sitl_gui.py
+++ b/Mcu/SITL/sitl_gui.py
@@ -37,12 +37,13 @@ import threading
 import time
 
 try:
-    from PySide6.QtCore import Qt, QTimer
-    from PySide6.QtGui import QFontDatabase
+    from PySide6.QtCore import Qt, QTimer, QRectF, QLineF
+    from PySide6.QtGui import QFontDatabase, QPen, QBrush, QColor, QPainter
     from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox,
+                                   QGraphicsScene, QGraphicsView,
                                    QGridLayout, QGroupBox, QHBoxLayout,
-                                   QLabel, QPushButton, QSlider, QSpinBox,
-                                   QWidget)
+                                   QDoubleSpinBox, QLabel, QPushButton,
+                                   QSlider, QSpinBox, QWidget)
 except ImportError:
     _here = os.path.dirname(os.path.abspath(__file__))
     if sys.platform == 'win32':
@@ -68,14 +69,24 @@ except ImportError:
                _run_cmd))
     sys.exit(1)
 
+try:
+    import pyqtgraph as pg
+    HAVE_PYQTGRAPH = True
+except ImportError:
+    HAVE_PYQTGRAPH = False
+
+import glob
+import math
+
 import sitl_dshot as sd
-from sitl_gui_backend import DshotPanel, CanPanel, HAVE_DRONECAN
+from sitl_gui_backend import DshotPanel, CanPanel, SimStream, HAVE_DRONECAN
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('--host', default='127.0.0.1')
     ap.add_argument('--port', type=int, default=57733)
+    ap.add_argument('--state-port', type=int, default=57734)
     ap.add_argument('--can-uri', default='mcast:0')
     ap.add_argument('--poles', type=int, default=14)
     ap.add_argument('--control-port', type=int, default=0,
@@ -97,6 +108,7 @@ def main():
 
     ds = DshotPanel(args.host, args.port)
     ds.poles = args.poles
+    sim = SimStream(args.host, args.state_port)
 
     # spawn the DroneCAN node with SIGINT ignored: its multiprocessing IO
     # child inherits the kernel-level SIG_IGN disposition, so a terminal
@@ -279,6 +291,229 @@ def main():
     else:
         g2.addWidget(QLabel('pydronecan not available'), 0, 0)
 
+    # ---- simulation panel: motor model selection and the optional high
+    # rate graph/animation views fed by the SITL state stream
+    f4 = QGroupBox('simulation')
+    g4 = QGridLayout(f4)
+    top.addWidget(f4, 2, 0, 1, 2)
+
+    models_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models')
+
+    g4.addWidget(QLabel('Motor model:'), 0, 0)
+    model_combo = QComboBox()
+    model_paths = {}
+    for path in sorted(glob.glob(os.path.join(models_dir, '*.json'))):
+        name = os.path.splitext(os.path.basename(path))[0]
+        model_paths[name] = path
+        model_combo.addItem(name)
+    g4.addWidget(model_combo, 0, 1)
+
+    def model_load():
+        name = model_combo.currentText()
+        if name in model_paths:
+            log_action('model %s' % name)
+            sim.load_model(model_paths[name])
+
+    load_btn = QPushButton('Load')
+    load_btn.clicked.connect(model_load)
+    g4.addWidget(load_btn, 0, 2)
+    model_status = QLabel('')
+    g4.addWidget(model_status, 0, 3, 1, 2)
+
+    graph_i_check = QCheckBox('Current graph')
+    graph_v_check = QCheckBox('Voltage graph')
+    motorview_check = QCheckBox('Motor view')
+    g4.addWidget(graph_i_check, 1, 0)
+    g4.addWidget(graph_v_check, 1, 1)
+    g4.addWidget(motorview_check, 1, 2)
+    sim_rate_label = QLabel('')
+    g4.addWidget(sim_rate_label, 1, 3, 1, 2)
+
+    # simulation speedup, logarithmic 0.001x .. 2x, for slow motion in
+    # the motor view
+    g4.addWidget(QLabel('Speedup:'), 2, 0)
+    speed_slider = QSlider(Qt.Horizontal)
+    speed_slider.setRange(0, 165)
+    speed_slider.setValue(150)
+    speed_slider.setMinimumWidth(200)
+    speed_label = QLabel('1.000x')
+
+    def slider_to_speedup(v):
+        return 10.0 ** ((v - 150) / 50.0)
+
+    def speed_changed(*a):
+        speedup = slider_to_speedup(speed_slider.value())
+        speed_label.setText('%.3fx' % speedup)
+        log_action('speedup %.4f' % speedup)
+        sim.set_speedup(speedup)
+
+    speed_slider.valueChanged.connect(speed_changed)
+    g4.addWidget(speed_slider, 2, 1, 1, 2)
+    g4.addWidget(speed_label, 2, 3)
+    speed_1x = QPushButton('1x')
+    speed_1x.clicked.connect(lambda: speed_slider.setValue(150))
+    g4.addWidget(speed_1x, 2, 4)
+
+    # scope controls: sample period and window, shared by both graph
+    # windows. Fine sample periods (down to the 500ns physics step,
+    # where the dead time windows are visible on the phase voltages) are
+    # meant to be used together with a low speedup to keep the wall
+    # clock data rate sane
+    sample_spin = QDoubleSpinBox()
+    sample_spin.setRange(0.5, 1000.0)
+    sample_spin.setValue(50.0)
+    sample_spin.setSuffix(' us sample')
+    sample_spin.setDecimals(1)
+    g4.addWidget(sample_spin, 3, 0, 1, 2)
+    window_spin = QDoubleSpinBox()
+    window_spin.setRange(0.05, 2000.0)
+    window_spin.setValue(50.0)
+    window_spin.setSuffix(' ms window')
+    window_spin.setDecimals(2)
+    g4.addWidget(window_spin, 3, 2)
+
+    def sample_changed(*a):
+        sim.period_us = sample_spin.value()
+        log_action('sample_us %.1f' % sample_spin.value())
+
+    sample_spin.valueChanged.connect(sample_changed)
+
+    def window_changed(*a):
+        log_action('window_ms %.2f' % window_spin.value())
+
+    window_spin.valueChanged.connect(window_changed)
+
+    # the scopes: each signal set gets its own top level pyqtgraph
+    # window, created lazily on first enable. Closing a window unchecks
+    # its box
+    SIGNAL_SETS = {
+        # key -> ((label, colour, sample column), ...), y axis label/unit
+        'i': ((('iu', 'r', 4), ('iv', 'g', 5), ('iw', 'b', 6),
+               ('ibus', 'w', 11)), 'current', 'A'),
+        'v': ((('vu', 'r', 7), ('vv', 'g', 8), ('vw', 'b', 9),
+               ('vbus', 'w', 10)), 'voltage', 'V'),
+    }
+    graph_windows = {}
+
+    def update_sim_enable():
+        sim.enabled = (graph_i_check.isChecked() or graph_v_check.isChecked()
+                       or motorview_check.isChecked())
+
+    def graph_toggled(key, check, title):
+        log_action('graph_%s %d' % (key, int(check.isChecked())))
+        if check.isChecked() and key not in graph_windows:
+            if not HAVE_PYQTGRAPH:
+                model_status.setText('pyqtgraph not available')
+                check.setChecked(False)
+                return
+
+            class GraphWindow(pg.PlotWidget):
+                def closeEvent(self, ev):
+                    check.setChecked(False)
+                    ev.accept()
+
+            w = GraphWindow()
+            w.setWindowTitle('AM32 SITL %s' % title)
+            w.resize(700, 300)
+            w.addLegend(offset=(10, 10))
+            w.setLabel('bottom', 'time', 's')
+            defs, label, unit = SIGNAL_SETS[key]
+            w.setLabel('left', label, unit)
+            curves = [(w.plot(pen=pg.mkPen(color, width=1), name=name), col)
+                      for name, color, col in defs]
+            graph_windows[key] = (w, curves)
+        if key in graph_windows:
+            graph_windows[key][0].setVisible(check.isChecked())
+        update_sim_enable()
+
+    graph_i_check.toggled.connect(
+        lambda: graph_toggled('i', graph_i_check, 'phase currents'))
+    graph_v_check.toggled.connect(
+        lambda: graph_toggled('v', graph_v_check, 'phase voltages'))
+
+    # motor/bridge animation, created lazily on first enable
+    view = None
+    scene = None
+    anim = {}
+
+    def make_motor_view():
+        nonlocal view, scene
+        scene = QGraphicsScene(0, 0, 420, 220)
+        view = QGraphicsView(scene)
+        view.setRenderHint(QPainter.Antialiasing)
+        view.setFixedHeight(240)
+        # rotor dial
+        scene.addEllipse(20, 20, 180, 180, QPen(QColor('gray'), 2))
+        anim['needle'] = scene.addLine(QLineF(110, 110, 110, 30), QPen(QColor('orange'), 4))
+        anim['e_needle'] = scene.addLine(QLineF(110, 110, 110, 60), QPen(QColor('cyan'), 2))
+        scene.addSimpleText('rotor').setPos(95, 202)
+        # bridge legs: three vertical phase bars, coloured by mode
+        anim['legs'] = []
+        for p, name in enumerate(('U', 'V', 'W')):
+            x = 240 + p * 55
+            rect = scene.addRect(QRectF(x, 40, 36, 120), QPen(Qt.NoPen), QBrush(QColor('gray')))
+            anim['legs'].append(rect)
+            label = scene.addSimpleText(name)
+            label.setPos(x + 12, 165)
+        anim['comp'] = scene.addSimpleText('')
+        anim['comp'].setPos(240, 190)
+        anim['rpm'] = scene.addSimpleText('')
+        anim['rpm'].setPos(240, 12)
+        top.addWidget(view, 4, 0, 1, 2)
+
+    MODE_COLORS = {
+        0: QColor(90, 90, 90),      # FLOAT
+        1: QColor(60, 100, 220),    # LOW
+        2: QColor(60, 190, 60),     # PWM
+        3: QColor(60, 190, 120),    # PWM_NOCOMP
+        4: QColor(220, 140, 40),    # BRAKE_PWM
+    }
+
+    def motorview_changed():
+        log_action('motorview %d' % int(motorview_check.isChecked()))
+        if motorview_check.isChecked() and view is None:
+            make_motor_view()
+        if view is not None:
+            view.setVisible(motorview_check.isChecked())
+        update_sim_enable()
+        win.adjustSize()
+
+    motorview_check.toggled.connect(motorview_changed)
+
+    def update_sim_views():
+        visible = [gw for gw, _ in graph_windows.values() if gw.isVisible()]
+        if visible:
+            win_s = window_spin.value() * 1e-3
+            w = sim.window(win_s)
+            if w:
+                t0 = w[-1][0] - win_s
+                ts = [smp[0] - t0 for smp in w]
+                for gw, curves in graph_windows.values():
+                    if gw.isVisible():
+                        for curve, col in curves:
+                            curve.setData(ts, [smp[col] for smp in w])
+                        # the x axis is the window control, not auto range
+                        gw.setXRange(0, win_s, padding=0)
+        if motorview_check.isChecked() and view is not None:
+            smp = sim.latest()
+            if smp is not None:
+                t, omega, theta, theta_e = smp[0], smp[1], smp[2], smp[3]
+                modes, comp_ph, comp_out = smp[12], smp[13], smp[14]
+                cx, cy, r = 110, 110, 80
+                anim['needle'].setLine(QLineF(cx, cy, cx + r * math.sin(theta),
+                                              cy - r * math.cos(theta)))
+                re = r * 0.6
+                anim['e_needle'].setLine(QLineF(cx, cy, cx + re * math.sin(theta_e),
+                                                cy - re * math.cos(theta_e)))
+                for p in range(3):
+                    anim['legs'][p].setBrush(QBrush(MODE_COLORS.get(modes[p], QColor('gray'))))
+                anim['comp'].setText('comparator: phase %s out=%d' % ('UVW'[comp_ph], comp_out))
+                anim['rpm'].setText('%.0f rpm' % (omega * 60 / (2 * math.pi)))
+
+    sim_view_timer = QTimer()
+    sim_view_timer.timeout.connect(update_sim_views)
+    sim_view_timer.start(33)
+
     # ---- telemetry panel
     f3 = QGroupBox('telemetry')
     g3 = QGridLayout(f3)
@@ -353,10 +588,40 @@ def main():
             can_rate.setValue(int(cargs[0]))
         elif cmd == 'param' and can is not None:
             can.set_param(cargs[0], int(cargs[1]))
+        elif cmd == 'motorview':
+            motorview_check.setChecked(bool(int(cargs[0])))
+        elif cmd == 'model':
+            if cargs[0] in model_paths:
+                model_combo.setCurrentText(cargs[0])
+                model_load()
+            else:
+                sim.load_model(cargs[0])
+        elif cmd == 'graph_i' or cmd == 'graphs':
+            graph_i_check.setChecked(bool(int(cargs[0])))
+        elif cmd == 'graph_v':
+            graph_v_check.setChecked(bool(int(cargs[0])))
+        elif cmd == 'signals':
+            # compatibility with recordings from the single-graph UI
+            if cargs[0] == 'voltages':
+                graph_v_check.setChecked(True)
+            else:
+                graph_i_check.setChecked(True)
+        elif cmd == 'sample_us':
+            sample_spin.setValue(float(cargs[0]))
+        elif cmd == 'window_ms':
+            window_spin.setValue(float(cargs[0]))
+        elif cmd == 'speedup':
+            x = float(cargs[0])
+            pos = int(round(150 + 50 * math.log10(max(0.001, min(2.0, x)))))
+            if pos == speed_slider.value():
+                speed_changed()
+            else:
+                speed_slider.setValue(pos)
         elif cmd == 'status':
             reply('STATUS %s' % bds_label.text())
             reply('STATUS %s' % can_label.text())
             reply('STATUS ds: %s' % (ds.status or '-'))
+            reply('STATUS sim: %s rate=%.0f/s' % (sim.model_status or '-', sim.rate.hz()))
             return
         elif cmd == 'quit':
             app.quit()
@@ -429,6 +694,11 @@ def main():
                 param_status.setText(can.param_result.get_nowait())
             except queue.Empty:
                 pass
+        model_status.setText(sim.model_status)
+        if sim.enabled:
+            sim_rate_label.setText('%.0f samples/s' % sim.rate.hz())
+        else:
+            sim_rate_label.setText('')
 
     update_timer = QTimer()
     update_timer.timeout.connect(update)
@@ -444,6 +714,7 @@ def main():
         app.exec()
     finally:
         ds.running = False
+        sim.close()
         if can is not None:
             can.running = False
             # let the CAN thread close the node and its IO child

--- a/Mcu/SITL/sitl_gui.py
+++ b/Mcu/SITL/sitl_gui.py
@@ -296,14 +296,50 @@ def main():
             log_action('can_enable %d' % int(can.enabled))
 
         can_enable.setToolTip(
-            'Start/stop the RawCommand + ArmingStatus stream. Cutting it\n'
-            'simulates losing the CAN flight controller: the firmware\n'
-            'zeroes the throttle 250ms after commands stop, then the\n'
-            'signal timeout reboots the ESC.')
+            'Master switch for this GUI\'s CAN traffic: ArmingStatus at the\n'
+            'configured rate plus RawCommand when its box is ticked.\n'
+            'Cutting everything simulates losing the flight controller\n'
+            'entirely: the firmware zeroes throttle 250ms after commands\n'
+            'stop and the CAN signal timeout then reboots the ESC. Use the\n'
+            'RawCommand box instead to cut only the command stream.')
         can_enable.toggled.connect(can_enable_changed)
         g2.addWidget(can_enable, 0, 0)
 
-        g2.addWidget(QLabel('Throttle:'), 1, 0)
+        can_rawcmd = QCheckBox('RawCommand')
+        can_rawcmd.setChecked(True)
+        can_rawcmd.setToolTip(
+            'Send the esc.RawCommand throttle broadcasts. Unchecking\n'
+            'simulates a flight controller that stops commanding while the\n'
+            'rest of its CAN traffic continues (the ArmingStatus stream\n'
+            'keeps flowing) - the firmware is expected to zero the input\n'
+            '250ms after commands stop.')
+
+        def can_rawcmd_changed():
+            can.send_rawcommand = can_rawcmd.isChecked()
+            log_action('can_rawcmd %d' % int(can.send_rawcommand))
+
+        can_rawcmd.toggled.connect(can_rawcmd_changed)
+        g2.addWidget(can_rawcmd, 1, 0)
+
+        can_armed = QCheckBox('Armed')
+        can_armed.setChecked(True)
+        can_armed.setToolTip(
+            'Value carried in the ArmingStatus broadcasts: checked sends\n'
+            'FULLY_ARMED (255), unchecked sends disarmed (0). With the\n'
+            'default REQUIRE_ARM setting the ESC only applies throttle\n'
+            'while armed, so unchecking this while spinning must stop the\n'
+            'motor. The ArmingStatus stream itself follows Enable; note\n'
+            'the ESC ignores NodeStatus, so ArmingStatus is what keeps its\n'
+            'CAN signal timeout fed.')
+
+        def can_armed_changed():
+            can.armed = can_armed.isChecked()
+            log_action('can_armed %d' % int(can.armed))
+
+        can_armed.toggled.connect(can_armed_changed)
+        g2.addWidget(can_armed, 1, 1)
+
+        g2.addWidget(QLabel('Throttle:'), 2, 0)
         # slider in 0..1000 -> throttle 0..1
         can_value = QSlider(Qt.Horizontal)
         can_value.setRange(0, 1000)
@@ -318,11 +354,11 @@ def main():
             'firmware settings also require an ArmingStatus broadcast\n'
             '(sent automatically while enabled) before spinning.')
         can_value.valueChanged.connect(can_value_changed)
-        g2.addWidget(can_value, 1, 1, 1, 2)
+        g2.addWidget(can_value, 2, 1, 1, 2)
         can_value_label = QLabel('0.00')
-        g2.addWidget(can_value_label, 1, 3)
+        g2.addWidget(can_value_label, 2, 3)
 
-        g2.addWidget(QLabel('Rate Hz:'), 2, 0)
+        g2.addWidget(QLabel('Rate Hz:'), 3, 0)
         can_rate = QSpinBox()
         can_rate.setRange(1, 1000)
         can_rate.setValue(50)
@@ -335,12 +371,12 @@ def main():
             'RawCommand broadcast rate. Autopilots typically send ESC\n'
             'commands at 50..400Hz on CAN.')
         can_rate.valueChanged.connect(can_rate_changed)
-        g2.addWidget(can_rate, 2, 1)
+        g2.addWidget(can_rate, 3, 1)
 
         can_zero_btn = QPushButton('Zero throttle')
         can_zero_btn.setToolTip('Set the CAN throttle to zero (keeps streaming commands).')
         can_zero_btn.clicked.connect(lambda: can_value.setValue(0))
-        g2.addWidget(can_zero_btn, 3, 0)
+        g2.addWidget(can_zero_btn, 4, 0)
 
         # parameter panel
         pf = QGroupBox('parameters (set + save + restart)')
@@ -351,7 +387,7 @@ def main():
             'the default 5 (dronecan) disables the PWM/DShot input\n'
             'interrupts entirely, so set 0..2 to test the signal wire.')
         gp = QGridLayout(pf)
-        g2.addWidget(pf, 4, 0, 1, 4)
+        g2.addWidget(pf, 5, 0, 1, 4)
         gp.addWidget(QLabel('INPUT_SIGNAL_TYPE:'), 0, 0)
         ptype_var = QSpinBox()
         ptype_var.setToolTip(
@@ -777,6 +813,10 @@ def main():
             ds_edt.setChecked(False)
         elif cmd == 'can_enable' and can is not None:
             can_enable.setChecked(bool(int(cargs[0])))
+        elif cmd == 'can_rawcmd' and can is not None:
+            can_rawcmd.setChecked(bool(int(cargs[0])))
+        elif cmd == 'can_armed' and can is not None:
+            can_armed.setChecked(bool(int(cargs[0])))
         elif cmd == 'can_value' and can is not None:
             can_value.setValue(int(float(cargs[0]) * 1000))
         elif cmd == 'can_rate' and can is not None:

--- a/Mcu/SITL/sitl_gui.py
+++ b/Mcu/SITL/sitl_gui.py
@@ -127,6 +127,11 @@ def main():
 
     # ---- PWM/DShot input panel
     f1 = QGroupBox('PWM/DShot input (udp %s:%u)' % (args.host, args.port))
+    f1.setToolTip(
+        'The classic ESC signal wire, emulated over UDP: each packet is one\n'
+        'frame on the wire, either a servo PWM pulse or a complete DShot\n'
+        'frame. The frames are decoded by the unmodified AM32 firmware,\n'
+        'including input auto-detection, CRC checking and arming.')
     g1 = QGridLayout(f1)
     top.addWidget(f1, 0, 0)
 
@@ -136,6 +141,12 @@ def main():
         ds.enabled = ds_enable.isChecked()
         log_action('ds_enable %d' % int(ds.enabled))
 
+    ds_enable.setToolTip(
+        'Start/stop the frame stream. The ESC arms after seeing zero\n'
+        'throttle for about 1.5 seconds, like on the bench. Unchecking\n'
+        'simulates signal loss: the firmware signal timeout zeroes the\n'
+        'motor and reboots the ESC, which is the behaviour exercised in\n'
+        'input failover testing.')
     ds_enable.toggled.connect(ds_enable_changed)
     g1.addWidget(ds_enable, 0, 0)
 
@@ -157,6 +168,15 @@ def main():
         log_action('ds_type %s' % ds_type.currentText())
         value_changed()
 
+    ds_type.setToolTip(
+        'Signal protocol on the wire.\n'
+        'pwm: the classic servo pulse, 1000..2000us pulse width = throttle,\n'
+        '  sent at 50..490Hz.\n'
+        'dshot300/600: digital frames at 300/600 kbit/s. Each frame is 16\n'
+        '  bits: 11 bit throttle (48..2047; 0=stop, 1..47 are commands),\n'
+        '  a telemetry request bit and a 4 bit checksum.\n'
+        'dshot150 exists in the protocol but AM32 input auto-detection has\n'
+        'no timing band for it, so the ESC never recognises it.')
     ds_type.currentTextChanged.connect(type_changed)
     g1.addWidget(ds_type, 1, 1)
 
@@ -166,6 +186,13 @@ def main():
         ds.bidir = ds_bidir.isChecked()
         log_action('ds_bidir %d' % int(ds.bidir))
 
+    ds_bidir.setToolTip(
+        'Bidirectional DShot (BDShot): the signal line idles high and the\n'
+        'frame checksum is inverted. After each received frame the ESC\n'
+        'answers on the same wire with a GCR-encoded reply carrying the\n'
+        'electrical rotation period, which flight controllers use for RPM\n'
+        'notch filtering. The reply also carries extended telemetry frames\n'
+        'when EDT is enabled. Required for the BDShot telemetry line below.')
     ds_bidir.toggled.connect(ds_bidir_changed)
     g1.addWidget(ds_bidir, 1, 2)
 
@@ -184,6 +211,12 @@ def main():
             v = 0
         ds.value = v
 
+    ds_value.setToolTip(
+        'Throttle value sent in every frame. DShot: 48..2047 (0 = motor\n'
+        'stop). Values 1..47 are DShot commands (beacons, direction,\n'
+        'settings save, programming mode) - the slider skips them because\n'
+        'a drag would dwell long enough to execute one. PWM: pulse width\n'
+        'in microseconds, 1000 = stop, 2000 = full throttle.')
     # valueChanged fires for both drags and programmatic setValue()
     ds_value.valueChanged.connect(value_changed)
     g1.addWidget(ds_value, 2, 1, 1, 2)
@@ -199,11 +232,22 @@ def main():
         ds.rate = float(ds_rate.value())
         log_action('ds_rate %d' % ds_rate.value())
 
+    ds_rate.setToolTip(
+        'Frame rate on the wire. Flight controllers send DShot at 1..8kHz\n'
+        'and servo PWM at 50..490Hz. The ESC needs a continuous stream:\n'
+        'arming, the signal-loss timeout and BDShot reply rate all follow\n'
+        'the frame rate. Note the rate is wall clock, so at low simulation\n'
+        'speedups frames arrive faster in simulated time and some are\n'
+        'dropped while the virtual wire is busy, as on real hardware.')
     ds_rate.valueChanged.connect(rate_changed)
     g1.addWidget(ds_rate, 3, 1)
 
     bf = QHBoxLayout()
     zero_btn = QPushButton('Zero throttle')
+    zero_btn.setToolTip(
+        'Set the throttle to the stop value (DShot 0 / PWM 1000us).\n'
+        'Needed for arming and before DShot commands such as the EDT\n'
+        'enable are accepted by the firmware.')
     zero_btn.clicked.connect(
         lambda: ds_value.setValue(1000 if ds.ptype == sd.TYPE_PWM else 0))
     bf.addWidget(zero_btn)
@@ -214,16 +258,33 @@ def main():
         ds.edt_want = ds_edt.isChecked()
         log_action('ds_edt %d' % int(ds.edt_want))
 
+    ds_edt.setToolTip(
+        'Extended DShot Telemetry: temperature, voltage and current frames\n'
+        'interleaved into the BDShot replies (temperature/voltage every\n'
+        '~200 replies, current every ~40). The firmware only accepts the\n'
+        'enable command (DShot command 13) while armed with the motor\n'
+        'stopped, and a reboot clears it, so this checkbox keeps re-sending\n'
+        'the command until the replies show EDT frames. Needs bidir.')
     ds_edt.toggled.connect(ds_edt_changed)
     bf.addWidget(ds_edt)
     bf.addStretch(1)
     g1.addLayout(bf, 4, 0, 1, 4)
 
     ds_status = QLabel('arm: enable + hold zero throttle >1.5s')
+    ds_status.setToolTip(
+        'Guidance from the DShot sender: arming procedure, EDT progress\n'
+        'and protocol notes.')
     g1.addWidget(ds_status, 5, 0, 1, 4)
 
     # ---- DroneCAN input panel
     f2 = QGroupBox('DroneCAN input (%s)' % args.can_uri)
+    f2.setToolTip(
+        'DroneCAN: the CAN bus protocol used on larger vehicles, here\n'
+        'carried over multicast UDP. Throttle goes as esc.RawCommand\n'
+        'broadcasts and the ESC sends esc.Status telemetry back. In the\n'
+        'current firmware, once any RawCommand has been received the CAN\n'
+        'input overrides the PWM/DShot wire until a reboot - the\n'
+        'arbitration behaviour the failover parameter work is about.')
     g2 = QGridLayout(f2)
     top.addWidget(f2, 0, 1)
 
@@ -234,6 +295,11 @@ def main():
             can.enabled = can_enable.isChecked()
             log_action('can_enable %d' % int(can.enabled))
 
+        can_enable.setToolTip(
+            'Start/stop the RawCommand + ArmingStatus stream. Cutting it\n'
+            'simulates losing the CAN flight controller: the firmware\n'
+            'zeroes the throttle 250ms after commands stop, then the\n'
+            'signal timeout reboots the ESC.')
         can_enable.toggled.connect(can_enable_changed)
         g2.addWidget(can_enable, 0, 0)
 
@@ -247,6 +313,10 @@ def main():
             can.throttle = can_value.value() / 1000.0
             log_action('can_value %.4f' % can.throttle)
 
+        can_value.setToolTip(
+            'Throttle 0..1, sent as esc.RawCommand 0..8191. The default\n'
+            'firmware settings also require an ArmingStatus broadcast\n'
+            '(sent automatically while enabled) before spinning.')
         can_value.valueChanged.connect(can_value_changed)
         g2.addWidget(can_value, 1, 1, 1, 2)
         can_value_label = QLabel('0.00')
@@ -261,19 +331,33 @@ def main():
             can.rate = float(can_rate.value())
             log_action('can_rate %d' % can_rate.value())
 
+        can_rate.setToolTip(
+            'RawCommand broadcast rate. Autopilots typically send ESC\n'
+            'commands at 50..400Hz on CAN.')
         can_rate.valueChanged.connect(can_rate_changed)
         g2.addWidget(can_rate, 2, 1)
 
         can_zero_btn = QPushButton('Zero throttle')
+        can_zero_btn.setToolTip('Set the CAN throttle to zero (keeps streaming commands).')
         can_zero_btn.clicked.connect(lambda: can_value.setValue(0))
         g2.addWidget(can_zero_btn, 3, 0)
 
         # parameter panel
         pf = QGroupBox('parameters (set + save + restart)')
+        pf.setToolTip(
+            'Sets an ESC setting over the DroneCAN parameter protocol, saves\n'
+            'to eeprom and reboots the ESC so it takes effect at startup.\n'
+            'INPUT_SIGNAL_TYPE selects which input the firmware listens to:\n'
+            'the default 5 (dronecan) disables the PWM/DShot input\n'
+            'interrupts entirely, so set 0..2 to test the signal wire.')
         gp = QGridLayout(pf)
         g2.addWidget(pf, 4, 0, 1, 4)
         gp.addWidget(QLabel('INPUT_SIGNAL_TYPE:'), 0, 0)
         ptype_var = QSpinBox()
+        ptype_var.setToolTip(
+            'INPUT_SIGNAL_TYPE value: 0 = auto detect the wire protocol,\n'
+            '1 = dshot, 2 = servo PWM, 5 = dronecan only (disables the\n'
+            'PWM/DShot input interrupts at boot).')
         ptype_var.setRange(0, 5)
         ptype_var.setValue(1)
         gp.addWidget(ptype_var, 0, 1)
@@ -286,6 +370,7 @@ def main():
             can.set_param('INPUT_SIGNAL_TYPE', ptype_var.value())
 
         apply_btn = QPushButton('Apply')
+        apply_btn.setToolTip('Set the parameter over CAN, save to eeprom and reboot the ESC.')
         apply_btn.clicked.connect(param_apply)
         gp.addWidget(apply_btn, 0, 3)
     else:
@@ -294,6 +379,10 @@ def main():
     # ---- simulation panel: motor model selection and the optional high
     # rate graph/animation views fed by the SITL state stream
     f4 = QGroupBox('simulation')
+    f4.setToolTip(
+        'Controls for the physics simulation itself (not the ESC firmware):\n'
+        'the motor/battery model, the simulation pace and the high rate\n'
+        'views fed by the simulation state stream.')
     g4 = QGridLayout(f4)
     top.addWidget(f4, 2, 0, 1, 2)
 
@@ -306,6 +395,13 @@ def main():
         name = os.path.splitext(os.path.basename(path))[0]
         model_paths[name] = path
         model_combo.addItem(name)
+    model_combo.setToolTip(
+        'Motor/battery models from Mcu/SITL/models/*.json: winding\n'
+        'resistance and inductance, Kv (rpm per volt), pole count, rotor\n'
+        'inertia and the propeller load (torque proportional to speed\n'
+        'squared), plus battery voltage and internal resistance. These\n'
+        'set how the virtual motor behaves; the ESC settings should\n'
+        'match the motor, as on a real bench.')
     g4.addWidget(model_combo, 0, 1)
 
     def model_load():
@@ -315,6 +411,10 @@ def main():
             sim.load_model(model_paths[name])
 
     load_btn = QPushButton('Load')
+    load_btn.setToolTip(
+        'Apply the selected model to the running simulation. Switching\n'
+        'while spinning is like swapping the motor mid-flight - expect\n'
+        'desyncs; switch at zero throttle for clean results.')
     load_btn.clicked.connect(model_load)
     g4.addWidget(load_btn, 0, 2)
     model_status = QLabel('')
@@ -323,10 +423,31 @@ def main():
     graph_i_check = QCheckBox('Current graph')
     graph_v_check = QCheckBox('Voltage graph')
     motorview_check = QCheckBox('Motor view')
+    graph_i_check.setToolTip(
+        'Open a scope window with the three phase currents and the battery\n'
+        'current, sampled from the physics. In a 6-step drive two phases\n'
+        'conduct at a time, so each phase carries a quasi-trapezoidal\n'
+        'current envelope that steps at every commutation (six steps per\n'
+        'electrical revolution).')
+    graph_v_check.setToolTip(
+        'Open a scope window with the three phase terminal voltages and\n'
+        'the battery voltage. At coarse sample periods it shows the duty\n'
+        'proportional average; at fine periods (with a low speedup) the\n'
+        'raw PWM switching, the back-EMF ramp on the floating phase (what\n'
+        'the comparator senses for zero crossings) and the dead time diode\n'
+        'spikes at each PWM edge become visible.')
+    motorview_check.setToolTip(
+        'Open the animated motor/bridge view. Slow the simulation right\n'
+        'down with the speedup slider to watch individual commutation\n'
+        'steps rotate the stator field ahead of the rotor.')
     g4.addWidget(graph_i_check, 1, 0)
     g4.addWidget(graph_v_check, 1, 1)
     g4.addWidget(motorview_check, 1, 2)
     sim_rate_label = QLabel('')
+    sim_rate_label.setToolTip(
+        'State stream rate actually arriving from the simulation (wall\n'
+        'clock). It is the sample period in simulated time divided by the\n'
+        'speedup, capped at about 200k samples/s.')
     g4.addWidget(sim_rate_label, 1, 3, 1, 2)
 
     # simulation speedup, logarithmic 0.001x .. 2x, for slow motion in
@@ -347,10 +468,18 @@ def main():
         log_action('speedup %.4f' % speedup)
         sim.set_speedup(speedup)
 
+    speed_slider.setToolTip(
+        'Simulation pace relative to wall clock, 0.001x to 2x. Everything\n'
+        'inside the simulation (arming times, timeouts, telemetry rates)\n'
+        'runs in simulated time, so at 0.01x the ESC responds 100x slower\n'
+        'from the outside. Use slow motion to watch the motor view and to\n'
+        'capture fine waveforms; the input frames you send arrive faster\n'
+        'in simulated time, so some are dropped as on a busy wire.')
     speed_slider.valueChanged.connect(speed_changed)
     g4.addWidget(speed_slider, 2, 1, 1, 2)
     g4.addWidget(speed_label, 2, 3)
     speed_1x = QPushButton('1x')
+    speed_1x.setToolTip('Back to real time.')
     speed_1x.clicked.connect(lambda: speed_slider.setValue(150))
     g4.addWidget(speed_1x, 2, 4)
 
@@ -376,11 +505,24 @@ def main():
         sim.period_us = sample_spin.value()
         log_action('sample_us %.1f' % sample_spin.value())
 
+    sample_spin.setToolTip(
+        'Scope sample period in simulated microseconds. At 10us and above\n'
+        'each sample is the average over its period (the honest duty\n'
+        'proportional envelope - point sampling would alias against the\n'
+        'PWM and show false gaps). Below 10us samples are instantaneous\n'
+        'levels, down to the 500ns physics step, showing PWM edges and\n'
+        'dead time. The wall clock rate is capped at ~200k samples/s, so\n'
+        'fine periods only take full effect at low speedups.')
     sample_spin.valueChanged.connect(sample_changed)
 
     def window_changed(*a):
         log_action('window_ms %.2f' % window_spin.value())
 
+    window_spin.setToolTip(
+        'Scope x axis span in simulated milliseconds, newest sample at the\n'
+        'right edge. For commutation-scale viewing use 10..50ms; for PWM\n'
+        'and dead time detail use 0.1..1ms together with a fine sample\n'
+        'period and a low speedup.')
     window_spin.valueChanged.connect(window_changed)
 
     # the scopes: each signal set gets its own top level pyqtgraph
@@ -414,6 +556,28 @@ def main():
 
             w = GraphWindow()
             w.setWindowTitle('AM32 SITL %s' % title)
+            if key == 'i':
+                w.setToolTip(
+                    'Phase currents iu/iv/iw (red/green/blue) and battery\n'
+                    'current ibus (white). Two phases conduct at a time in a\n'
+                    '6-step drive: current flows in one phase, back through\n'
+                    'another, and the third floats near zero. Each commutation\n'
+                    'advances the pattern; torque is proportional to the\n'
+                    'conducted current. ibus is the PWM-chopped share drawn\n'
+                    'from the battery - averaged it equals duty times phase\n'
+                    'current, which is why battery current is far below phase\n'
+                    'current at partial throttle.')
+            else:
+                w.setToolTip(
+                    'Phase terminal voltages vu/vv/vw (red/green/blue) and\n'
+                    'battery voltage vbus (white). At coarse sample periods\n'
+                    'the trace is the duty proportional average. With a fine\n'
+                    'sample period and low speedup the raw switching shows:\n'
+                    'the PWM square wave on the driven phase, the low side\n'
+                    'held near 0V, the floating phase ramping with back-EMF\n'
+                    'through the zero crossing the comparator detects, and\n'
+                    '500ns dead time spikes to -0.7V or vbus+0.7V where the\n'
+                    'body diodes conduct at each PWM edge.')
             w.resize(700, 300)
             w.addLegend(offset=(10, 10))
             w.setLabel('bottom', 'time', 's')
@@ -440,6 +604,19 @@ def main():
         nonlocal view, scene
         scene = QGraphicsScene(0, 0, 420, 220)
         view = QGraphicsView(scene)
+        view.setToolTip(
+            'Live motor and bridge state.\n'
+            'Dial: the orange needle is the mechanical rotor angle, the\n'
+            'cyan needle the electrical angle - with 7 pole pairs the\n'
+            'electrical needle turns 7x faster, one electrical turn per 6\n'
+            'commutation steps.\n'
+            'U/V/W bars: the bridge output for each phase - green = PWM\n'
+            'driven high side, blue = tied low, grey = floating (undriven,\n'
+            'used for back-EMF sensing), orange = brake PWM.\n'
+            'The comparator line shows which floating phase is being\n'
+            'watched for its back-EMF zero crossing, which is how a\n'
+            'sensorless ESC knows the rotor position.\n'
+            'Use the speedup slider for slow motion.')
         view.setRenderHint(QPainter.Antialiasing)
         view.setFixedHeight(240)
         # rotor dial
@@ -520,9 +697,27 @@ def main():
     top.addWidget(f3, 1, 0, 1, 2)
     fixed = QFontDatabase.systemFont(QFontDatabase.FixedFont)
     bds_label = QLabel('BDShot: -')
+    bds_label.setToolTip(
+        'Telemetry decoded from the BDShot replies on the signal wire:\n'
+        'rpm: from the eRPM period in each reply and the pole count.\n'
+        'spinning/stopped: whether the replies report rotation.\n'
+        'EDT on/off: whether extended telemetry frames are arriving.\n'
+        'sent/replies: frame rates on the virtual wire; replies stop when\n'
+        '  the wire is saturated or the ESC is rebooting.\n'
+        'badcrc: replies that failed their checksum.\n'
+        'temp/volt/current: extended telemetry values when EDT is on.')
     bds_label.setFont(fixed)
     g3.addWidget(bds_label, 0, 0)
     can_label = QLabel('DroneCAN: -')
+    can_label.setToolTip(
+        'Telemetry from the DroneCAN esc.Status broadcasts:\n'
+        'rpm/volt/cur/temp: as reported by the firmware (voltage and\n'
+        '  current from the simulated ADC path).\n'
+        'err: desync count - commutation losses detected by the firmware.\n'
+        'esc.Status: telemetry rate (TELEM_RATE parameter, sim time).\n'
+        'cmds: RawCommand rate this GUI is sending.\n'
+        'node: the ESC node id; up: firmware uptime in simulated seconds\n'
+        '  (resets on every reboot, so it exposes signal-timeout reboots).')
     can_label.setFont(fixed)
     g3.addWidget(can_label, 1, 0)
 

--- a/Mcu/SITL/sitl_gui_backend.py
+++ b/Mcu/SITL/sitl_gui_backend.py
@@ -1,0 +1,274 @@
+'''
+UI-independent backends for the AM32 SITL control GUI: the PWM/DShot
+sender, the DroneCAN node and rate counters. These run in their own
+threads and expose plain attributes/queues, so they can be driven by any
+front end or by headless tests without a display.
+'''
+
+import queue
+import threading
+import time
+
+import sitl_dshot as sd
+
+try:
+    import dronecan
+    HAVE_DRONECAN = True
+except ImportError:
+    HAVE_DRONECAN = False
+
+
+class RateCounter(object):
+    def __init__(self):
+        self.count = 0
+        self.rate = 0.0
+        self.last = time.time()
+        self.last_count = 0
+
+    def tick(self, n=1):
+        self.count += n
+
+    def hz(self):
+        now = time.time()
+        dt = now - self.last
+        if dt >= 1.0:
+            self.rate = (self.count - self.last_count) / dt
+            self.last = now
+            self.last_count = self.count
+        return self.rate
+
+
+class DshotPanel(object):
+    '''PWM/DShot sender thread + state'''
+
+    def __init__(self, host, port):
+        self.port = sd.InputPort(host, port)
+        self.enabled = False
+        self.ptype = sd.TYPE_DSHOT300
+        self.bidir = False
+        self.telem_bit = False
+        self.value = 0          # dshot value or pwm width
+        self.rate = 500.0
+        self.cmd_queue = queue.Queue()
+        self.sent = RateCounter()
+        self.replies = RateCounter()
+        self.rpm = 0.0
+        self.spinning = False
+        self.badcrc = 0
+        self.edt = {}           # kind -> (value, time received)
+        self.edt_want = False
+        self.last_edt_seen = 0.0
+        self.last_edt_cmd = 0.0
+        self.poles = 14
+        self.status = ''
+        self.running = True
+        threading.Thread(target=self._sender, daemon=True).start()
+
+    def _sender(self):
+        next_send = time.time()
+        while self.running:
+            now = time.time()
+            if not self.enabled:
+                next_send = now
+                time.sleep(0.02)
+                self._collect()
+                continue
+            if now < next_send:
+                time.sleep(next_send - now)
+            next_send += 1.0 / max(1.0, self.rate)
+            try:
+                cmd = self.cmd_queue.get_nowait()
+            except queue.Empty:
+                cmd = None
+            if cmd is not None:
+                self.port.send_dshot(cmd, ptype=self.ptype, telem=True, bidir=self.bidir)
+            elif self.ptype == sd.TYPE_PWM:
+                self.port.send_pwm(int(self.value))
+            else:
+                self.port.send_dshot(int(self.value), ptype=self.ptype,
+                                     telem=self.telem_bit, bidir=self.bidir)
+            self.sent.tick()
+            self._collect()
+            self._edt_maintain(now)
+        self.port.close()
+
+    def _collect(self):
+        for r in self.port.get_replies():
+            self.replies.tick()
+            kind, val = sd.decode_reply(r[3], edt_expected=True)
+            if kind == 'erpm':
+                self.spinning = val < 65408
+                self.rpm = sd.erpm_period_to_rpm(val, self.poles)
+            elif kind == 'badcrc':
+                self.badcrc += 1
+            else:
+                self.last_edt_seen = time.time()
+                if kind == 'edt' and val in (0xE00, 0xEFF):
+                    # EDT init/deinit acknowledgement frames, not data
+                    continue
+                self.edt[kind] = (val, time.time())
+
+    def edt_active(self):
+        '''true when EDT frames are actually arriving from the ESC'''
+        return time.time() - self.last_edt_seen < 3.0
+
+    def edt_fresh(self, max_age=15.0):
+        '''EDT values received recently. The age allows for the slow EDT
+        schedule at low frame rates (temp/voltage every ~400 replies)'''
+        if not self.edt_active():
+            return {}
+        now = time.time()
+        return {k: v for k, (v, t) in self.edt.items() if now - t < max_age}
+
+    def send_command(self, cmd, count=8):
+        for _ in range(count):
+            self.cmd_queue.put(cmd)
+
+    def _edt_maintain(self, now):
+        '''EDT is a maintained state: the firmware only processes DShot
+        commands while armed with the motor stopped, silently discarding
+        them otherwise, and a reboot clears EDT. Keep (re)sending the
+        enable/disable command until the reply stream matches the
+        requested state'''
+        if self.ptype == sd.TYPE_PWM or not self.bidir:
+            return
+        active = self.edt_active()
+        if self.edt_want == active:
+            if self.edt_want and self.status.startswith('EDT'):
+                self.status = ''
+            return
+        if int(self.value) != 0 or self.spinning:
+            if self.edt_want:
+                self.status = 'EDT pending: needs the motor stopped at zero throttle'
+            return
+        if now - self.last_edt_cmd > 1.5:
+            self.last_edt_cmd = now
+            if self.edt_want:
+                self.send_command(sd.DSHOT_CMD_EDT_ENABLE)
+                self.status = 'EDT enable sent, waiting for EDT frames (arms after >1.5s at zero)'
+            else:
+                self.send_command(sd.DSHOT_CMD_EDT_DISABLE)
+                self.status = 'EDT disable sent'
+
+
+class CanPanel(object):
+    '''DroneCAN node thread: RawCommand/ArmingStatus stream, telemetry
+    handlers and parameter set requests'''
+
+    def __init__(self, uri):
+        self.uri = uri
+        self.enabled = False
+        self.throttle = 0.0     # 0..1
+        self.rate = 50.0
+        self.esc_index = 0
+        self.status = {}
+        self.node_id = None
+        self.uptime = 0
+        self.esc_rate = RateCounter()
+        self.sent = RateCounter()
+        self.param_queue = queue.Queue()
+        self.param_result = queue.Queue()
+        self.error = None
+        self.running = True
+        # set once make_node has spawned the IO child (or failed), so the
+        # caller can sequence signal handler setup around the spawn
+        self.started = threading.Event()
+        self.thread = threading.Thread(target=self._can_thread, daemon=True)
+        self.thread.start()
+
+    def _can_thread(self):
+        try:
+            node = dronecan.make_node(self.uri, node_id=126, bitrate=1000000)
+        except Exception as ex:
+            self.error = str(ex)
+            self.started.set()
+            return
+        self.started.set()
+
+        def on_esc_status(e):
+            m = e.message
+            if m.esc_index != self.esc_index:
+                return
+            # the ESC is unambiguously the sender of esc.Status; other
+            # nodes on the bus also send NodeStatus
+            self.node_id = e.transfer.source_node_id
+            self.esc_rate.tick()
+            self.status = {
+                'rpm': m.rpm,
+                'voltage': m.voltage,
+                'current': m.current,
+                'temp': m.temperature - 273.15,
+                'errors': m.error_count,
+            }
+
+        def on_node_status(e):
+            if e.transfer.source_node_id == self.node_id:
+                self.uptime = e.message.uptime_sec
+
+        node.add_handler(dronecan.uavcan.equipment.esc.Status, on_esc_status)
+        node.add_handler(dronecan.uavcan.protocol.NodeStatus, on_node_status)
+
+        next_send = time.time()
+        while self.running:
+            try:
+                node.spin(0.002)
+            except Exception:
+                pass
+            self._handle_param(node)
+            if not self.enabled:
+                next_send = time.time()
+                continue
+            now = time.time()
+            if now >= next_send:
+                next_send += 1.0 / max(1.0, self.rate)
+                cmds = [0] * (self.esc_index + 1)
+                cmds[self.esc_index] = int(8191 * self.throttle)
+                node.broadcast(dronecan.uavcan.equipment.safety.ArmingStatus(status=255))
+                node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=cmds))
+                self.sent.tick()
+        # orderly shutdown of the mcast IO child process
+        try:
+            node.close()
+        except Exception:
+            pass
+
+    def _handle_param(self, node):
+        try:
+            name, value = self.param_queue.get_nowait()
+        except queue.Empty:
+            return
+        if self.node_id is None:
+            self.param_result.put('no node seen yet')
+            return
+        target = self.node_id
+        result = {}
+
+        def cb(e):
+            result['rsp'] = e.response if e is not None else None
+            result['done'] = True
+
+        def wait(req, timeout=2.0):
+            result.clear()
+            node.request(req, target, cb)
+            deadline = time.time() + timeout
+            while 'done' not in result and time.time() < deadline:
+                node.spin(0.05)
+            return result.get('rsp')
+
+        req = dronecan.uavcan.protocol.param.GetSet.Request()
+        req.name = name
+        req.value = dronecan.uavcan.protocol.param.Value(integer_value=int(value))
+        rsp = wait(req)
+        if rsp is None or len(rsp.name) == 0:
+            self.param_result.put('%s: set failed' % name)
+            return
+        req = dronecan.uavcan.protocol.param.ExecuteOpcode.Request()
+        req.opcode = req.OPCODE_SAVE
+        wait(req)
+        req = dronecan.uavcan.protocol.RestartNode.Request()
+        req.magic_number = req.MAGIC_NUMBER
+        wait(req, timeout=1.0)
+        self.param_result.put('%s=%d saved, node %d restarted' % (name, int(value), target))
+
+    def set_param(self, name, value):
+        self.param_queue.put((name, value))

--- a/Mcu/SITL/sitl_gui_backend.py
+++ b/Mcu/SITL/sitl_gui_backend.py
@@ -78,19 +78,28 @@ class DshotPanel(object):
                 continue
             if now < next_send:
                 time.sleep(next_send - now)
-            next_send += 1.0 / max(1.0, self.rate)
-            try:
-                cmd = self.cmd_queue.get_nowait()
-            except queue.Empty:
-                cmd = None
-            if cmd is not None:
-                self.port.send_dshot(cmd, ptype=self.ptype, telem=True, bidir=self.bidir)
-            elif self.ptype == sd.TYPE_PWM:
-                self.port.send_pwm(int(self.value))
-            else:
-                self.port.send_dshot(int(self.value), ptype=self.ptype,
-                                     telem=self.telem_bit, bidir=self.bidir)
-            self.sent.tick()
+                now = time.time()
+            # catch-up burst: keep the average rate under coarse sleep
+            # granularity (VMs, CI runners) - the firmware's bidirectional
+            # auto-detect needs >100 frames before arming completes
+            burst = 0
+            while now >= next_send and burst < 10:
+                next_send += 1.0 / max(1.0, self.rate)
+                try:
+                    cmd = self.cmd_queue.get_nowait()
+                except queue.Empty:
+                    cmd = None
+                if cmd is not None:
+                    self.port.send_dshot(cmd, ptype=self.ptype, telem=True, bidir=self.bidir)
+                elif self.ptype == sd.TYPE_PWM:
+                    self.port.send_pwm(int(self.value))
+                else:
+                    self.port.send_dshot(int(self.value), ptype=self.ptype,
+                                         telem=self.telem_bit, bidir=self.bidir)
+                self.sent.tick()
+                burst += 1
+            if now - next_send > 0.25:
+                next_send = now  # fell too far behind, resync
             self._collect()
             self._edt_maintain(now)
         self.port.close()

--- a/Mcu/SITL/sitl_gui_backend.py
+++ b/Mcu/SITL/sitl_gui_backend.py
@@ -5,7 +5,10 @@ threads and expose plain attributes/queues, so they can be driven by any
 front end or by headless tests without a display.
 '''
 
+import collections
 import queue
+import socket
+import struct
 import threading
 import time
 
@@ -272,3 +275,110 @@ class CanPanel(object):
 
     def set_param(self, name, value):
         self.param_queue.put((name, value))
+
+
+class SimStream(object):
+    """subscriber for the SITL simulation state stream (--state-port):
+    high rate physics samples for graphs/animation, and runtime motor
+    model loading. Samples are (t_s, omega, theta, theta_e, iu, iv, iw,
+    vu, vv, vw, vbus, ibus, modes, comp_phase, comp_out)"""
+
+    SAMPLE = struct.Struct('<Qfffffffffff3sBB3x')
+    MAGIC_CMD = 0x5353
+    MAGIC_DATA = 0x5354
+    MAGIC_REPLY = 0x5355
+
+    def __init__(self, host='127.0.0.1', port=57734, period_us=50, maxlen=40000):
+        self.addr = (host, port)
+        self.period_us = period_us
+        self.enabled = False
+        self.samples = collections.deque(maxlen=maxlen)
+        self.lock = threading.Lock()  # guards samples against the reader
+        self.rate = RateCounter()
+        self.model_status = ''
+        self.running = True
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.bind(('127.0.0.1', 0))
+        self.sock.settimeout(0.2)
+        threading.Thread(target=self._reader, daemon=True).start()
+        threading.Thread(target=self._subscriber, daemon=True).start()
+
+    def _subscriber(self):
+        while self.running:
+            if self.enabled:
+                # averaged sampling at coarse periods, so a slow scope
+                # shows the mean over each period instead of aliased
+                # point samples of the PWM
+                flags = 1 if self.period_us >= 10 else 0
+                pkt = struct.pack('<HBBI', self.MAGIC_CMD, 0, flags,
+                                  int(round(self.period_us * 1000)))
+                try:
+                    self.sock.sendto(pkt, self.addr)
+                except OSError:
+                    pass
+            time.sleep(1.0)
+
+    def _reader(self):
+        while self.running:
+            try:
+                d = self.sock.recv(4096)
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            if len(d) < 4:
+                continue
+            magic, b2, b3 = struct.unpack('<HBB', d[:4])
+            if magic == self.MAGIC_REPLY:
+                self.model_status = d[4:].split(b'\0')[0].decode(errors='replace')
+                continue
+            if magic != self.MAGIC_DATA or b2 != 2:
+                continue
+            count = b3
+            batch = []
+            for k in range(count):
+                off = 4 + k * self.SAMPLE.size
+                if off + self.SAMPLE.size > len(d):
+                    break
+                smp = self.SAMPLE.unpack_from(d, off)
+                batch.append((smp[0] * 1e-9,) + smp[1:])
+            with self.lock:
+                self.samples.extend(batch)
+            self.rate.tick(len(batch))
+
+    def latest(self):
+        with self.lock:
+            return self.samples[-1] if self.samples else None
+
+    def window(self, seconds):
+        """most recent samples spanning the given time window"""
+        out = []
+        with self.lock:
+            if not self.samples:
+                return out
+            t_end = self.samples[-1][0]
+            for smp in reversed(self.samples):
+                if t_end - smp[0] > seconds:
+                    break
+                out.append(smp)
+        out.reverse()
+        return out
+
+    def set_speedup(self, speedup):
+        pkt = struct.pack('<HBBf', self.MAGIC_CMD, 2, 0, speedup)
+        try:
+            self.sock.sendto(pkt, self.addr)
+        except OSError:
+            pass
+
+    def load_model(self, path):
+        self.model_status = 'loading %s ...' % path
+        pkt = struct.pack('<HBB', self.MAGIC_CMD, 1, 0) + path.encode()
+        try:
+            self.sock.sendto(pkt, self.addr)
+        except OSError as ex:
+            self.model_status = str(ex)
+
+    def close(self):
+        self.running = False
+        self.sock.close()

--- a/Mcu/SITL/sitl_gui_backend.py
+++ b/Mcu/SITL/sitl_gui_backend.py
@@ -161,6 +161,8 @@ class CanPanel(object):
     def __init__(self, uri):
         self.uri = uri
         self.enabled = False
+        self.send_rawcommand = True
+        self.armed = True
         self.throttle = 0.0     # 0..1
         self.rate = 50.0
         self.esc_index = 0
@@ -224,11 +226,13 @@ class CanPanel(object):
             now = time.time()
             if now >= next_send:
                 next_send += 1.0 / max(1.0, self.rate)
-                cmds = [0] * (self.esc_index + 1)
-                cmds[self.esc_index] = int(8191 * self.throttle)
-                node.broadcast(dronecan.uavcan.equipment.safety.ArmingStatus(status=255))
-                node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=cmds))
-                self.sent.tick()
+                status = 255 if self.armed else 0
+                node.broadcast(dronecan.uavcan.equipment.safety.ArmingStatus(status=status))
+                if self.send_rawcommand:
+                    cmds = [0] * (self.esc_index + 1)
+                    cmds[self.esc_index] = int(8191 * self.throttle)
+                    node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=cmds))
+                    self.sent.tick()
         # orderly shutdown of the mcast IO child process
         try:
             node.close()

--- a/Mcu/SITL/sitl_harness.py
+++ b/Mcu/SITL/sitl_harness.py
@@ -57,6 +57,24 @@ def free_mcast_group():
     return bus
 
 
+class SitlStartError(RuntimeError):
+    '''SITL process died during startup (e.g. mcast unavailable on CI).'''
+
+    def __init__(self, returncode, log_tail):
+        self.returncode = returncode
+        self.log_tail = log_tail
+        super().__init__('SITL exited early (code %s):\n%s' % (returncode, log_tail))
+
+    @property
+    def looks_like_mcast_failure(self):
+        t = self.log_tail or ''
+        # SIGPIPE (-13) during CAN init on macOS, or an explicit mcast error
+        if self.returncode in (-13, 13):
+            return True
+        return ('CAN init mcast' in t and 'CAN on' not in t) or (
+            'multicast' in t.lower() and 'failed' in t.lower())
+
+
 class Sitl(object):
     '''start / stop one SITL instance with unique ports'''
 
@@ -87,8 +105,7 @@ class Sitl(object):
                     tail = f.read()[-800:].decode(errors='replace')
             except OSError:
                 pass
-            raise RuntimeError('SITL exited early (code %s):\n%s' % (
-                self.proc.returncode, tail))
+            raise SitlStartError(self.proc.returncode, tail)
 
     def __enter__(self):
         return self

--- a/Mcu/SITL/sitl_harness.py
+++ b/Mcu/SITL/sitl_harness.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+'''
+Shared helpers for AM32 SITL CI tests: process lifecycle, free UDP ports,
+frame senders, RPM measurement from the state stream.
+'''
+
+from __future__ import annotations
+
+import glob
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SITL_DIR = HERE
+REPO_ROOT = os.path.normpath(os.path.join(HERE, '..', '..'))
+
+sys.path.insert(0, HERE)
+import sitl_dshot as sd  # noqa: E402
+from sitl_gui_backend import SimStream  # noqa: E402
+
+
+def find_sitl_binary(explicit=None):
+    if explicit:
+        return os.path.abspath(explicit)
+    pat = os.path.join(REPO_ROOT, 'obj', 'AM32_AM32_SITL_CAN_*.elf')
+    hits = sorted(glob.glob(pat))
+    if not hits:
+        return None
+    return os.path.normpath(hits[-1])
+
+
+def free_udp_port():
+    '''bind a throwaway UDP socket to get an unused port number'''
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+_mcast_seq = 0
+
+
+def free_mcast_group():
+    '''pick a mcast bus index 0..9 (SITL rejects anything outside that).
+
+    Sequential tests get distinct buses so leftover traffic does not cross
+    talk; wraps after 10.
+    '''
+    global _mcast_seq
+    bus = _mcast_seq % 10
+    _mcast_seq += 1
+    return bus
+
+
+class Sitl(object):
+    '''start / stop one SITL instance with unique ports'''
+
+    def __init__(self, sitl_path, extra_args=(), workdir=None, nosleep=True,
+                 input_port=None, state_port=None, can_uri=None,
+                 wait_s=0.6):
+        self.workdir = workdir or os.getcwd()
+        self.input_port = input_port if input_port is not None else free_udp_port()
+        self.state_port = state_port if state_port is not None else free_udp_port()
+        args = [sitl_path,
+                '--input-port', str(self.input_port),
+                '--state-port', str(self.state_port)]
+        if can_uri is not None:
+            args += ['--can-uri', can_uri]
+        if nosleep:
+            args.append('--nosleep')
+        args += list(extra_args)
+        self.log_path = os.path.join(self.workdir, 'sitl_ci.log')
+        self.log = open(self.log_path, 'ab')
+        self.proc = subprocess.Popen(
+            args, stdout=self.log, stderr=self.log, cwd=self.workdir)
+        time.sleep(wait_s)
+        if self.proc.poll() is not None:
+            self.log.flush()
+            tail = ''
+            try:
+                with open(self.log_path, 'rb') as f:
+                    tail = f.read()[-800:].decode(errors='replace')
+            except OSError:
+                pass
+            raise RuntimeError('SITL exited early (code %s):\n%s' % (
+                self.proc.returncode, tail))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.close()
+
+    def close(self):
+        if self.proc.poll() is None:
+            self.proc.kill()
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+        try:
+            self.log.close()
+        except Exception:
+            pass
+        # eeprom lock + file created in workdir
+        for f in os.listdir(self.workdir):
+            if f.startswith('am32_eeprom.bin'):
+                try:
+                    os.unlink(os.path.join(self.workdir, f))
+                except OSError:
+                    pass
+
+    def log_tail(self, n=20):
+        try:
+            with open(self.log_path, 'rb') as f:
+                lines = f.read().decode(errors='replace').splitlines()
+            return '\n'.join(lines[-n:])
+        except OSError:
+            return ''
+
+
+class Sender(object):
+    '''background PWM/DShot frame sender with rate catch-up (CI-safe)'''
+
+    def __init__(self, host, port, ptype, bidir=False, rate=500.0):
+        self.port = sd.InputPort(host, port)
+        self.ptype = ptype
+        self.bidir = bidir
+        self.rate = rate
+        self.value = 1000 if ptype == sd.TYPE_PWM else 0
+        self.cmds = []
+        self.running = True
+        threading.Thread(target=self._loop, daemon=True).start()
+
+    def _loop(self):
+        try:
+            self._run()
+        except OSError:
+            pass
+
+    def _run(self):
+        nxt = time.time()
+        while self.running:
+            now = time.time()
+            burst = 0
+            while now >= nxt and burst < 10:
+                nxt += 1.0 / self.rate
+                if self.cmds:
+                    self.port.send_dshot(self.cmds.pop(0), ptype=self.ptype,
+                                         telem=True, bidir=self.bidir)
+                elif self.ptype == sd.TYPE_PWM:
+                    self.port.send_pwm(int(self.value))
+                else:
+                    self.port.send_dshot(int(self.value), ptype=self.ptype,
+                                         bidir=self.bidir)
+                burst += 1
+            if now - nxt > 0.25:
+                nxt = now
+            time.sleep(0.0005)
+
+    def stop(self):
+        self.running = False
+        self.port.close()
+
+
+def rpm_from_state(sim, window=1.0):
+    w = sim.window(window)
+    if not w:
+        return -1.0
+    return sum(s[1] for s in w) / len(w) * 60.0 / 6.28318
+
+
+def wait_for_state(sim, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if sim.samples:
+            return True
+        time.sleep(0.1)
+    return bool(sim.samples)
+
+
+def open_state(host, port, period_us=200):
+    sim = SimStream(host, port, period_us=period_us)
+    sim.enabled = True
+    return sim

--- a/Mcu/SITL/tests/conftest.py
+++ b/Mcu/SITL/tests/conftest.py
@@ -1,0 +1,86 @@
+'''pytest fixtures for AM32 SITL CI tests.'''
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SITL_DIR = os.path.normpath(os.path.join(HERE, '..'))
+sys.path.insert(0, SITL_DIR)
+
+from sitl_harness import (  # noqa: E402
+    Sitl,
+    find_sitl_binary,
+    free_mcast_group,
+    open_state,
+)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--sitl',
+        action='store',
+        default=None,
+        help='path to AM32 SITL binary (default: newest obj/AM32_AM32_SITL_CAN_*.elf)',
+    )
+
+
+@pytest.fixture(scope='session')
+def sitl_path(request):
+    path = find_sitl_binary(request.config.getoption('--sitl'))
+    if not path or not os.path.exists(path):
+        pytest.fail(
+            'SITL binary not found. Build with: make AM32_SITL_CAN\n'
+            'or pass --sitl /path/to/elf')
+    return path
+
+
+@pytest.fixture
+def workdir(tmp_path):
+    '''isolated cwd so eeprom files and logs do not collide'''
+    d = tempfile.mkdtemp(prefix='sitl_ci_', dir=str(tmp_path))
+    cwd = os.getcwd()
+    os.chdir(d)
+    try:
+        yield d
+    finally:
+        os.chdir(cwd)
+
+
+@pytest.fixture
+def sitl_factory(sitl_path, workdir):
+    '''factory: sitl_factory(extra_args=..., can_uri=..., **kw) -> Sitl'''
+    instances = []
+
+    def _make(extra_args=(), can_uri='none', **kw):
+        s = Sitl(sitl_path, extra_args=extra_args, workdir=workdir,
+                 can_uri=can_uri, **kw)
+        instances.append(s)
+        return s
+
+    yield _make
+    for s in instances:
+        s.close()
+
+
+@pytest.fixture
+def mcast_uri():
+    return 'mcast:%d' % free_mcast_group()
+
+
+@pytest.fixture
+def state_stream():
+    streams = []
+
+    def _open(sitl, period_us=200):
+        sim = open_state('127.0.0.1', sitl.state_port, period_us=period_us)
+        streams.append(sim)
+        return sim
+
+    yield _open
+    for s in streams:
+        s.close()

--- a/Mcu/SITL/tests/conftest.py
+++ b/Mcu/SITL/tests/conftest.py
@@ -14,6 +14,7 @@ sys.path.insert(0, SITL_DIR)
 
 from sitl_harness import (  # noqa: E402
     Sitl,
+    SitlStartError,
     find_sitl_binary,
     free_mcast_group,
     open_state,
@@ -70,6 +71,29 @@ def sitl_factory(sitl_path, workdir):
 @pytest.fixture
 def mcast_uri():
     return 'mcast:%d' % free_mcast_group()
+
+
+@pytest.fixture
+def sitl_can_factory(sitl_factory):
+    '''like sitl_factory, but skip the test if multicast CAN cannot start.
+
+    GitHub macOS runners historically lack a usable multicast route; the
+    SITL either dies during CAN init or never becomes reachable. Match
+    upstream behaviour: skip rather than fail the job.
+    '''
+
+    def _make(extra_args=(), can_uri=None, **kw):
+        if can_uri is None:
+            raise TypeError('sitl_can_factory requires can_uri')
+        try:
+            return sitl_factory(extra_args=extra_args, can_uri=can_uri, **kw)
+        except SitlStartError as e:
+            if e.looks_like_mcast_failure:
+                pytest.skip('SITL multicast CAN unavailable on this host:\n%s'
+                            % e)
+            raise
+
+    return _make
 
 
 @pytest.fixture

--- a/Mcu/SITL/tests/test_boot.py
+++ b/Mcu/SITL/tests/test_boot.py
@@ -1,0 +1,41 @@
+'''SITL process boot and basic I/O surface.'''
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from sitl_harness import wait_for_state
+
+
+def test_boot_binds_ports_and_streams_state(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim, timeout=5.0), (
+        'state stream never started\n' + sitl.log_tail())
+    latest = sim.latest()
+    assert latest is not None
+    # omega ~ 0 at idle, bus voltage from default model (~16.8 V)
+    omega, vbus = latest[1], latest[10]
+    assert abs(omega) < 50.0, 'motor spinning at idle: omega=%g' % omega
+    assert 10.0 < vbus < 30.0, 'unexpected bus voltage: %g' % vbus
+
+
+def test_boot_verbose_log_mentions_ports(sitl_factory):
+    sitl = sitl_factory(extra_args=['--input-type', '1', '--verbose'],
+                        can_uri='none', wait_s=1.0)
+    # give the verbose 1 Hz line a chance; port banners print at startup
+    time.sleep(0.5)
+    log = sitl.log_tail(40)
+    assert 'PWM/DShot input on udp port' in log or str(sitl.input_port) in log, log
+    assert 'state/model port' in log or str(sitl.state_port) in log, log
+
+
+def test_eeprom_file_created(sitl_factory, workdir):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none', wait_s=0.8)
+    eeprom = os.path.join(workdir, 'am32_eeprom.bin')
+    assert os.path.exists(eeprom), 'eeprom not created in %s: %s' % (
+        workdir, os.listdir(workdir))
+    assert os.path.getsize(eeprom) > 0

--- a/Mcu/SITL/tests/test_dronecan.py
+++ b/Mcu/SITL/tests/test_dronecan.py
@@ -1,0 +1,98 @@
+'''DroneCAN RawCommand / telemetry path over multicast UDP.'''
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from sitl_harness import rpm_from_state, wait_for_state
+
+dronecan = pytest.importorskip('dronecan')
+
+
+def _multicast_usable(sitl, sim, timeout=5.0):
+    '''GitHub macOS (and some locked-down VMs) have no multicast route.
+    Skip rather than fail when the SITL never starts streaming with CAN on.'''
+    if wait_for_state(sim, timeout=timeout):
+        return True
+    pytest.skip(
+        'SITL state stream never started with CAN enabled; '
+        'multicast is probably unavailable.\n' + sitl.log_tail())
+
+
+def test_dronecan_throttle_and_esc_status(sitl_factory, state_stream, mcast_uri):
+    sitl = sitl_factory(
+        extra_args=['--node-id', '10'],
+        can_uri=mcast_uri,
+        wait_s=1.0)
+    sim = state_stream(sitl)
+    _multicast_usable(sitl, sim)
+
+    node = dronecan.make_node(mcast_uri, node_id=100, bitrate=1000000)
+    status = {}
+
+    def on_esc(e):
+        status['rpm'] = e.message.rpm
+        status['voltage'] = e.message.voltage
+        status['count'] = status.get('count', 0) + 1
+
+    node.add_handler(dronecan.uavcan.equipment.esc.Status, on_esc)
+    try:
+        t0 = time.time()
+        nxt = t0
+        while time.time() - t0 < 10:
+            node.spin(0)
+            now = time.time()
+            if now >= nxt:
+                nxt += 0.02
+                thr = 0.35 if now - t0 > 2.5 else 0.0
+                node.broadcast(
+                    dronecan.uavcan.equipment.safety.ArmingStatus(status=255))
+                node.broadcast(
+                    dronecan.uavcan.equipment.esc.RawCommand(
+                        cmd=[int(8191 * thr)]))
+            time.sleep(0.001)
+
+        rpm = rpm_from_state(sim)
+        assert 3500 <= rpm <= 6500, 'state rpm=%.0f' % rpm
+        assert 3500 <= status.get('rpm', -1) <= 6500, status
+        assert 15 < status.get('voltage', 0) < 18, status
+        assert status.get('count', 0) >= 3, 'too few esc.Status: %s' % status
+    finally:
+        # stop motor
+        for _ in range(10):
+            node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=[0]))
+            node.spin(0.02)
+        node.close()
+
+
+def test_dronecan_requires_arming(sitl_factory, state_stream, mcast_uri):
+    '''default REQUIRE_ARMING=1: RawCommand alone must not spin the motor'''
+    sitl = sitl_factory(
+        extra_args=['--node-id', '10'],
+        can_uri=mcast_uri,
+        wait_s=1.0)
+    sim = state_stream(sitl)
+    _multicast_usable(sitl, sim)
+
+    node = dronecan.make_node(mcast_uri, node_id=101, bitrate=1000000)
+    try:
+        t0 = time.time()
+        nxt = t0
+        while time.time() - t0 < 5.0:
+            node.spin(0)
+            now = time.time()
+            if now >= nxt:
+                nxt += 0.02
+                # no ArmingStatus — only RawCommand at mid throttle
+                node.broadcast(
+                    dronecan.uavcan.equipment.esc.RawCommand(cmd=[4000]))
+            time.sleep(0.001)
+        rpm = rpm_from_state(sim, 0.5)
+        assert rpm < 500, 'spun without arming: rpm=%.0f' % rpm
+    finally:
+        for _ in range(5):
+            node.broadcast(dronecan.uavcan.equipment.esc.RawCommand(cmd=[0]))
+            node.spin(0.02)
+        node.close()

--- a/Mcu/SITL/tests/test_dronecan.py
+++ b/Mcu/SITL/tests/test_dronecan.py
@@ -21,8 +21,8 @@ def _multicast_usable(sitl, sim, timeout=5.0):
         'multicast is probably unavailable.\n' + sitl.log_tail())
 
 
-def test_dronecan_throttle_and_esc_status(sitl_factory, state_stream, mcast_uri):
-    sitl = sitl_factory(
+def test_dronecan_throttle_and_esc_status(sitl_can_factory, state_stream, mcast_uri):
+    sitl = sitl_can_factory(
         extra_args=['--node-id', '10'],
         can_uri=mcast_uri,
         wait_s=1.0)
@@ -67,9 +67,9 @@ def test_dronecan_throttle_and_esc_status(sitl_factory, state_stream, mcast_uri)
         node.close()
 
 
-def test_dronecan_requires_arming(sitl_factory, state_stream, mcast_uri):
+def test_dronecan_requires_arming(sitl_can_factory, state_stream, mcast_uri):
     '''default REQUIRE_ARMING=1: RawCommand alone must not spin the motor'''
-    sitl = sitl_factory(
+    sitl = sitl_can_factory(
         extra_args=['--node-id', '10'],
         can_uri=mcast_uri,
         wait_s=1.0)

--- a/Mcu/SITL/tests/test_dshot.py
+++ b/Mcu/SITL/tests/test_dshot.py
@@ -1,0 +1,97 @@
+'''PWM/DShot input path tests against the SITL motor model.'''
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+import sitl_dshot as sd
+from sitl_harness import Sender, rpm_from_state, wait_for_state
+
+
+def _run_throttle(sitl, state_stream, ptype, value, rpm_lo, rpm_hi,
+                  bidir=False, edt=False, arm_s=2.2, run_s=4.0, stop_s=3.0):
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), 'state stream dead\n' + sitl.log_tail()
+    tx = Sender('127.0.0.1', sitl.input_port, ptype, bidir=bidir)
+    try:
+        time.sleep(arm_s)
+        if edt:
+            tx.cmds = [sd.DSHOT_CMD_EDT_ENABLE] * 8
+            time.sleep(0.5)
+        tx.value = value
+        time.sleep(run_s)
+        rpm = rpm_from_state(sim)
+        assert rpm_lo <= rpm <= rpm_hi, (
+            'rpm=%.0f expected %d..%d\n%s' % (rpm, rpm_lo, rpm_hi, sitl.log_tail()))
+
+        if bidir:
+            replies = tx.port.reply_count
+            assert replies > 500, 'too few BDShot replies: %d' % replies
+            erpm = [sd.decode_reply(r[3], edt_expected=edt)
+                    for r in tx.port.get_replies()]
+            rpms = [sd.erpm_period_to_rpm(v) for k, v in erpm if k == 'erpm']
+            if rpms:
+                assert abs(rpms[-1] - rpm) < max(200, rpm * 0.05), (
+                    'bdshot=%.0f state=%.0f' % (rpms[-1], rpm))
+            if edt:
+                edt_vals = {k: v for k, v in erpm
+                            if k in ('temp', 'volt', 'current')}
+                assert edt_vals.get('temp') == 25, edt_vals
+                assert 14 < edt_vals.get('volt', 0) < 18, edt_vals
+
+        # must stop again at zero throttle
+        tx.value = 0
+        time.sleep(stop_s)
+        rpm = rpm_from_state(sim, 0.3)
+        assert rpm < 500, 'motor did not stop: rpm=%.0f' % rpm
+    finally:
+        tx.stop()
+
+
+def test_dshot600_bidir_edt(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    _run_throttle(sitl, state_stream, sd.TYPE_DSHOT600, value=800,
+                  rpm_lo=4000, rpm_hi=7000, bidir=True, edt=True)
+
+
+def test_dshot300(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    _run_throttle(sitl, state_stream, sd.TYPE_DSHOT300, value=600,
+                  rpm_lo=3000, rpm_hi=6000)
+
+
+def test_zero_throttle_stays_stopped(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600, bidir=True)
+    try:
+        tx.value = 0
+        time.sleep(3.0)
+        rpm = rpm_from_state(sim, 0.5)
+        assert rpm < 200, 'spun at zero throttle: rpm=%.0f' % rpm
+    finally:
+        tx.stop()
+
+
+def test_bad_crc_frames_do_not_arm_or_spin(sitl_factory, state_stream):
+    '''all-corrupted frames must never produce throttle'''
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    port = sd.InputPort('127.0.0.1', sitl.input_port)
+    try:
+        t0 = time.time()
+        nxt = t0
+        while time.time() - t0 < 4.0:
+            now = time.time()
+            while now >= nxt:
+                nxt += 1.0 / 500.0
+                port.send_dshot(800, ptype=sd.TYPE_DSHOT600, corrupt=True)
+            time.sleep(0.0005)
+        rpm = rpm_from_state(sim, 0.5)
+        assert rpm < 200, 'motor spun on bad-CRC frames: rpm=%.0f' % rpm
+    finally:
+        port.close()

--- a/Mcu/SITL/tests/test_models.py
+++ b/Mcu/SITL/tests/test_models.py
@@ -1,0 +1,65 @@
+'''Runtime motor model load over the SITL state port.'''
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from sitl_harness import SITL_DIR, rpm_from_state, wait_for_state
+import sitl_dshot as sd
+from sitl_harness import Sender
+
+
+MODELS = os.path.join(SITL_DIR, 'models')
+
+
+@pytest.mark.parametrize('model', [
+    'racer_5inch.json',
+    'default_7inch.json',
+    'heavy_13inch.json',
+    'unloaded.json',
+])
+def test_load_stock_model(sitl_factory, state_stream, model):
+    path = os.path.join(MODELS, model)
+    assert os.path.isfile(path), path
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    sim.load_model(path)
+    # model_status is updated asynchronously over UDP
+    deadline = time.time() + 3.0
+    status = ''
+    while time.time() < deadline:
+        status = sim.model_status or ''
+        if status and 'fail' not in status.lower() and 'error' not in status.lower():
+            if 'loading' not in status.lower() or 'ok' in status.lower() or model in status:
+                break
+        time.sleep(0.1)
+    # Accept either an explicit OK-style status or a cleared error-free load
+    assert 'error' not in status.lower() and 'fail' not in status.lower(), status
+
+
+def test_racer_model_spins_under_dshot(sitl_factory, state_stream):
+    '''heavier/lighter models still produce plausible RPM under DShot'''
+    path = os.path.join(MODELS, 'racer_5inch.json')
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    sim.load_model(path)
+    time.sleep(0.5)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    try:
+        time.sleep(2.2)
+        tx.value = 700
+        time.sleep(4.0)
+        rpm = rpm_from_state(sim)
+        # racer is higher kV / lighter load — allow a wide but non-zero band
+        assert 2000 <= rpm <= 15000, 'rpm=%.0f out of range on racer model' % rpm
+        tx.value = 0
+        time.sleep(3.0)
+        assert rpm_from_state(sim, 0.3) < 800
+    finally:
+        tx.stop()

--- a/Mcu/SITL/tests/test_params.py
+++ b/Mcu/SITL/tests/test_params.py
@@ -1,0 +1,141 @@
+'''DroneCAN parameter GetSet / save path.'''
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from sitl_harness import wait_for_state
+
+dronecan = pytest.importorskip('dronecan')
+
+
+def _wait_for_node(uri, timeout=8.0, our_id=110):
+    node = dronecan.make_node(uri, node_id=our_id, bitrate=1000000)
+    found = {}
+
+    def on_status(e):
+        found[e.transfer.source_node_id] = True
+
+    node.add_handler(dronecan.uavcan.protocol.NodeStatus, on_status)
+    deadline = time.time() + timeout
+    while time.time() < deadline and not found:
+        node.spin(0.1)
+    return node, found
+
+
+def _request_wait(node, target, req, timeout=2.5):
+    '''send a service request; pydronecan delivers timeout as e=None'''
+    result = {}
+
+    def cb(e):
+        result['response'] = e.response if e is not None else None
+        result['done'] = True
+
+    node.request(req, target, cb)
+    deadline = time.time() + timeout
+    while 'done' not in result and time.time() < deadline:
+        node.spin(0.05)
+    return result.get('response')
+
+
+def _get_param(node, target, name, attempts=5):
+    '''GetSet with retries — idle SITL reboots every ~2s on signal timeout,
+    which can swallow a single in-flight service transfer.'''
+    for _ in range(attempts):
+        req = dronecan.uavcan.protocol.param.GetSet.Request()
+        req.name = name
+        rsp = _request_wait(node, target, req)
+        if rsp is not None and str(rsp.name):
+            return rsp
+        time.sleep(0.3)
+    return None
+
+
+def _set_param(node, target, name, value, attempts=5):
+    for _ in range(attempts):
+        req = dronecan.uavcan.protocol.param.GetSet.Request()
+        req.name = name
+        req.value = dronecan.uavcan.protocol.param.Value(integer_value=int(value))
+        rsp = _request_wait(node, target, req)
+        if rsp is not None and str(rsp.name):
+            if int(rsp.value.integer_value) == int(value):
+                return rsp
+        time.sleep(0.3)
+    return None
+
+
+def test_param_get_defaults(sitl_factory, state_stream, mcast_uri):
+    sitl = sitl_factory(
+        extra_args=['--node-id', '10'],
+        can_uri=mcast_uri,
+        wait_s=1.0)
+    sim = state_stream(sitl)
+    if not wait_for_state(sim, timeout=5.0):
+        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+
+    node, found = _wait_for_node(mcast_uri)
+    try:
+        assert 10 in found, 'ESC node 10 not seen: %s' % found
+        rsp = _get_param(node, 10, 'MOTOR_POLES')
+        assert rsp is not None, 'GetSet failed for MOTOR_POLES\n' + sitl.log_tail()
+        assert int(rsp.value.integer_value) == 14, rsp.value
+        rsp = _get_param(node, 10, 'INPUT_SIGNAL_TYPE')
+        assert rsp is not None
+        assert int(rsp.value.integer_value) in (0, 1, 2, 5), rsp.value
+        rsp = _get_param(node, 10, 'TELEM_RATE')
+        assert rsp is not None
+        assert 0 <= int(rsp.value.integer_value) <= 200
+    finally:
+        node.close()
+
+
+def test_param_set_telem_rate(sitl_factory, state_stream, mcast_uri):
+    sitl = sitl_factory(
+        extra_args=['--node-id', '10'],
+        can_uri=mcast_uri,
+        wait_s=1.0)
+    sim = state_stream(sitl)
+    if not wait_for_state(sim, timeout=5.0):
+        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+
+    node, found = _wait_for_node(mcast_uri, our_id=111)
+    try:
+        assert 10 in found, found
+        new_rate = 50
+        rsp = _set_param(node, 10, 'TELEM_RATE', new_rate)
+        assert rsp is not None, 'set TELEM_RATE failed\n' + sitl.log_tail()
+        assert int(rsp.value.integer_value) == new_rate, rsp.value
+        rsp = _get_param(node, 10, 'TELEM_RATE')
+        assert rsp is not None
+        assert int(rsp.value.integer_value) == new_rate
+    finally:
+        node.close()
+
+
+def test_param_save_opcode(sitl_factory, state_stream, mcast_uri):
+    sitl = sitl_factory(
+        extra_args=['--node-id', '10'],
+        can_uri=mcast_uri,
+        wait_s=1.0)
+    sim = state_stream(sitl)
+    if not wait_for_state(sim, timeout=5.0):
+        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+
+    node, found = _wait_for_node(mcast_uri, our_id=112)
+    try:
+        assert 10 in found, found
+        assert _set_param(node, 10, 'BEEP_VOLUME', 7) is not None
+        ok = False
+        for _ in range(5):
+            req = dronecan.uavcan.protocol.param.ExecuteOpcode.Request()
+            req.opcode = req.OPCODE_SAVE
+            rsp = _request_wait(node, 10, req, timeout=3.0)
+            if rsp is not None and rsp.ok:
+                ok = True
+                break
+            time.sleep(0.3)
+        assert ok, 'OPCODE_SAVE failed\n' + sitl.log_tail()
+    finally:
+        node.close()

--- a/Mcu/SITL/tests/test_params.py
+++ b/Mcu/SITL/tests/test_params.py
@@ -66,18 +66,25 @@ def _set_param(node, target, name, value, attempts=5):
     return None
 
 
-def test_param_get_defaults(sitl_factory, state_stream, mcast_uri):
-    sitl = sitl_factory(
+def _require_mcast_node(sitl, sim, mcast_uri, our_id=110):
+    if not wait_for_state(sim, timeout=5.0):
+        pytest.skip('multicast/state unavailable\n' + sitl.log_tail())
+    node, found = _wait_for_node(mcast_uri, our_id=our_id)
+    if 10 not in found:
+        node.close()
+        pytest.skip('ESC node 10 not seen on %s (mcast likely broken)\n%s'
+                    % (mcast_uri, sitl.log_tail()))
+    return node, found
+
+
+def test_param_get_defaults(sitl_can_factory, state_stream, mcast_uri):
+    sitl = sitl_can_factory(
         extra_args=['--node-id', '10'],
         can_uri=mcast_uri,
         wait_s=1.0)
     sim = state_stream(sitl)
-    if not wait_for_state(sim, timeout=5.0):
-        pytest.skip('multicast unavailable\n' + sitl.log_tail())
-
-    node, found = _wait_for_node(mcast_uri)
+    node, found = _require_mcast_node(sitl, sim, mcast_uri)
     try:
-        assert 10 in found, 'ESC node 10 not seen: %s' % found
         rsp = _get_param(node, 10, 'MOTOR_POLES')
         assert rsp is not None, 'GetSet failed for MOTOR_POLES\n' + sitl.log_tail()
         assert int(rsp.value.integer_value) == 14, rsp.value
@@ -91,18 +98,14 @@ def test_param_get_defaults(sitl_factory, state_stream, mcast_uri):
         node.close()
 
 
-def test_param_set_telem_rate(sitl_factory, state_stream, mcast_uri):
-    sitl = sitl_factory(
+def test_param_set_telem_rate(sitl_can_factory, state_stream, mcast_uri):
+    sitl = sitl_can_factory(
         extra_args=['--node-id', '10'],
         can_uri=mcast_uri,
         wait_s=1.0)
     sim = state_stream(sitl)
-    if not wait_for_state(sim, timeout=5.0):
-        pytest.skip('multicast unavailable\n' + sitl.log_tail())
-
-    node, found = _wait_for_node(mcast_uri, our_id=111)
+    node, found = _require_mcast_node(sitl, sim, mcast_uri, our_id=111)
     try:
-        assert 10 in found, found
         new_rate = 50
         rsp = _set_param(node, 10, 'TELEM_RATE', new_rate)
         assert rsp is not None, 'set TELEM_RATE failed\n' + sitl.log_tail()
@@ -114,18 +117,14 @@ def test_param_set_telem_rate(sitl_factory, state_stream, mcast_uri):
         node.close()
 
 
-def test_param_save_opcode(sitl_factory, state_stream, mcast_uri):
-    sitl = sitl_factory(
+def test_param_save_opcode(sitl_can_factory, state_stream, mcast_uri):
+    sitl = sitl_can_factory(
         extra_args=['--node-id', '10'],
         can_uri=mcast_uri,
         wait_s=1.0)
     sim = state_stream(sitl)
-    if not wait_for_state(sim, timeout=5.0):
-        pytest.skip('multicast unavailable\n' + sitl.log_tail())
-
-    node, found = _wait_for_node(mcast_uri, our_id=112)
+    node, found = _require_mcast_node(sitl, sim, mcast_uri, our_id=112)
     try:
-        assert 10 in found, found
         assert _set_param(node, 10, 'BEEP_VOLUME', 7) is not None
         ok = False
         for _ in range(5):

--- a/Mcu/SITL/tests/test_pwm.py
+++ b/Mcu/SITL/tests/test_pwm.py
@@ -1,0 +1,29 @@
+'''Servo / PWM input path.'''
+
+from __future__ import annotations
+
+import time
+
+import sitl_dshot as sd
+from sitl_harness import Sender, rpm_from_state, wait_for_state
+
+
+def test_pwm_midstick_spins_and_stops(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '2'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_PWM)
+    try:
+        # arm at 1000 us
+        tx.value = 1000
+        time.sleep(2.2)
+        tx.value = 1500
+        time.sleep(4.0)
+        rpm = rpm_from_state(sim)
+        assert 4000 <= rpm <= 9000, 'rpm=%.0f expected 4000..9000' % rpm
+        tx.value = 1000
+        time.sleep(3.0)
+        rpm = rpm_from_state(sim, 0.3)
+        assert rpm < 500, 'did not stop: rpm=%.0f' % rpm
+    finally:
+        tx.stop()

--- a/Mcu/SITL/tests/test_safety.py
+++ b/Mcu/SITL/tests/test_safety.py
@@ -193,8 +193,11 @@ def test_dronecan_arms_after_zero_then_spins(
         _can_drive(dronecan, node, thr=0.35, armed=True, duration=4.0)
         _assert_spinning(sim, 'can after proper arm', lo=3000, hi=8000)
 
-        _can_drive(dronecan, node, thr=0.0, armed=True, duration=2.0)
-        _assert_stopped(sim, 'can post-run zero', window=0.4, limit=800)
+        # Prop inertia coasts for a while after input goes to zero; match
+        # the DShot post-run settle (3s) so CI hosts with variable load
+        # are not flaky around ~1k rpm residual.
+        _can_drive(dronecan, node, thr=0.0, armed=True, duration=3.0)
+        _assert_stopped(sim, 'can post-run zero', window=0.5, limit=800)
     finally:
         _can_drive(dronecan, node, thr=0.0, armed=False, duration=0.3)
         node.close()

--- a/Mcu/SITL/tests/test_safety.py
+++ b/Mcu/SITL/tests/test_safety.py
@@ -1,0 +1,253 @@
+'''Safety / arming functional tests.
+
+Firmware contract (Src/main.c, signal.c, DroneCAN.c):
+  - DShot/PWM: arming needs ~1s of valid signal with zero throttle
+    (adjusted_input == 0 and zero_input_count > 30). High throttle from
+    boot must never spin the motor.
+  - DroneCAN defaults REQUIRE_ARMING=1 and REQUIRE_ZERO_THROTTLE=1:
+    high RawCommand without ArmingStatus must not spin; high throttle
+    at first contact even with ArmingStatus must not spin until a zero
+    throttle period has armed the ESC.
+  - Bad / missing signal must not leave the motor running.
+'''
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+import sitl_dshot as sd
+from sitl_harness import Sender, rpm_from_state, wait_for_state
+
+
+def _need_dronecan():
+    return pytest.importorskip('dronecan')
+
+
+def _assert_stopped(sim, label, window=0.5, limit=200.0):
+    rpm = rpm_from_state(sim, window)
+    assert rpm < limit, '%s: motor spinning rpm=%.0f (limit %.0f)' % (
+        label, rpm, limit)
+
+
+def _assert_spinning(sim, label, lo=2000.0, hi=20000.0, window=1.0):
+    rpm = rpm_from_state(sim, window)
+    assert lo <= rpm <= hi, '%s: rpm=%.0f expected %.0f..%.0f' % (
+        label, rpm, lo, hi)
+
+
+# ---------------------------------------------------------------------------
+# DShot / PWM: boot with high throttle must not spin
+# ---------------------------------------------------------------------------
+
+def test_dshot_high_throttle_from_boot_does_not_spin(sitl_factory, state_stream):
+    '''never send zero — high DShot from the first frame must not arm.'''
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    try:
+        tx.value = 1000  # mid-high throttle immediately, no zero period
+        time.sleep(4.0)
+        _assert_stopped(sim, 'dshot high-from-boot', window=0.8)
+    finally:
+        tx.stop()
+
+
+def test_pwm_high_throttle_from_boot_does_not_spin(sitl_factory, state_stream):
+    '''high PWM pulse from boot (no 1000 us arming) must not spin.'''
+    sitl = sitl_factory(extra_args=['--input-type', '2'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_PWM)
+    try:
+        tx.value = 1800  # high stick from first frame
+        time.sleep(4.0)
+        _assert_stopped(sim, 'pwm high-from-boot', window=0.8)
+    finally:
+        tx.stop()
+
+
+def test_dshot_arms_only_after_zero_then_spins(sitl_factory, state_stream):
+    '''high-from-boot blocked, then zero arms, then throttle spins, then stop.'''
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    try:
+        tx.value = 900
+        time.sleep(2.5)
+        _assert_stopped(sim, 'pre-arm high')
+
+        tx.value = 0
+        time.sleep(2.2)
+        _assert_stopped(sim, 'arming zero')
+
+        tx.value = 700
+        time.sleep(3.5)
+        _assert_spinning(sim, 'after proper arm', lo=3000, hi=9000)
+
+        tx.value = 0
+        time.sleep(3.0)
+        _assert_stopped(sim, 'post-run zero', window=0.4, limit=500)
+    finally:
+        tx.stop()
+
+
+def test_pwm_arms_only_after_low_then_spins(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '2'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_PWM)
+    try:
+        tx.value = 1600
+        time.sleep(2.5)
+        _assert_stopped(sim, 'pre-arm high pwm')
+
+        tx.value = 1000
+        time.sleep(2.2)
+        _assert_stopped(sim, 'arming low pwm')
+
+        tx.value = 1500
+        time.sleep(3.5)
+        _assert_spinning(sim, 'after pwm arm', lo=3500, hi=10000)
+
+        tx.value = 1000
+        time.sleep(3.0)
+        _assert_stopped(sim, 'post-run low pwm', window=0.4, limit=500)
+    finally:
+        tx.stop()
+
+
+# ---------------------------------------------------------------------------
+# DroneCAN arming / zero-throttle safety
+# ---------------------------------------------------------------------------
+
+def _can_drive(dronecan, node, thr, armed=True, rate_hz=50.0, duration=3.0,
+               send_arming_status=True):
+    '''broadcast ArmingStatus + RawCommand for duration seconds.
+
+    armed=True  → FULLY_ARMED (255)
+    armed=False → SAFE (0) so REQUIRE_ARMING zeros the applied throttle;
+                  merely stopping ArmingStatus traffic leaves the last
+                  armed state latched in the ESC.
+    '''
+    t0 = time.time()
+    nxt = t0
+    period = 1.0 / rate_hz
+    arm_status = 255 if armed else 0
+    while time.time() - t0 < duration:
+        node.spin(0)
+        now = time.time()
+        if now >= nxt:
+            nxt += period
+            if send_arming_status:
+                node.broadcast(
+                    dronecan.uavcan.equipment.safety.ArmingStatus(
+                        status=arm_status))
+            node.broadcast(
+                dronecan.uavcan.equipment.esc.RawCommand(
+                    cmd=[int(8191 * thr)]))
+        time.sleep(0.001)
+
+
+def test_dronecan_high_throttle_from_boot_does_not_spin(
+        sitl_can_factory, state_stream, mcast_uri):
+    '''REQUIRE_ZERO_THROTTLE=1: arm + high RawCommand from first contact
+    must not spin until a zero-throttle arming window has passed.'''
+    dronecan = _need_dronecan()
+    sitl = sitl_can_factory(
+        extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
+    sim = state_stream(sitl)
+    if not wait_for_state(sim, timeout=5.0):
+        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+
+    node = dronecan.make_node(mcast_uri, node_id=120, bitrate=1000000)
+    try:
+        # no zero period — arm + 50% throttle immediately
+        _can_drive(dronecan, node, thr=0.5, armed=True, duration=4.0)
+        _assert_stopped(sim, 'can high-from-boot', window=0.8, limit=500)
+    finally:
+        _can_drive(dronecan, node, thr=0.0, armed=True, duration=0.5)
+        node.close()
+
+
+def test_dronecan_arms_after_zero_then_spins(
+        sitl_can_factory, state_stream, mcast_uri):
+    dronecan = _need_dronecan()
+    sitl = sitl_can_factory(
+        extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
+    sim = state_stream(sitl)
+    if not wait_for_state(sim, timeout=5.0):
+        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+
+    node = dronecan.make_node(mcast_uri, node_id=121, bitrate=1000000)
+    try:
+        _can_drive(dronecan, node, thr=0.5, armed=True, duration=2.5)
+        _assert_stopped(sim, 'can pre-arm high', limit=500)
+
+        _can_drive(dronecan, node, thr=0.0, armed=True, duration=2.5)
+        _assert_stopped(sim, 'can arming zero', limit=500)
+
+        _can_drive(dronecan, node, thr=0.35, armed=True, duration=4.0)
+        _assert_spinning(sim, 'can after proper arm', lo=3000, hi=8000)
+
+        _can_drive(dronecan, node, thr=0.0, armed=True, duration=2.0)
+        _assert_stopped(sim, 'can post-run zero', window=0.4, limit=800)
+    finally:
+        _can_drive(dronecan, node, thr=0.0, armed=False, duration=0.3)
+        node.close()
+
+
+def test_dronecan_disarm_zeros_input(
+        sitl_can_factory, state_stream, mcast_uri):
+    '''dropping ArmingStatus while running must stop applying throttle
+    (REQUIRE_ARMING=1 forces input to 0 when disarmed).'''
+    dronecan = _need_dronecan()
+    sitl = sitl_can_factory(
+        extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
+    sim = state_stream(sitl)
+    if not wait_for_state(sim, timeout=5.0):
+        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+
+    node = dronecan.make_node(mcast_uri, node_id=122, bitrate=1000000)
+    try:
+        _can_drive(dronecan, node, thr=0.0, armed=True, duration=2.5)
+        _can_drive(dronecan, node, thr=0.35, armed=True, duration=4.0)
+        _assert_spinning(sim, 'can spinning before disarm', lo=3000, hi=8000)
+
+        # keep high RawCommand but publish SAFE ArmingStatus
+        _can_drive(dronecan, node, thr=0.35, armed=False, duration=3.0)
+        _assert_stopped(sim, 'can after SAFE arming status', window=0.6, limit=800)
+    finally:
+        _can_drive(dronecan, node, thr=0.0, armed=False, duration=0.3)
+        node.close()
+
+
+# ---------------------------------------------------------------------------
+# Signal loss / stop behaviour (DShot)
+# ---------------------------------------------------------------------------
+
+def test_dshot_signal_loss_stops_motor(sitl_factory, state_stream):
+    '''after arming and spinning, ceasing frames must stop the motor
+    (signal timeout → allOff / reset). Allow a reboot; omega must fall.'''
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim)
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    try:
+        time.sleep(2.2)
+        tx.value = 700
+        time.sleep(3.5)
+        _assert_spinning(sim, 'before signal loss', lo=3000, hi=9000)
+
+        tx.stop()  # stop sending entirely
+        # armed timeout is ~0.5s; unarmed reboot ~2s — wait long enough
+        time.sleep(3.0)
+        _assert_stopped(sim, 'after signal loss', window=0.5, limit=800)
+    finally:
+        try:
+            tx.stop()
+        except Exception:
+            pass

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -60,7 +60,7 @@ const struct {
     uint32_t crc2; // crc32 from end of app_signature to end of fw
     char mcu[16];
     uint32_t unused[2];
-} app_signature __attribute__((section(".app_signature"))) = {
+} app_signature AM32_FLASH_SECTION(".app_signature") = {
         .magic1 = APP_SIGNATURE_MAGIC1,
         .magic2 = APP_SIGNATURE_MAGIC2,
         .fwlen = 0,

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -257,7 +257,9 @@ static uint64_t micros64(void)
     static uint64_t base_us;
     static uint16_t last_cnt;
     // the static state must be updated atomically, this is called from
-    // both interrupt handlers and the main loop
+    // both interrupt handlers and the main loop. Save and restore
+    // PRIMASK so a caller's critical section is not ended early
+    const uint32_t primask = __get_PRIMASK();
     __disable_irq();
 #ifdef ARTERY
     uint16_t cnt = UTILITY_TIMER->cval;
@@ -269,7 +271,9 @@ static uint64_t micros64(void)
     }
     last_cnt = cnt;
     const uint64_t ret = base_us + cnt;
-    __enable_irq();
+    if (!primask) {
+        __enable_irq();
+    }
     return ret;
 }
 

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -10,10 +10,10 @@
 
 #include "peripherals.h"
 #include "serial_telemetry.h"
-#include <common.h>
-#include <signal.h>
-#include <version.h>
-#include <eeprom.h>
+#include "common.h"
+#include "signal.h"
+#include "version.h"
+#include "eeprom.h"
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -256,6 +256,9 @@ static uint64_t micros64(void)
 {
     static uint64_t base_us;
     static uint16_t last_cnt;
+    // the static state must be updated atomically, this is called from
+    // both interrupt handlers and the main loop
+    __disable_irq();
 #ifdef ARTERY
     uint16_t cnt = UTILITY_TIMER->cval;
 #else
@@ -265,7 +268,9 @@ static uint64_t micros64(void)
 	base_us += 0x10000;
     }
     last_cnt = cnt;
-    return base_us + cnt;
+    const uint64_t ret = base_us + cnt;
+    __enable_irq();
+    return ret;
 }
 
 /*
@@ -285,6 +290,16 @@ static const uint8_t default_settings[] = {
     0x20, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x1a, 0x18, 0x64, 0x37, 0x0e, 0x00, 0x00, 0x05, 0x00,
     0x80, 0x80, 0x80, 0x32, 0x00, 0x32, 0x00, 0x00, 0x0f, 0x0a, 0x0a, 0x8d, 0x66, 0x06, 0x01, 0x00
 };
+
+#ifdef MCU_SITL
+// let the SITL eeprom emulation seed a missing eeprom file with defaults
+const uint8_t* DroneCAN_default_settings(unsigned* len);
+const uint8_t* DroneCAN_default_settings(unsigned* len)
+{
+    *len = sizeof(default_settings);
+    return default_settings;
+}
+#endif
 
 static const uint8_t advance_level_v3_remap[] = {
   0x00, 0x08, 0x10, 0x16 // old values 0-3 map to new values 0,8,16,22 
@@ -427,7 +442,7 @@ static void handle_param_GetSet(CanardInstance* ins, CanardRxTransfer* transfer)
             }
             if ((uint8_t *)p->ptr == &eepromBuffer.advance_level) {
               // automatically remap old values
-              if (pkt.value.integer_value < sizeof(advance_level_v3_remap)) {
+              if ((uint64_t)pkt.value.integer_value < sizeof(advance_level_v3_remap)) {
                 pkt.value.integer_value = advance_level_v3_remap[pkt.value.integer_value];
               }
               // adjust for advance level offset for eeprom v3
@@ -1187,6 +1202,9 @@ static void DroneCAN_Startup(void)
         NVIC_DisableIRQ(DMA1_Channel6_IRQn);
         NVIC_DisableIRQ(EXINT15_10_IRQn);
         EXINT->inten &= ~EXINT_LINE_15;
+#elif defined(MCU_SITL)
+        NVIC_DisableIRQ(SITL_IRQ_DMA);
+        NVIC_DisableIRQ(SITL_IRQ_EXTI15);
 #else
         #error "unsupported MCU"
 #endif

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -1266,8 +1266,14 @@ void DroneCAN_update()
         canstats.last_raw_command_us = 0;
         set_input(0);
     }
-    if (ts - canstats.last_raw_command_us > TARGET_PERIOD_US) {
-        // ensure at least 1kHz signal is seen by main code
+    if (canstats.last_raw_command_us != 0 && ts - canstats.last_raw_command_us > TARGET_PERIOD_US) {
+        /*
+          ensure at least 1kHz signal is seen by main code. Only once we
+          have received a RawCommand: set_input() overrides the
+          dshot/servo input state, so injecting it before CAN is
+          actually the input source would kill PWM/DShot input on any
+          node with a CAN node ID
+         */
         set_input(last_can_input);
         canstats.last_raw_command_us = ts;
     }

--- a/Src/DroneCAN/filter.c
+++ b/Src/DroneCAN/filter.c
@@ -63,6 +63,7 @@ float Filter2P_apply(const float sample, float cutoff_freq, float sample_freq)
     return output;
 }
 
+#ifndef MCU_SITL
 /*
   unfortunately the maths libraries have an abort() linkage
  */
@@ -70,3 +71,4 @@ void abort(void)
 {
     __builtin_unreachable();
 }
+#endif

--- a/Src/DroneCAN/sys_can_SITL.c
+++ b/Src/DroneCAN/sys_can_SITL.c
@@ -125,11 +125,17 @@ void sys_can_init(void)
     }
     const int one = 1;
     setsockopt(fd_in, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+#ifdef SO_REUSEPORT
+    // macOS needs SO_REUSEPORT for multiple SITL instances / pydronecan
+    // on the same mcast group+port
+    setsockopt(fd_in, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
+#endif
     struct sockaddr_in bind_addr = addr;
-#if defined(__CYGWIN__) || defined(_WIN32)
-    // Windows cannot bind to a multicast group address; bind the port
-    // on INADDR_ANY and rely on the group membership plus the packet
-    // magic/CRC for filtering, as pydronecan's mcast driver does
+#if defined(__CYGWIN__) || defined(_WIN32) || defined(__APPLE__)
+    // Windows and macOS cannot reliably bind to a multicast group
+    // address; bind the port on INADDR_ANY and rely on the group
+    // membership plus the packet magic/CRC for filtering, as
+    // pydronecan's mcast driver does
     bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 #endif
     if (bind(fd_in, (struct sockaddr*)&bind_addr, sizeof(bind_addr)) != 0) {
@@ -184,7 +190,16 @@ void sys_can_init(void)
      */
     for (int attempt = have_if ? 1 : 0; attempt < 2; attempt++) {
         uint8_t probe[4] = { 0xde, 0xad, 0xbe, 0xef }; // wrong magic, ignored by receivers
-        send(fd_out, probe, sizeof(probe), 0);
+        // Prefer sendto over a connected send so a dead mcast route does
+        // not depend on SIGPIPE being ignored (belt-and-braces with
+        // signal(SIGPIPE, SIG_IGN) / SO_NOSIGPIPE).
+#if defined(MSG_NOSIGNAL)
+        sendto(fd_out, probe, sizeof(probe), MSG_NOSIGNAL,
+            (struct sockaddr*)&addr, sizeof(addr));
+#else
+        sendto(fd_out, probe, sizeof(probe), 0,
+            (struct sockaddr*)&addr, sizeof(addr));
+#endif
         struct pollfd pfd = { .fd = fd_in, .events = POLLIN, .revents = 0 };
         bool got = false;
         while (poll(&pfd, 1, 50) == 1) {
@@ -234,7 +249,11 @@ int16_t sys_can_transmit(const CanardCANFrame* txf)
     pkt.message_id = txf->id;
     memcpy(pkt.data, txf->data, txf->data_len);
     pkt.crc = crc16_CCITT((const uint8_t*)&pkt.flags, txf->data_len + 6);
+#if defined(MSG_NOSIGNAL)
+    const ssize_t ret = send(fd_out, &pkt, txf->data_len + MCAST_HDR_LEN, MSG_NOSIGNAL);
+#else
     const ssize_t ret = send(fd_out, &pkt, txf->data_len + MCAST_HDR_LEN, 0);
+#endif
     if (ret < 0) {
         return (errno == EAGAIN || errno == EWOULDBLOCK) ? 0 : -1;
     }

--- a/Src/DroneCAN/sys_can_SITL.c
+++ b/Src/DroneCAN/sys_can_SITL.c
@@ -117,7 +117,7 @@ void sys_can_init(void)
     addr.sin_port = htons(MCAST_PORT);
     inet_pton(AF_INET, address, &addr.sin_addr);
 
-    fd_in = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    fd_in = sitl_udp_socket();
     if (fd_in < 0) {
         perror("SITL: can socket");
         exit(1);
@@ -144,7 +144,7 @@ void sys_can_init(void)
         exit(1);
     }
 
-    fd_out = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    fd_out = sitl_udp_socket();
     if (fd_out < 0) {
         perror("SITL: can tx socket");
         exit(1);
@@ -200,7 +200,7 @@ void sys_can_init(void)
         if (attempt == 0) {
             // retry with the sender bound to loopback
             close(fd_out);
-            fd_out = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+            fd_out = sitl_udp_socket();
             struct sockaddr_in lo_addr;
             memset(&lo_addr, 0, sizeof(lo_addr));
             lo_addr.sin_family = AF_INET;

--- a/Src/DroneCAN/sys_can_SITL.c
+++ b/Src/DroneCAN/sys_can_SITL.c
@@ -360,16 +360,63 @@ void sys_can_getUniqueID(uint8_t id[16])
     }
 }
 
+/*
+  RTC backup survives hardware reset. SITL reboots via execv, so keep the
+  eight words next to the eeprom file (`<eeprom>.rtc`) for warm-boot /
+  FW-update handoff (RTC_BKUP0_BOOTED / SIGNAL / FWUPDATE).
+ */
 static uint32_t rtc_backup[8];
+static bool rtc_loaded;
+
+static void rtc_backup_path(char* path, size_t pathlen)
+{
+    snprintf(path, pathlen, "%s.rtc", sitl_cfg.eeprom_path);
+}
+
+static void rtc_backup_load(void)
+{
+    if (rtc_loaded) {
+        return;
+    }
+    rtc_loaded = true;
+    char path[512];
+    rtc_backup_path(path, sizeof(path));
+    FILE* f = fopen(path, "rb");
+    if (!f) {
+        return;
+    }
+    if (fread(rtc_backup, 1, sizeof(rtc_backup), f) != sizeof(rtc_backup)) {
+        memset(rtc_backup, 0, sizeof(rtc_backup));
+    }
+    fclose(f);
+}
+
+static void rtc_backup_save(void)
+{
+    char path[512];
+    rtc_backup_path(path, sizeof(path));
+    FILE* f = fopen(path, "wb");
+    if (!f) {
+        perror("SITL: rtc backup open");
+        return;
+    }
+    if (fwrite(rtc_backup, 1, sizeof(rtc_backup), f) != sizeof(rtc_backup)) {
+        perror("SITL: rtc backup write");
+    }
+    fclose(f);
+}
 
 uint32_t get_rtc_backup_register(uint8_t idx)
 {
-    return rtc_backup[idx];
+    rtc_backup_load();
+    return rtc_backup[idx & 7];
 }
 
 void set_rtc_backup_register(uint8_t idx, uint32_t value)
 {
-    rtc_backup[idx] = value;
+    rtc_backup_load();
+    rtc_backup[idx & 7] = value;
+    rtc_backup_save();
 }
 
 void setup_portpin(uint16_t portpin, bool enable)

--- a/Src/DroneCAN/sys_can_SITL.c
+++ b/Src/DroneCAN/sys_can_SITL.c
@@ -66,6 +66,12 @@ static uint16_t crc16_CCITT(const uint8_t* buf, uint32_t len)
 void sys_can_init(void)
 {
     const char* name = sitl_cfg.can_uri;
+    if (strcmp(name, "none") == 0) {
+        // no CAN bus: the node stays in DNA allocation forever, so
+        // DroneCAN never injects throttle. Used for pure PWM/DShot tests
+        fprintf(stderr, "SITL: CAN disabled\n");
+        return;
+    }
     int bus_num = 0;
     const char* ifname = NULL;
     if (strncmp(name, "mcast:", 6) == 0 && name[6] != 0) {

--- a/Src/DroneCAN/sys_can_SITL.c
+++ b/Src/DroneCAN/sys_can_SITL.c
@@ -124,7 +124,14 @@ void sys_can_init(void)
     }
     const int one = 1;
     setsockopt(fd_in, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
-    if (bind(fd_in, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    struct sockaddr_in bind_addr = addr;
+#if defined(__CYGWIN__) || defined(_WIN32)
+    // Windows cannot bind to a multicast group address; bind the port
+    // on INADDR_ANY and rely on the group membership plus the packet
+    // magic/CRC for filtering, as pydronecan's mcast driver does
+    bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+#endif
+    if (bind(fd_in, (struct sockaddr*)&bind_addr, sizeof(bind_addr)) != 0) {
         perror("SITL: can bind");
         exit(1);
     }
@@ -158,6 +165,14 @@ void sys_can_init(void)
         exit(1);
     }
 
+#if defined(__CYGWIN__) || defined(_WIN32)
+    /*
+      no TX self test on Windows: a socket never receives its own
+      multicast there, so the test always fails, and the 127.0.0.1
+      rebind is wrong (the loopback interface has no multicast). On a
+      multi homed machine pass an explicit interface: mcast:0:<ip>
+     */
+#else
     /*
       self test: verify our transmissions are delivered back to us. With
       a "ip route add 239.65.82.0/24 dev lo" style route the kernel picks
@@ -202,6 +217,7 @@ void sys_can_init(void)
                 address);
         }
     }
+#endif
 
     fprintf(stderr, "SITL: CAN on %s (%s:%d)\n", name, address, MCAST_PORT);
 }

--- a/Src/DroneCAN/sys_can_SITL.c
+++ b/Src/DroneCAN/sys_can_SITL.c
@@ -1,0 +1,339 @@
+/*
+  sys_can_SITL.c - CAN over multicast UDP for the SITL build.
+
+  Wire compatible with the DroneCAN "mcast:N" URI as implemented in
+  libcanard drivers/mcast/mcast.c and ArduPilot SITL: group 239.65.82.N
+  port 57732, packets carrying a 10 byte header (magic, crc16-CCITT,
+  flags, 29 bit message id) followed by the frame data, with the DLC
+  implied by the datagram length. An optional interface may be given as
+  "mcast:N:lo" or "mcast:N:192.168.1.5".
+ */
+
+#include "targets.h"
+
+#if DRONECAN_SUPPORT && defined(MCU_SITL)
+
+#include "sys_can.h"
+#include "sitl.h"
+#include "sitl_config.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define MCAST_ADDRESS_BASE "239.65.82.0"
+#define MCAST_PORT 57732
+#define MCAST_MAGIC 0x2934
+#define MCAST_FLAG_CANFD 0x0001
+
+struct __attribute__((packed)) mcast_pkt {
+    uint16_t magic;
+    uint16_t crc;
+    uint16_t flags;
+    uint32_t message_id;
+    uint8_t data[CANARD_CAN_FRAME_MAX_DATA_LEN];
+};
+#define MCAST_HDR_LEN 10
+
+static int fd_in = -1;
+static int fd_out = -1;
+
+static uint16_t crc16_CCITT(const uint8_t* buf, uint32_t len)
+{
+    uint16_t crc = 0xFFFF;
+    while (len--) {
+        crc ^= (uint16_t)(*buf++) << 8;
+        for (int i = 0; i < 8; i++) {
+            if (crc & 0x8000) {
+                crc = (crc << 1) ^ 0x1021;
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+    return crc;
+}
+
+void sys_can_init(void)
+{
+    const char* name = sitl_cfg.can_uri;
+    int bus_num = 0;
+    const char* ifname = NULL;
+    if (strncmp(name, "mcast:", 6) == 0 && name[6] != 0) {
+        bus_num = atoi(name + 6);
+        const char* colon = strchr(name + 6, ':');
+        if (colon != NULL && colon[1] != 0) {
+            ifname = colon + 1;
+        }
+    }
+    if (bus_num < 0 || bus_num > 9) {
+        fprintf(stderr, "SITL: invalid mcast bus %d\n", bus_num);
+        exit(1);
+    }
+
+    // optional interface, by name or IPv4 address
+    struct in_addr if_addr;
+    bool have_if = false;
+    if (ifname != NULL) {
+        if (inet_pton(AF_INET, ifname, &if_addr) == 1) {
+            have_if = true;
+        } else {
+            struct ifreq ifr;
+            memset(&ifr, 0, sizeof(ifr));
+            strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+            const int s = socket(AF_INET, SOCK_DGRAM, 0);
+            if (s < 0 || ioctl(s, SIOCGIFADDR, &ifr) != 0) {
+                fprintf(stderr, "SITL: no IPv4 address for interface %s\n", ifname);
+                exit(1);
+            }
+            if_addr = ((struct sockaddr_in*)&ifr.ifr_addr)->sin_addr;
+            close(s);
+            have_if = true;
+        }
+    }
+    char address[32];
+    strncpy(address, MCAST_ADDRESS_BASE, sizeof(address) - 1);
+    address[sizeof(address) - 1] = 0;
+    address[strlen(address) - 1] = '0' + bus_num;
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(MCAST_PORT);
+    inet_pton(AF_INET, address, &addr.sin_addr);
+
+    fd_in = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (fd_in < 0) {
+        perror("SITL: can socket");
+        exit(1);
+    }
+    const int one = 1;
+    setsockopt(fd_in, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    if (bind(fd_in, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+        perror("SITL: can bind");
+        exit(1);
+    }
+    struct ip_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    mreq.imr_multiaddr = addr.sin_addr;
+    mreq.imr_interface.s_addr = have_if ? if_addr.s_addr : htonl(INADDR_ANY);
+    if (setsockopt(fd_in, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) != 0) {
+        perror("SITL: can multicast join");
+        exit(1);
+    }
+
+    fd_out = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (fd_out < 0) {
+        perror("SITL: can tx socket");
+        exit(1);
+    }
+    if (have_if) {
+        struct sockaddr_in src;
+        memset(&src, 0, sizeof(src));
+        src.sin_family = AF_INET;
+        src.sin_addr = if_addr;
+        if (bind(fd_out, (struct sockaddr*)&src, sizeof(src)) != 0 ||
+            setsockopt(fd_out, IPPROTO_IP, IP_MULTICAST_IF, &if_addr, sizeof(if_addr)) != 0) {
+            perror("SITL: can tx interface");
+            exit(1);
+        }
+    }
+    if (connect(fd_out, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+        perror("SITL: can tx socket");
+        exit(1);
+    }
+
+    /*
+      self test: verify our transmissions are delivered back to us. With
+      a "ip route add 239.65.82.0/24 dev lo" style route the kernel picks
+      a non-loopback source address and then drops the packet on receive,
+      breaking multicast silently. Rebinding the sender to 127.0.0.1
+      fixes that case. With an explicit interface in the URI we respect
+      it and only warn
+     */
+    for (int attempt = have_if ? 1 : 0; attempt < 2; attempt++) {
+        uint8_t probe[4] = { 0xde, 0xad, 0xbe, 0xef }; // wrong magic, ignored by receivers
+        send(fd_out, probe, sizeof(probe), 0);
+        struct pollfd pfd = { .fd = fd_in, .events = POLLIN, .revents = 0 };
+        bool got = false;
+        while (poll(&pfd, 1, 50) == 1) {
+            uint8_t buf[MCAST_HDR_LEN + 64];
+            const ssize_t ret = recv(fd_in, buf, sizeof(buf), MSG_DONTWAIT);
+            if (ret == (ssize_t)sizeof(probe) && memcmp(buf, probe, sizeof(probe)) == 0) {
+                got = true;
+                break;
+            }
+        }
+        if (got) {
+            break;
+        }
+        if (attempt == 0) {
+            // retry with the sender bound to loopback
+            close(fd_out);
+            fd_out = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+            struct sockaddr_in lo_addr;
+            memset(&lo_addr, 0, sizeof(lo_addr));
+            lo_addr.sin_family = AF_INET;
+            inet_pton(AF_INET, "127.0.0.1", &lo_addr.sin_addr);
+            if (fd_out < 0 || bind(fd_out, (struct sockaddr*)&lo_addr, sizeof(lo_addr)) != 0 || connect(fd_out, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+                perror("SITL: can tx socket (loopback)");
+                exit(1);
+            }
+            fprintf(stderr, "SITL: CAN multicast loopback failed, using 127.0.0.1 source\n");
+        } else {
+            fprintf(stderr,
+                "SITL: WARNING: CAN multicast self test failed, check the route for "
+                "%s (a 'dev lo' route needs 'src 127.0.0.1')\n",
+                address);
+        }
+    }
+
+    fprintf(stderr, "SITL: CAN on %s (%s:%d)\n", name, address, MCAST_PORT);
+}
+
+int16_t sys_can_transmit(const CanardCANFrame* txf)
+{
+    if (fd_out < 0) {
+        return -1;
+    }
+    struct mcast_pkt pkt;
+    pkt.magic = MCAST_MAGIC;
+    pkt.flags = 0;
+    pkt.message_id = txf->id;
+    memcpy(pkt.data, txf->data, txf->data_len);
+    pkt.crc = crc16_CCITT((const uint8_t*)&pkt.flags, txf->data_len + 6);
+    const ssize_t ret = send(fd_out, &pkt, txf->data_len + MCAST_HDR_LEN, 0);
+    if (ret < 0) {
+        return (errno == EAGAIN || errno == EWOULDBLOCK) ? 0 : -1;
+    }
+    canstats.num_tx_interrupts++;
+    return 1;
+}
+
+int16_t sys_can_receive(CanardCANFrame* rx_frame)
+{
+    if (fd_in < 0) {
+        return -1;
+    }
+    struct mcast_pkt pkt;
+    const ssize_t ret = recv(fd_in, &pkt, sizeof(pkt), MSG_DONTWAIT);
+    if (ret < 0) {
+        return (errno == EAGAIN || errno == EWOULDBLOCK) ? 0 : -1;
+    }
+    if (ret < MCAST_HDR_LEN || pkt.magic != MCAST_MAGIC) {
+        canstats.rxframe_error++;
+        return 0;
+    }
+    if (pkt.crc != crc16_CCITT((const uint8_t*)&pkt.flags, ret - 4)) {
+        canstats.rxframe_error++;
+        return 0;
+    }
+    rx_frame->id = pkt.message_id;
+    rx_frame->data_len = ret - MCAST_HDR_LEN;
+    memcpy(rx_frame->data, pkt.data, rx_frame->data_len);
+    return 1;
+}
+
+/*
+  called from the SITL sim thread every 100us: if frames are waiting,
+  deliver them through the interrupt mechanism so handling happens with
+  the firmware thread suspended, like a real CAN RX interrupt
+ */
+void sitl_can_poll(void);
+void sitl_can_poll(void)
+{
+    if (fd_in < 0) {
+        return;
+    }
+    struct pollfd pfd = { .fd = fd_in, .events = POLLIN, .revents = 0 };
+    if (poll(&pfd, 1, 0) == 1) {
+        sitl_irq_pend(SITL_IRQ_CAN);
+    }
+}
+
+/*
+  CAN RX "interrupt handler", called by sitl_it.c in interrupt context
+ */
+void sitl_can_irq(void);
+void sitl_can_irq(void)
+{
+    CanardCANFrame rx_frame;
+    while (sys_can_receive(&rx_frame) == 1) {
+        canstats.num_rx_interrupts++;
+        DroneCAN_handleFrame(&rx_frame);
+    }
+}
+
+// CAN statistics for the SITL --verbose output
+void sitl_can_stats(uint32_t stats[4]);
+void sitl_can_stats(uint32_t stats[4])
+{
+    stats[0] = canstats.num_rx_interrupts;
+    stats[1] = canstats.num_commands;
+    stats[2] = canstats.rxframe_error;
+    stats[3] = (uint32_t)canstats.rx_ecode;
+}
+
+void sys_can_disable_IRQ(void)
+{
+    sitl_nvic_disable_irq(SITL_IRQ_CAN);
+}
+
+void sys_can_enable_IRQ(void)
+{
+    sitl_nvic_enable_irq(SITL_IRQ_CAN);
+}
+
+/*
+  a stable 16 byte unique ID, from --uid if given, otherwise derived from
+  hostname and eeprom path so DNA node IDs stick across restarts
+ */
+void sys_can_getUniqueID(uint8_t id[16])
+{
+    char seed[256];
+    if (sitl_cfg.uid != NULL) {
+        strncpy(seed, sitl_cfg.uid, sizeof(seed) - 1);
+        seed[sizeof(seed) - 1] = 0;
+    } else {
+        char host[128] = "sitl";
+        gethostname(host, sizeof(host) - 1);
+        snprintf(seed, sizeof(seed), "%s:%s", host, sitl_cfg.eeprom_path);
+    }
+    // FNV-1a expanded over 4 lanes
+    for (int lane = 0; lane < 4; lane++) {
+        uint32_t h = 2166136261U + lane * 16777619U;
+        for (const char* p = seed; *p; p++) {
+            h = (h ^ (uint8_t)*p) * 16777619U;
+        }
+        memcpy(&id[lane * 4], &h, 4);
+    }
+}
+
+static uint32_t rtc_backup[8];
+
+uint32_t get_rtc_backup_register(uint8_t idx)
+{
+    return rtc_backup[idx];
+}
+
+void set_rtc_backup_register(uint8_t idx, uint32_t value)
+{
+    rtc_backup[idx] = value;
+}
+
+void setup_portpin(uint16_t portpin, bool enable)
+{
+    (void)portpin;
+    (void)enable;
+}
+
+#endif // DRONECAN_SUPPORT && MCU_SITL

--- a/Src/DroneCAN/sys_can_SITL.c
+++ b/Src/DroneCAN/sys_can_SITL.c
@@ -66,6 +66,7 @@ static uint16_t crc16_CCITT(const uint8_t* buf, uint32_t len)
 void sys_can_init(void)
 {
     const char* name = sitl_cfg.can_uri;
+    fprintf(stderr, "SITL: CAN init %s\n", name);
     if (strcmp(name, "none") == 0) {
         // no CAN bus: the node stays in DNA allocation forever, so
         // DroneCAN never injects throttle. Used for pure PWM/DShot tests

--- a/Src/main.c
+++ b/Src/main.c
@@ -345,7 +345,7 @@ uint16_t low_cell_volt_cutoff = 330; // 3.3volts per cell
 
 //=========================== END EEPROM Defaults ===========================
 
-const char filename[30] __attribute__((section(".file_name"))) = FILE_NAME;
+const char filename[30] AM32_FLASH_SECTION(".file_name") = FILE_NAME;
 _Static_assert(sizeof(FIRMWARE_NAME) <=13,"Firmware name too long");   // max 12 character firmware name plus NULL 
 
 // move these to targets folder or peripherals for each mcu

--- a/Src/main.c
+++ b/Src/main.c
@@ -249,7 +249,7 @@ an settings option)
 #include "DroneCAN/DroneCAN.h"
 #endif
 
-#include <version.h>
+#include "version.h"
 
 void zcfoundroutine(void);
 
@@ -1837,6 +1837,10 @@ void runBrushedLoop()
  */
 static void checkDeviceInfo(void)
 {
+#ifdef MCU_SITL
+    // no bootloader device info page in SITL
+    return;
+#endif
 #ifdef NXP
     uint32_t pflashBlockBase  = 0U;
     uint32_t pflashTotalSize  = 0U;

--- a/Src/main.c
+++ b/Src/main.c
@@ -805,8 +805,19 @@ void loadEEpromSettings()
         if (motor_kv < 300) {
             low_rpm_throttle_limit = 0;
         }
-        low_rpm_level = motor_kv / 100 / (32 / eepromBuffer.motor_poles);
-        high_rpm_level = motor_kv / 12 / (32 / eepromBuffer.motor_poles);				
+        // guard divisions for an erased eeprom (motor_poles 0 or 0xff),
+        // ARM hardware division returns 0 but it is UB in C
+        uint8_t rpm_level_div = 0;
+        if (eepromBuffer.motor_poles != 0) {
+            rpm_level_div = 32 / eepromBuffer.motor_poles;
+        }
+        if (rpm_level_div != 0) {
+            low_rpm_level = motor_kv / 100 / rpm_level_div;
+            high_rpm_level = motor_kv / 12 / rpm_level_div;
+        } else {
+            low_rpm_level = 0;
+            high_rpm_level = 0;
+        }
     }
     reverse_speed_threshold = map(motor_kv, 300, 3000, 1000, 500);
     if (eepromBuffer.bi_direction){

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -6,12 +6,16 @@
 
 
 ifeq ($(OS),Windows_NT)
-# a POSIX environment on Windows (Cygwin/MSYS2) uses the unix tools;
-# uname only exists there, so the plain cmd.exe flow is unaffected
 UNAME_O := $(shell uname -o 2>/dev/null)
+# only Cygwin gets the unix tools flow. cmd.exe and git-bash/MSYS keep
+# the cmd.exe flow: git-bash may put uname on PATH but its MinGW tools
+# cannot build the SITL, and the cmd.exe flow is proven there
+ifneq ($(UNAME_O),Cygwin)
+WIN_CMD_FLOW := 1
+endif
 endif
 
-ifeq ($(OS)$(UNAME_O),Windows_NT)
+ifeq ($(WIN_CMD_FLOW),1)
 ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
 SHELL:=cmd.exe
 CP:=tools\\windows\\make\\bin\\cp
@@ -24,7 +28,7 @@ FGREP:=tools\\windows\\make\\bin\\fgrep
 OSDIR:=windows
 
 else ifeq ($(OS),Windows_NT)
-# Cygwin/MSYS2
+# Cygwin
 ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
 CP:=cp
 DSEP:=/

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -6,6 +6,12 @@
 
 
 ifeq ($(OS),Windows_NT)
+# a POSIX environment on Windows (Cygwin/MSYS2) uses the unix tools;
+# uname only exists there, so the plain cmd.exe flow is unaffected
+UNAME_O := $(shell uname -o 2>/dev/null)
+endif
+
+ifeq ($(OS)$(UNAME_O),Windows_NT)
 ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
 SHELL:=cmd.exe
 CP:=tools\\windows\\make\\bin\\cp
@@ -15,6 +21,18 @@ MKDIR:=tools\\windows\\make\\bin\\mkdir
 RM:=tools\\windows\\make\\bin\\rm
 CUT:=tools\\windows\\make\\bin\\cut
 FGREP:=tools\\windows\\make\\bin\\fgrep
+OSDIR:=windows
+
+else ifeq ($(OS),Windows_NT)
+# Cygwin/MSYS2
+ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+CP:=cp
+DSEP:=/
+NUL:=/dev/null
+MKDIR:=mkdir
+RM:=rm
+CUT:=cut
+FGREP:=fgrep
 OSDIR:=windows
 
 else

--- a/sitl_gui.bat
+++ b/sitl_gui.bat
@@ -1,0 +1,11 @@
+@echo off
+rem launch the AM32 SITL GUI using the environment created by
+rem "py Mcu\SITL\make_gui_env.py". Lives in the repo root so the venv
+rem paths resolve relative to it
+cd /d "%~dp0"
+if not exist "Mcu\SITL\venv\Scripts\pythonw.exe" (
+    echo GUI environment not found, run:  py Mcu\SITL\make_gui_env.py
+    pause
+    exit /b 1
+)
+start "" "Mcu\SITL\venv\Scripts\pythonw.exe" "Mcu\SITL\sitl_gui.py" %*

--- a/sitlmakefile.mk
+++ b/sitlmakefile.mk
@@ -2,7 +2,17 @@ MCU := SITL
 
 MCU_LC := $(call lc,$(MCU))
 
+ifeq ($(OS),Windows_NT)
+ifeq ($(UNAME_O),Cygwin)
 TARGETS_$(MCU) := $(call get_targets,$(MCU))
+else
+# plain Windows (cmd.exe or git-bash/MinGW): no POSIX environment, the
+# SITL only builds under Cygwin there
+TARGETS_$(MCU) :=
+endif
+else
+TARGETS_$(MCU) := $(call get_targets,$(MCU))
+endif
 
 HAL_FOLDER_$(MCU) := $(HAL_FOLDER)/$(MCU)
 

--- a/sitlmakefile.mk
+++ b/sitlmakefile.mk
@@ -29,8 +29,16 @@ CFLAGS_$(MCU) += -DCANARD_64_BIT="(__SIZEOF_POINTER__ == 8)"
 # native compiler flags, replacing the ARM specific CFLAGS_COMMON. Inc is
 # searched via -iquote rather than -I so that Inc/signal.h does not shadow
 # the system <signal.h>
-CFLAGS_COMMON_$(MCU) := -fsingle-precision-constant -iquote $(MAIN_INC_DIR) -g3 -O2 \
-	-Wall -Wundef -Wextra -Werror -Wno-unused-parameter -Wno-stringop-truncation \
+ifeq ($(UNAME_S),Darwin)
+# clang: no -fsingle-precision-constant, and ignore the gcc-only
+# -Wno- options inherited from the common CFLAGS
+SITL_GCC_FLAGS := -Wno-unknown-warning-option
+else
+SITL_GCC_FLAGS := -fsingle-precision-constant -Wno-stringop-truncation
+endif
+# -funsigned-char matches the ARM targets, where char is unsigned
+CFLAGS_COMMON_$(MCU) := $(SITL_GCC_FLAGS) -funsigned-char -iquote $(MAIN_INC_DIR) -g3 -O2 \
+	-Wall -Wundef -Wextra -Werror -Wno-unused-parameter \
 	-fno-strict-aliasing -pthread
 
 LDFLAGS_COMMON_$(MCU) := -pthread

--- a/sitlmakefile.mk
+++ b/sitlmakefile.mk
@@ -23,6 +23,8 @@ CFLAGS_$(MCU) := \
 	-I$(HAL_FOLDER_$(MCU))/sim
 
 CFLAGS_$(MCU) += -D_GNU_SOURCE
+# newlib based hosts (Cygwin) have no __WORDSIZE for the canard.h default
+CFLAGS_$(MCU) += -DCANARD_64_BIT="(__SIZEOF_POINTER__ == 8)"
 
 # native compiler flags, replacing the ARM specific CFLAGS_COMMON. Inc is
 # searched via -iquote rather than -I so that Inc/signal.h does not shadow

--- a/sitlmakefile.mk
+++ b/sitlmakefile.mk
@@ -1,0 +1,52 @@
+MCU := SITL
+
+MCU_LC := $(call lc,$(MCU))
+
+TARGETS_$(MCU) := $(call get_targets,$(MCU))
+
+HAL_FOLDER_$(MCU) := $(HAL_FOLDER)/$(MCU)
+
+# native build using the host compiler
+SITL_CC := gcc
+SITL_OBJCOPY := objcopy
+NATIVE_$(MCU) := 1
+
+MCU_$(MCU) :=
+LDSCRIPT_$(MCU) :=
+
+SRC_DIR_$(MCU) := \
+	$(HAL_FOLDER_$(MCU))/Src \
+	$(HAL_FOLDER_$(MCU))/sim
+
+CFLAGS_$(MCU) := \
+	-I$(HAL_FOLDER_$(MCU))/Inc \
+	-I$(HAL_FOLDER_$(MCU))/sim
+
+CFLAGS_$(MCU) += -D_GNU_SOURCE
+
+# native compiler flags, replacing the ARM specific CFLAGS_COMMON. Inc is
+# searched via -iquote rather than -I so that Inc/signal.h does not shadow
+# the system <signal.h>
+CFLAGS_COMMON_$(MCU) := -fsingle-precision-constant -iquote $(MAIN_INC_DIR) -g3 -O2 \
+	-Wall -Wundef -Wextra -Werror -Wno-unused-parameter -Wno-stringop-truncation \
+	-fno-strict-aliasing -pthread
+
+LDFLAGS_COMMON_$(MCU) := -pthread
+
+LDLIBS_$(MCU) := -lm
+
+SRC_$(MCU) := $(foreach dir,$(SRC_DIR_$(MCU)),$(wildcard $(dir)/*.c))
+
+# optional CAN support
+CFLAGS_CAN_$(MCU) = \
+	-ISrc/DroneCAN \
+	-ISrc/DroneCAN/libcanard \
+	-ISrc/DroneCAN/dsdl_generated/include
+
+SRC_DIR_CAN_$(MCU) = Src/DroneCAN \
+		Src/DroneCAN/dsdl_generated/src \
+		Src/DroneCAN/libcanard
+
+SRC_CAN_$(MCU) := $(foreach dir,$(SRC_DIR_CAN_$(MCU)),$(wildcard $(dir)/*.[cs]))
+
+LDSCRIPT_CAN_$(MCU) :=


### PR DESCRIPTION
## Summary

Port of upstream [am32-firmware/AM32#394](https://github.com/am32-firmware/AM32/pull/394) (tridge) onto `ark-release`.

Adds a software-in-the-loop simulation of the AM32 firmware so the ESC can run on Linux, Windows, or macOS. It simulates a BLDC motor at fine granularity as well as PWM/DShot/BDShot/DroneCAN inputs via a new `Mcu/SITL` hardware port that implements the same APIs used on real ESC hardware.

Useful for testing DShot ↔ DroneCAN interactions and parameter behavior without hardware.

Many thanks to https://github.com/open-bldc/open-bldc-csim for much of the BLDC simulation system.

## What was brought over

- `Mcu/SITL/` — software MCU emulation, motor model, UDP DShot/PWM input, state streaming, GUI, and CI test tools
- `AM32_SITL_CAN` target in `Inc/targets.h`
- Native MCU build support in `Makefile` / `sitlmakefile.mk`
- SITL DroneCAN driver (`Src/DroneCAN/sys_can_SITL.c`) over multicast UDP
- `.github/workflows/SITL.yml` CI workflow
- Related `main.c` / DroneCAN / tools.mk hooks

Cherry-picked all 27 commits from the upstream PR head onto `ark-release` (clean cherry-pick; no conflict resolution needed).

## Verification

- `make AM32_SITL_CAN` succeeds on this machine
- Binary smoke-test starts and binds UDP ports:

```
AM32 SITL: eeprom=am32_eeprom.bin can=mcast:0 speedup=1.0
SITL: PWM/DShot input on udp port 57733
SITL: state/model port udp 57734
SITL: CAN on mcast:0 (239.65.82.0:57732)
```

## Upstream source

https://github.com/am32-firmware/AM32/pull/394

## Test plan

- [x] `make AM32_SITL_CAN` builds
- [x] SITL binary starts and prints CAN/UDP setup
- [ ] Optional: run `Mcu/SITL/run_ci_tests.py` / GUI smoke
- [ ] Confirm ARK targets still build (`make ARK_4IN1_F051` or CI)
