### PR TITLE
fix(ark-f051): raise POLLING_MODE_THRESHOLD for low-RPM closed-loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AM32 (ARK) project rules
+
+## Formatting
+
+Always run `make format` from the repo root **before committing** any code changes (C/C++/headers and other clang-format-managed sources). Include format-only diffs in the commit or a follow-up `style:` commit on the same PR.

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -91,7 +91,7 @@
 #	define NFAULT_PORT GPIOB
 #	define NFAULT_PIN LL_GPIO_PIN_5
 #	define TARGET_MIN_BEMF_COUNTS 3
-	/* Closed-loop when commutation_interval < this (0.5 us ticks). Default
+/* Closed-loop when commutation_interval < this (0.5 us ticks). Default
 	 * F051 fallback is 2000; noprop ~1k RPM has CI~2700 so the ESC stayed
 	 * open-loop (rough low-speed sound). Bench sweep on 900KV noprop:
 	 * T=2000 OL@5%; T=3200 CL@5%; T=5000 also CL@~4% with no demag/jitter

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -91,6 +91,14 @@
 #	define NFAULT_PORT GPIOB
 #	define NFAULT_PIN LL_GPIO_PIN_5
 #	define TARGET_MIN_BEMF_COUNTS 3
+	/* Closed-loop when commutation_interval < this (0.5 us ticks). Default
+	 * F051 fallback is 2000; noprop ~1k RPM has CI~2700 so the ESC stayed
+	 * open-loop (rough low-speed sound). Bench sweep on 900KV noprop:
+	 * T=2000 OL@5%; T=3200 CL@5%; T=5000 also CL@~4% with no demag/jitter
+	 * regression. Stay-in-CL needs average_interval <= T+500 (~CI). */
+#	ifndef POLLING_MODE_THRESHOLD
+#		define POLLING_MODE_THRESHOLD 5000
+#	endif
 #endif
 
 #ifdef ARK_4IN1_RAMP_F051


### PR DESCRIPTION
## Summary

On ARK 4IN1 F051, low throttle free-run (especially low-KV / noprop) stayed in **open-loop poll ZC** because `commutation_interval` sat above the default `POLLING_MODE_THRESHOLD` (2000). That produces the rough low-speed sound.

Raise **ARK-only** `POLLING_MODE_THRESHOLD` to **5000** so closed-loop interrupt ZC engages through the low-RPM band.

## Bench evidence (900 KV, 14 poles, noprop, 6S)

| Threshold | hold @ 5% (~1k RPM) | Time to closed-loop |
|-----------|---------------------|---------------------|
| 2000 (stock) | 100% open-loop | ~11 s |
| 3200 | 100% closed-loop | ~0.03 s |
| **5000** | 100% closed-loop; CL from ~4% | ~0.02 s |

- No demag / BEMF-timeout regression vs 3200  
- `noprop_smoke_100pct_900kv` smoke gates **PASS** with T=5000  

Other F051 targets unchanged (still default 2000).

## Test plan

- [x] Low-RPM crawl: closed-loop at 5% throttle  
- [x] Free-run smoke to 100% on 900 KV noprop  
- [ ] Optional: prop-on efficiency / demag stress  
- [ ] Confirm other ARK targets still build  