### PR TITLE
DroneCAN: fix timeout when zero input and gate keep-alive on RawCommand

### DIFF
--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -1206,8 +1206,11 @@ void DroneCAN_update()
 		canstats.last_raw_command_us = 0;
 		set_input(0);
 	}
-	if (ts - last_heartbeat_us > TARGET_PERIOD_US) {
-		// ensure at least 1kHz signal is seen by main code
+	if (canstats.last_raw_command_us != 0 && ts - last_heartbeat_us > TARGET_PERIOD_US) {
+		/*
+          ensure at least 1kHz signal is seen by main code, but only
+          once we have received a RawCommand
+         */
 		set_input(last_can_input);
 		last_heartbeat_us = ts;
 	}

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -110,6 +110,7 @@ extern uint16_t low_cell_volt_cutoff;
 extern uint32_t desync_happened;
 
 static uint16_t last_can_input;
+static uint64_t last_heartbeat_us;
 static struct {
 	uint32_t sum;
 	uint32_t count;
@@ -1205,16 +1206,10 @@ void DroneCAN_update()
 		canstats.last_raw_command_us = 0;
 		set_input(0);
 	}
-	if (canstats.last_raw_command_us != 0 && ts - canstats.last_raw_command_us > TARGET_PERIOD_US) {
-		/*
-          ensure at least 1kHz signal is seen by main code. Only once we
-          have received a RawCommand: set_input() overrides the
-          dshot/servo input state, so injecting it before CAN is
-          actually the input source would kill PWM/DShot input on any
-          node with a CAN node ID
-         */
+	if (ts - last_heartbeat_us > TARGET_PERIOD_US) {
+		// ensure at least 1kHz signal is seen by main code
 		set_input(last_can_input);
-		canstats.last_raw_command_us = ts;
+		last_heartbeat_us = ts;
 	}
 
 	sys_can_enable_IRQ();


### PR DESCRIPTION
## Summary

Backports two upstream DroneCAN fixes from am32-firmware/AM32 `main`:

- **2fb46a7** (`fix: dronecan timeout when zero input`) — use a separate `last_heartbeat_us` for the 1 kHz keep-alive instead of updating `canstats.last_raw_command_us`. Refreshing the raw-command timestamp on every keep-alive prevented real command loss from being detected when input stayed at zero.
- **ad91453** (`DroneCAN: don't inject CAN input before a RawCommand is received`) — only inject keep-alive `set_input()` after a RawCommand has been received, so a CAN node ID alone does not override PWM/DShot input.

`ark-release` already had a partial form of the second fix (gate on `last_raw_command_us != 0`) but still advanced `last_raw_command_us` in the keep-alive path. These cherry-picks complete the fix to match upstream.

## Test plan

- [ ] Build a DroneCAN-enabled target (e.g. ARK G431 CAN)
- [ ] With no RawCommand traffic, confirm DShot/PWM input still works when a node ID is assigned
- [ ] With RawCommand at zero throttle, confirm command-loss timeout still zeros input after ~250 ms (keep-alive no longer refreshes the raw-command timestamp)
- [ ] With active RawCommand throttle, confirm 1 kHz keep-alive still maintains input