### PR TITLE
feat(zc): BLHeli-style missed-ZC blind-step — closed loop never falls back to poll at runtime

### DIFF
--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -48,8 +48,9 @@
  *     frozen at offset 60).
  * v4: appended the 32-bin PWM-phase histogram of accepted zero-crossings.
  * v5: appended esc_state + illegal edge counter (drive state machine).
- * v6: appended bidirectional DShot (BDShot) RX/TX health counters. */
-#	define HWCI_PERF_VERSION 6u
+ * v6: appended bidirectional DShot (BDShot) RX/TX health counters.
+ * v7: appended zc_blind_steps (missed-ZC blind commutation counter). */
+#	define HWCI_PERF_VERSION 7u
 
 /* PWM-phase histogram bins (power of two: the binning multiply-shift and the
  * host's modular math both assume it). */
@@ -151,7 +152,15 @@ typedef struct hwci_perf_s {
 	uint16_t dshot_last_com_us; /* off 164: last packed com period   */
 	uint8_t dshot_telem_mode;   /* off 166: 0=uni DShot, 1=BDShot    */
 	uint8_t dshot_edt_mode;	    /* off 167: EDT enabled              */
-} hwci_perf_t;			    /* total size: 168 bytes             */
+
+	/* --- v7: missed-ZC blind commutation counter ---
+     * Incremented once per blind (deadline-extrapolated) commutation in
+     * PeriodElapsedCallback. Monotonic u32, host-diffed like loop_iters:
+     * delta over a window is the blind-step rate, the health monitor for
+     * the BLHeli-style timeout-commutation path (zero on a healthy loop;
+     * a short burst at commanded stop is the designed teardown). */
+	uint32_t zc_blind_steps; /* off 168: blind commutations       */
+} hwci_perf_t;			 /* total size: 172 bytes             */
 
 extern volatile hwci_perf_t hwci_perf;
 
@@ -257,6 +266,17 @@ void hwci_perf_reset_stats(void);
 #	define HWCI_PERF_CONFIRM_REJECT()                                                                                                 \
 		do {                                                                                                                       \
 			hwci_perf.zc_confirm_reject++;                                                                                     \
+		} while (0)
+
+/*
+ * Blind (deadline-extrapolated) commutation counter. Runs in the COM timer
+ * ISR, only on the blind path - a single volatile u32 increment. Not gated
+ * on zero_crosses: blind steps only ever happen past the deadline arming
+ * gate, and the commanded-stop teardown burst is itself worth counting.
+ */
+#	define HWCI_PERF_BLIND_STEP()                                                                                                     \
+		do {                                                                                                                       \
+			hwci_perf.zc_blind_steps++;                                                                                        \
 		} while (0)
 
 /*
@@ -371,6 +391,9 @@ void hwci_perf_reset_stats(void);
 		do {                                                                                                                       \
 		} while (0)
 #	define HWCI_PERF_CONFIRM_REJECT()                                                                                                 \
+		do {                                                                                                                       \
+		} while (0)
+#	define HWCI_PERF_BLIND_STEP()                                                                                                     \
 		do {                                                                                                                       \
 		} while (0)
 #	define HWCI_PERF_ZC_PHASE_CAPTURE()                                                                                               \

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -30,6 +30,10 @@ extern uint8_t auto_advance_level;
 extern volatile char old_routine;
 extern volatile uint32_t zero_crosses;
 extern volatile uint32_t polling_mode_changeover;
+/* Missed-ZC blind-step fallback (bemf_zc.c) */
+extern volatile uint8_t zc_deadline_armed;
+extern volatile uint8_t zc_blind_steps;
+extern volatile uint32_t zc_blind_steps_total;
 extern uint8_t filter_level;
 extern uint8_t bad_count;
 extern uint8_t bad_count_threshold;

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -33,7 +33,7 @@ extern volatile uint32_t polling_mode_changeover;
 /* Missed-ZC blind-step fallback (bemf_zc.c) */
 extern volatile uint8_t zc_deadline_armed;
 extern volatile uint8_t zc_blind_steps;
-extern volatile uint32_t zc_blind_steps_total;
+extern volatile uint8_t zc_miss_bucket;
 extern uint8_t filter_level;
 extern uint8_t bad_count;
 extern uint8_t bad_count_threshold;

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -20,14 +20,24 @@
         coarse periods)
       cmd 1 LOAD_MODEL: JSON file path (rest of packet)
       cmd 2 SET_SPEEDUP: float speedup (0 = free run)
+      cmd 3 ZC_FAULT: pad byte = mode (0 off, 1 drop all comparator
+        edge deliveries, 2 drop every other commutation window),
+        u32 duration_us. For blind-step/missed-ZC path tests.
+      cmd 4 ZC_STATS: no payload; replies with the commutation
+        tracking snapshot below
   SITL -> client:
     u16 magic 0x5354, u8 version=1, u8 count, count * sample
     u16 magic 0x5355, u8 ok, u8 pad, message   (LOAD_MODEL reply)
+    u16 magic 0x5356, u8 version=1, u8 pad, u32 zero_crosses,
+      u32 commutation_interval, u32 dropped_edges, u32 desync_happened,
+      u8 old_routine, u8 running, u8 armed, u8 zc_blind_steps,
+      u8 zc_miss_bucket, u8 zc_deadline_armed  (ZC_STATS reply)
 */
 
 #include "sitl.h"
 #include "sitl_config.h"
 #include "motor.h"
+#include "motor_runtime.h"
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -194,6 +204,42 @@ void sitl_state_poll(void)
 			apply_period();
 			fprintf(stderr, "SITL: speedup %.3f\n", (double)speedup);
 		}
+	} else if (cmd == 3 && ret >= 8) {
+		uint32_t duration_us;
+		memcpy(&duration_us, pkt + 4, 4);
+		motor_zc_fault(pkt[3], duration_us);
+	} else if (cmd == 4) {
+		// racy reads of firmware globals are fine here: every field is a
+		// naturally-aligned scalar and the client polls
+		struct __attribute__((packed)) {
+			uint16_t magic;
+			uint8_t version;
+			uint8_t pad;
+			uint32_t zero_crosses;
+			uint32_t commutation_interval;
+			uint32_t dropped_edges;
+			uint32_t desync_happened;
+			uint8_t old_routine;
+			uint8_t running;
+			uint8_t armed;
+			uint8_t zc_blind_steps;
+			uint8_t zc_miss_bucket;
+			uint8_t zc_deadline_armed;
+		} reply = {
+			.magic = 0x5356,
+			.version = 1,
+			.zero_crosses = zero_crosses,
+			.commutation_interval = commutation_interval,
+			.dropped_edges = motor_zc_dropped(),
+			.desync_happened = desync_happened,
+			.old_routine = (uint8_t)old_routine,
+			.running = running,
+			.armed = (uint8_t)armed,
+			.zc_blind_steps = zc_blind_steps,
+			.zc_miss_bucket = zc_miss_bucket,
+			.zc_deadline_armed = zc_deadline_armed,
+		};
+		sendto(fd, &reply, sizeof(reply), 0, (struct sockaddr *)&src, sizeof(src));
 	}
 }
 

--- a/Mcu/SITL/Src/sitl_timers.c
+++ b/Mcu/SITL/Src/sitl_timers.c
@@ -169,7 +169,7 @@ void sitl_interval_timer_set(uint32_t cnt)
 void sitl_com_int_arm(uint32_t time)
 {
 	extern void motor_log_event(int kind, uint32_t a, uint32_t b, uint32_t c);
-	motor_log_event(4 /*MEV_ZC_ACCEPT*/, time, 0, 0);
+	motor_log_event(4 /*MEV_COM_ARM*/, time, 0, 0);
 	SITL_TIM_TypeDef *t = &tims[SITL_TIM16_IDX];
 	tim16.base_ns = sitl_time_ns();
 	tim16.cnt_base = 0;

--- a/Mcu/SITL/sim/motor.c
+++ b/Mcu/SITL/sim/motor.c
@@ -56,6 +56,34 @@ extern uint32_t current_EXTI_LINE;
 static void check_desync_dump(void);
 static void dump_ring(void);
 
+/*
+  zero-cross fault injection (state port cmd 3): suppress comparator EXTI
+  delivery so the firmware's missed-ZC blind-step path can be exercised
+  deterministically. The comparator OUTPUT keeps tracking the physics (poll
+  mode and the confirm loop read the level directly and must stay honest) -
+  only the edge -> EXTI pend -> NVIC delivery is dropped, which is exactly
+  what a crossing invisible to the interrupt path looks like.
+  mode 0: off, 1: drop every delivery, 2: drop deliveries during every
+  other commutation window (alternating real/missed - the demag signature
+  the miss-rate bucket exists for).
+ */
+static uint8_t zc_fault_mode;
+static uint64_t zc_fault_end_ns;
+static uint32_t zc_dropped_edges;
+static uint32_t commutation_count; // total comStep calls, real + blind
+
+void motor_zc_fault(uint8_t mode, uint32_t duration_us)
+{
+	zc_fault_mode = mode;
+	zc_fault_end_ns = sitl_time_ns() + (uint64_t)duration_us * 1000ULL;
+	fprintf(stderr, "SITL: zc fault mode %u for %u us\n", mode, duration_us);
+}
+
+uint32_t motor_zc_dropped(void)
+{
+	return zc_dropped_edges;
+}
+
 static struct {
 	double theta; // mechanical angle, rad
 	double omega; // mechanical speed, rad/s
@@ -427,12 +455,22 @@ void motor_step(uint64_t now_ns, uint32_t dt_ns)
 		const uint32_t line = current_EXTI_LINE;
 		const bool rising_edge = out != 0;
 		if ((rising_edge && (sitl_exti.RTSR & line)) || (!rising_edge && (sitl_exti.FTSR & line))) {
-			sitl_exti.PR |= line;
-			const bool unmasked = (sitl_exti.IMR & line) != 0;
-			if (unmasked) {
-				sitl_irq_pend(SITL_IRQ_COMP);
+			if (zc_fault_mode && now_ns < zc_fault_end_ns && (zc_fault_mode == 1 || (commutation_count & 1u) == 0u)) {
+				// injected missed crossing: edge never reaches EXTI.
+				// Alternating mode keys off the commutation counter
+				// (blind steps increment it too), so a blind step in a
+				// dropped window flips the parity and the next window
+				// delivers - real/missed/real/missed indefinitely.
+				zc_dropped_edges++;
+				motor_log_event(MEV_EDGE, out, 0, 1);
+			} else {
+				sitl_exti.PR |= line;
+				const bool unmasked = (sitl_exti.IMR & line) != 0;
+				if (unmasked) {
+					sitl_irq_pend(SITL_IRQ_COMP);
+				}
+				motor_log_event(MEV_EDGE, out, unmasked, 0);
 			}
-			motor_log_event(MEV_EDGE, out, unmasked, 0);
 		}
 	}
 
@@ -506,6 +544,7 @@ void motor_log_commutation(int step)
 {
 	extern volatile uint16_t duty_cycle;
 	extern uint16_t duty_cycle_maximum;
+	commutation_count++;
 	motor_log_event(MEV_COMMUTATE, (uint32_t)step, duty_cycle, duty_cycle_maximum);
 }
 

--- a/Mcu/SITL/sim/motor.h
+++ b/Mcu/SITL/sim/motor.h
@@ -24,6 +24,13 @@ void motor_get_live_state(float *omega, float *theta, float *theta_e, float i[3]
 // re-derive cached values after a runtime config reload
 void motor_config_changed(void);
 
+// zero-cross fault injection (state port cmd 3): suppress comparator EXTI
+// delivery for duration_us. mode 0 = off, 1 = drop every delivery,
+// 2 = drop deliveries during every other commutation window
+void motor_zc_fault(uint8_t mode, uint32_t duration_us);
+// total edge deliveries dropped by the fault gate (monotonic)
+uint32_t motor_zc_dropped(void);
+
 // accumulate iu,iv,iw,vu,vv,vw,vbus,ibus for averaged state sampling
 void motor_add_signals(double acc[8]);
 
@@ -39,7 +46,10 @@ enum motor_ev {
 	MEV_EDGE,	   // comparator edge: a = new level, b = IMR set, c = pended
 	MEV_COMP_BLANKED,  // comp irq discarded by blanking: a = CNT, b = ci/2
 	MEV_COMP_RUN,	   // comp irq calling interruptRoutine: a = CNT
-	MEV_ZC_ACCEPT,	   // interruptRoutine armed COM timer: a = waitTime
+	MEV_COM_ARM,	   // COM timer armed: a = ticks. From interruptRoutine
+			   // (accepted crossing, a = waitTime) or from
+			   // PeriodElapsedCallback (blind-step deadline arm /
+			   // cancel-race re-arm) - not necessarily an accepted ZC.
 	MEV_MAINLOOP,	   // firmware main loop iteration: a = avg, b = last_avg, c = gap us
 };
 void motor_log_event(int kind, uint32_t a, uint32_t b, uint32_t c);

--- a/Mcu/SITL/tests/test_blind_step.py
+++ b/Mcu/SITL/tests/test_blind_step.py
@@ -1,0 +1,174 @@
+'''Missed-ZC blind-step path tests (PR #41, BLHeli-style timeout commutation).
+
+Uses state-port fault injection (cmd 3) to suppress comparator EXTI
+delivery - the comparator LEVEL keeps tracking the physics, so poll mode
+and the confirm loop stay honest while the interrupt path sees missed
+crossings. Covers the three paths that previously rested only on bench
+traces:
+
+  - bridge:      a short full suppression is ridden out with blind steps,
+                 no desync, no restart
+  - limit:       a long full suppression exhausts the consecutive
+                 blind-step budget and hands off to the stall rail
+                 (restart), then recovers when the fault clears
+  - alternating: dropping every other commutation window (the demag
+                 signature) climbs the leaky miss-rate bucket until it
+                 trips the same rail - the pattern the consecutive-step
+                 counter alone can never catch
+'''
+
+from __future__ import annotations
+
+import socket
+import struct
+import time
+
+import sitl_dshot as sd
+from sitl_harness import Sender, rpm_from_state, wait_for_state
+
+STATE_MAGIC_CMD = 0x5353
+ZC_STATS_MAGIC = 0x5356
+
+STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
+                'desync_happened', 'old_routine', 'running', 'armed',
+                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed')
+STATS_FMT = '<HBBIIIIBBBBBB'
+
+
+def _open_ctl(sitl):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(('127.0.0.1', sitl.state_port))
+    s.settimeout(0.5)
+    return s
+
+
+def _zc_fault(ctl, mode, duration_us):
+    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 3, mode, duration_us))
+
+
+def _zc_stats(ctl, retries=5):
+    for _ in range(retries):
+        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 4, 0))
+        try:
+            pkt = ctl.recv(64)
+        except socket.timeout:
+            continue
+        if len(pkt) >= struct.calcsize(STATS_FMT):
+            vals = struct.unpack_from(STATS_FMT, pkt)
+            if vals[0] == ZC_STATS_MAGIC:
+                return dict(zip(STATS_FIELDS, vals[3:]))
+    raise AssertionError('no ZC_STATS reply from SITL state port')
+
+
+def _poll_stats(ctl, seconds):
+    '''lockstep-sample stats as fast as the state port answers'''
+    out = []
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        out.append(_zc_stats(ctl))
+    return out
+
+
+def _spin_up(sitl, state_stream, value=250, arm_s=2.2, run_s=3.0):
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), 'state stream dead\n' + sitl.log_tail()
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT300)
+    time.sleep(arm_s)
+    tx.value = value
+    time.sleep(run_s)
+    rpm = rpm_from_state(sim)
+    assert rpm > 500, 'motor not spinning: rpm=%.0f\n%s' % (rpm, sitl.log_tail())
+    return sim, tx, rpm
+
+
+def _assert_recovered(ctl, sim, rpm_before, sitl):
+    time.sleep(1.5)
+    end = _zc_stats(ctl)
+    assert end['running'] == 1 and end['old_routine'] == 0, (
+        'no closed-loop recovery: %r\n%s' % (end, sitl.log_tail()))
+    assert end['zc_blind_steps'] == 0, end
+    assert end['zc_miss_bucket'] < 6, end
+    rpm = rpm_from_state(sim, 0.5)
+    assert rpm > rpm_before * 0.6, (
+        'rpm did not recover: %.0f vs %.0f before' % (rpm, rpm_before))
+
+
+def test_blind_step_bridges_short_dropout(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim, tx, rpm0 = _spin_up(sitl, state_stream)
+    try:
+        ctl = _open_ctl(sitl)
+        pre = _zc_stats(ctl)
+        assert pre['old_routine'] == 0 and pre['running'] == 1, pre
+        ci_us = max(pre['commutation_interval'] // 2, 100)
+
+        # ~3-4 missed crossings: well under the 8-step consecutive budget
+        _zc_fault(ctl, mode=1, duration_us=6 * ci_us)
+        samples = _poll_stats(ctl, seconds=max(0.2, 30 * ci_us * 1e-6))
+
+        post = _zc_stats(ctl)
+        assert post['dropped_edges'] > pre['dropped_edges'], (
+            'fault gate never dropped an edge: %r -> %r' % (pre, post))
+        # blind stepping engaged: the live counters were caught nonzero
+        # (bucket lingers ~3 accepts per miss, so sampling cannot miss it)
+        assert any(s['zc_blind_steps'] > 0 or s['zc_miss_bucket'] > 0
+                   for s in samples), 'no blind step observed in %d samples' % len(samples)
+        # and it BRIDGED: no restart (zero_crosses never reset), no desync,
+        # never fell back to poll mode
+        assert all(s['zero_crosses'] >= pre['zero_crosses'] for s in samples), (
+            'zero_crosses reset during a bridgeable dropout')
+        assert post['desync_happened'] == pre['desync_happened'], (pre, post)
+        assert all(s['old_routine'] == 0 for s in samples)
+        _assert_recovered(ctl, sim, rpm0, sitl)
+    finally:
+        tx.stop()
+
+
+def test_blind_step_limit_hands_off_to_stall_rail(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim, tx, rpm0 = _spin_up(sitl, state_stream)
+    try:
+        ctl = _open_ctl(sitl)
+        pre = _zc_stats(ctl)
+        assert pre['old_routine'] == 0 and pre['zero_crosses'] > 100, pre
+        ci_us = max(pre['commutation_interval'] // 2, 100)
+
+        # far beyond the 8-step budget (8 steps cost ~23x CI in total)
+        _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
+        samples = _poll_stats(ctl, seconds=max(0.5, 120 * ci_us * 1e-6))
+
+        # the limit tripped: stall-rail restart resets zero_crosses
+        assert min(s['zero_crosses'] for s in samples) < 100, (
+            'blind-step limit never handed off to the stall rail '
+            '(min zc %d over %d samples)\n%s'
+            % (min(s['zero_crosses'] for s in samples), len(samples),
+               sitl.log_tail()))
+        _assert_recovered(ctl, sim, rpm0, sitl)
+    finally:
+        tx.stop()
+
+
+def test_alternating_misses_trip_miss_rate_bucket(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim, tx, rpm0 = _spin_up(sitl, state_stream)
+    try:
+        ctl = _open_ctl(sitl)
+        pre = _zc_stats(ctl)
+        assert pre['old_routine'] == 0 and pre['zero_crosses'] > 100, pre
+
+        # drop every other commutation window: real/missed alternation.
+        # The consecutive counter resets on every accepted crossing, so
+        # only the leaky bucket (+3 per miss, -1 per accept) can end this.
+        _zc_fault(ctl, mode=2, duration_us=500_000)
+        samples = _poll_stats(ctl, seconds=0.7)
+
+        assert max(s['zc_miss_bucket'] for s in samples) >= 12, (
+            'miss-rate bucket never climbed under sustained alternating '
+            'misses (max %d over %d samples)'
+            % (max(s['zc_miss_bucket'] for s in samples), len(samples)))
+        assert min(s['zero_crosses'] for s in samples) < 100, (
+            'bucket never tripped the stall rail: alternating misses ran '
+            'unbounded\n' + sitl.log_tail())
+        _assert_recovered(ctl, sim, rpm0, sitl)
+    finally:
+        tx.stop()

--- a/Mcu/f051/Src/peripherals.c
+++ b/Mcu/f051/Src/peripherals.c
@@ -301,7 +301,23 @@ void MX_TIM14_Init(void)
 	TIM14->ARR = 4000;
 	NVIC_SetPriority(TIM14_IRQn, 0);
 	NVIC_EnableIRQ(TIM14_IRQn);
-	LL_TIM_EnableARRPreload(TIM14);
+	/*
+	 * ARR preload must stay OFF on the commutation timer. The blind-step
+	 * deadline alternates COM_TIMER->ARR between ~waitTime (commutation
+	 * scheduled by an accepted crossing) and ~2.2x waitTime (missed-ZC
+	 * deadline armed after commutating). With ARPE each write only takes
+	 * effect at the next update event, so the two values arrive one event
+	 * LATE - swapped: commutations fire at the deadline value and the
+	 * "deadline" fires right at the expected crossing, racing (and ~50%
+	 * of the time beating) every genuine zero-cross. Bench: 46% of
+	 * commutations went blind on a healthy spinning loop, phase scrambled,
+	 * 3 A stall on a 0.2 A operating point. Legacy never noticed the
+	 * preload because both its writers wrote ~waitTime, so a one-cycle-old
+	 * ARR was indistinguishable. Immediate ARR writes are safe here: every
+	 * writer (SET_AND_ENABLE_COM_INT, zcfoundroutine) zeroes CNT before
+	 * setting ARR, so the new value is always ahead of the counter.
+	 */
+	LL_TIM_DisableARRPreload(TIM14);
 }
 
 void MX_TIM16_Init(void)

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -26,6 +26,25 @@
  * is no fallback to poll mode at runtime.
  */
 #define ZC_BLIND_STEP_LIMIT 8 /* consecutive extrapolated steps before the stall rail takes over */
+/*
+ * Blind stepping requires an ESTABLISHED closed loop. At the poll->interrupt
+ * handoff commutation_interval is whatever the startup noise made of it -
+ * bench: noise-shrunk to ~1300 ticks while the true interval of the barely
+ * moving rotor is 5-10x longer - so a deadline at 1.5x the believed interval
+ * fires BEFORE the first real crossing can arrive, commutates blind, and
+ * drags the stator field away from the rotor. The result is a stable false
+ * lock: noise bursts get accepted as crossings, blind steps bridge the gaps
+ * between bursts (bench: ~40% of commutations blind, phantom ~15k eRPM,
+ * rotor stalled at 3 A), and the stall rail almost never fires because every
+ * blind step resets INTERVAL_TIMER. Below this zero-cross count the handler
+ * keeps legacy semantics (commutate once per accepted crossing, no re-arm):
+ * a noise chain then dies at the 45000-tick stall rail and the poll path
+ * kick-steps the rotor exactly as ark-release does. 100 matches the startup
+ * self-heal window in commutate() and the "stable running" gates elsewhere;
+ * zero_crosses resets on desync/stop, so every re-acquisition passes through
+ * the legacy path again before blind stepping re-arms.
+ */
+#define ZC_DEADLINE_MIN_ZC 100
 
 RAM_FUNC void PeriodElapsedCallback()
 {
@@ -94,16 +113,19 @@ RAM_FUNC void PeriodElapsedCallback()
 	waitTime = (commutation_interval >> 1) - advance;
 	if (!old_routine) {
 		enableCompInterrupts(); // enable comp interrupt
-		// Next crossing expected (commutation_interval - waitTime) from
-		// now; arm the blind-step deadline at expected + 50% grace. The
-		// 16-bit clamp shrinks the grace above CI ~40000, but the trust
-		// rail restarts long before a healthy loop runs that slow.
-		uint32_t deadline = (commutation_interval - waitTime) + (commutation_interval >> 1);
-		if (deadline > 65535u) {
-			deadline = 65535u;
+		if (zero_crosses >= ZC_DEADLINE_MIN_ZC) {
+			// Next crossing expected (commutation_interval - waitTime)
+			// from now; arm the blind-step deadline at expected + 50%
+			// grace. The 16-bit clamp shrinks the grace above CI ~40000,
+			// but the trust rail restarts long before a healthy loop
+			// runs that slow.
+			uint32_t deadline = (commutation_interval - waitTime) + (commutation_interval >> 1);
+			if (deadline > 65535u) {
+				deadline = 65535u;
+			}
+			zc_deadline_armed = 1;
+			SET_AND_ENABLE_COM_INT((uint16_t)deadline);
 		}
-		zc_deadline_armed = 1;
-		SET_AND_ENABLE_COM_INT((uint16_t)deadline);
 	}
 	if (!blind && zero_crosses < 10000) {
 		zero_crosses++;

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -27,6 +27,22 @@
  */
 #define ZC_BLIND_STEP_LIMIT 8 /* consecutive extrapolated steps before the stall rail takes over */
 /*
+ * Miss-RATE rail. zc_blind_steps only counts CONSECUTIVE misses - an
+ * alternating real/missed pattern (the demag signature) resets it on every
+ * accepted crossing and would blind-step indefinitely at ~12.5% interval
+ * inflation per miss, never reaching the step limit, the trust rail (real
+ * crossings keep the average under the changeover band) or the stall rail
+ * (both paths reset INTERVAL_TIMER). Leaky bucket: each blind step adds
+ * ZC_MISS_BUCKET_INC, each accepted crossing drains 1, at
+ * ZC_MISS_BUCKET_LIMIT the handler stops stepping blind and hands the loop
+ * to the stall rail exactly like the consecutive-step limit. Sustained miss
+ * rates above 1-in-4 climb; 8 consecutive misses reach the limit on the
+ * same deadline event as ZC_BLIND_STEP_LIMIT, so the consecutive case is
+ * unchanged. Alternating 50% trips after ~12 misses (~4 electrical revs).
+ */
+#define ZC_MISS_BUCKET_INC 3
+#define ZC_MISS_BUCKET_LIMIT 24
+/*
  * Blind stepping requires an ESTABLISHED closed loop. At the poll->interrupt
  * handoff commutation_interval is whatever the startup noise made of it -
  * bench: noise-shrunk to ~1300 ticks while the true interval of the barely
@@ -65,9 +81,10 @@ RAM_FUNC void PeriodElapsedCallback()
 		// Deadline firing, not a commutation scheduled by an accepted
 		// zero-cross (interruptRoutine cancels the deadline first).
 		zc_deadline_armed = 0;
-		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT) {
-			// Position unknown for too long: stop stepping blind. Kick
-			// the INTERVAL_TIMER past the 45000 stall threshold so the
+		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT || zc_miss_bucket >= ZC_MISS_BUCKET_LIMIT) {
+			// Position unknown for too long (consecutively or as a
+			// sustained miss rate): stop stepping blind. Kick the
+			// INTERVAL_TIMER past the 45000 stall threshold so the
 			// main-loop rail (faultHandleBemfIntervalStall) restarts
 			// through the startup path on its next pass instead of
 			// 22 ms from now.
@@ -77,7 +94,8 @@ RAM_FUNC void PeriodElapsedCallback()
 		}
 		blind = 1;
 		zc_blind_steps++;
-		zc_blind_steps_total++;
+		zc_miss_bucket += ZC_MISS_BUCKET_INC;
+		HWCI_PERF_BLIND_STEP();
 		// Take the full elapsed time as the (late) crossing measurement
 		// and commutate now. The inflated interval feeds the average so
 		// timing hunts slower - the safe direction for a decelerating
@@ -130,7 +148,15 @@ RAM_FUNC void PeriodElapsedCallback()
 	if (!blind && zero_crosses < 10000) {
 		zero_crosses++;
 	}
-	HWCI_PERF_ZC();
+	if (!blind) {
+		// Blind steps must not feed the jitter accumulators: the
+		// extrapolated 1.5x interval is not a measured crossing, and the
+		// perf gate (zero_crosses >= 100) is the same window in which
+		// blind stepping is armed - counting them would conflate real
+		// jitter with blind-step count in exactly the runs being read.
+		// Blind steps have their own counter (HWCI_PERF_BLIND_STEP).
+		HWCI_PERF_ZC();
+	}
 }
 
 RAM_FUNC void interruptRoutine()
@@ -253,6 +279,9 @@ RAM_FUNC void interruptRoutine()
 	maskPhaseInterrupts();
 	zc_deadline_armed = 0; // COM_TIMER now times commutation, not the missed-ZC deadline
 	zc_blind_steps = 0;
+	if (zc_miss_bucket) {
+		zc_miss_bucket--; // accepted crossing drains the miss-rate bucket
+	}
 	lastzctime = thiszctime;
 #ifdef MCU_F051
 	thiszctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
@@ -268,13 +297,14 @@ RAM_FUNC void interruptRoutine()
 void startMotor()
 {
 	if (running == 0) {
+		DISABLE_COM_TIMER_INT(); // a stale blind-step deadline must not commutate the restart
+		zc_deadline_armed = 0;
+		zc_blind_steps = 0;
+		zc_miss_bucket = 0;
 		commutate();
 		commutation_interval = 10000;
 		SET_INTERVAL_TIMER_COUNT(5000);
 		running = 1;
 	}
-	DISABLE_COM_TIMER_INT(); // a stale blind-step deadline must not commutate the restart
-	zc_deadline_armed = 0;
-	zc_blind_steps = 0;
 	enableCompInterrupts();
 }

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -39,10 +39,13 @@ RAM_FUNC void PeriodElapsedCallback()
 			return; // stale deadline after a stop or forced restart
 		}
 		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT) {
-			// Position unknown for too long: stop stepping blind and let
-			// the INTERVAL_TIMER stall rail / desync machinery restart
-			// through the normal startup path.
+			// Position unknown for too long: stop stepping blind. Kick
+			// the INTERVAL_TIMER past the 45000 stall threshold so the
+			// main-loop rail (faultHandleBemfIntervalStall) restarts
+			// through the startup path on its next pass instead of
+			// 22 ms from now.
 			maskPhaseInterrupts();
+			SET_INTERVAL_TIMER_COUNT(46000);
 			return;
 		}
 		blind = 1;
@@ -60,6 +63,18 @@ RAM_FUNC void PeriodElapsedCallback()
 		lastzctime = thiszctime;
 		thiszctime = (uint16_t)elapsed;
 		SET_INTERVAL_TIMER_COUNT(0);
+	} else {
+		// Cancel race: SET_AND_ENABLE_COM_INT clears the peripheral flag,
+		// but a deadline event that reached NVIC pending just before an
+		// accepted zero-cross cancelled it still runs this handler once.
+		// The genuine commutation fires with INTERVAL_TIMER at ~waitTime
+		// (both reset together at the crossing); far earlier means this
+		// entry is that stale pend - re-arm the remainder and bail.
+		uint32_t t = INTERVAL_TIMER_COUNT;
+		if (t + 4u < waitTime) {
+			SET_AND_ENABLE_COM_INT((uint16_t)(waitTime - t));
+			return;
+		}
 	}
 	commutate();
 	commutation_interval = ((commutation_interval) + ((lastzctime + thiszctime) >> 1)) >> 1;
@@ -72,7 +87,9 @@ RAM_FUNC void PeriodElapsedCallback()
 	if (!old_routine) {
 		enableCompInterrupts(); // enable comp interrupt
 		// Next crossing expected (commutation_interval - waitTime) from
-		// now; arm the blind-step deadline at expected + 50% grace.
+		// now; arm the blind-step deadline at expected + 50% grace. The
+		// 16-bit clamp shrinks the grace above CI ~40000, but the trust
+		// rail restarts long before a healthy loop runs that slow.
 		uint32_t deadline = (commutation_interval - waitTime) + (commutation_interval >> 1);
 		if (deadline > 65535u) {
 			deadline = 65535u;

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -16,9 +16,51 @@
 #include "eeprom.h"
 #include "hwci_perf.h"
 
+/*
+ * Missed-ZC fallback (BLHeli-style timeout commutation). After each
+ * commutation COM_TIMER is re-armed as a deadline for the next crossing:
+ * expected arrival plus 50% grace. An accepted crossing re-arms COM_TIMER
+ * for the commutation schedule (cancelling the deadline); if the deadline
+ * fires instead, commutate blind at extrapolated timing and keep watching.
+ * A missed crossing costs one extrapolated step, not a mode change - there
+ * is no fallback to poll mode at runtime.
+ */
+#define ZC_BLIND_STEP_LIMIT 8 /* consecutive extrapolated steps before the stall rail takes over */
+
 RAM_FUNC void PeriodElapsedCallback()
 {
+	uint8_t blind = 0;
 	DISABLE_COM_TIMER_INT(); // disable interrupt
+	if (zc_deadline_armed) {
+		// Deadline firing, not a commutation scheduled by an accepted
+		// zero-cross (interruptRoutine cancels the deadline first).
+		zc_deadline_armed = 0;
+		if (!running || old_routine) {
+			return; // stale deadline after a stop or forced restart
+		}
+		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT) {
+			// Position unknown for too long: stop stepping blind and let
+			// the INTERVAL_TIMER stall rail / desync machinery restart
+			// through the normal startup path.
+			maskPhaseInterrupts();
+			return;
+		}
+		blind = 1;
+		zc_blind_steps++;
+		zc_blind_steps_total++;
+		// Take the full elapsed time as the (late) crossing measurement
+		// and commutate now. The inflated interval feeds the average so
+		// timing hunts slower - the safe direction for a decelerating
+		// rotor - and the next accepted crossing resyncs immediately.
+		maskPhaseInterrupts();
+		uint32_t elapsed = INTERVAL_TIMER_COUNT;
+		if (elapsed > 65535u) {
+			elapsed = 65535u;
+		}
+		lastzctime = thiszctime;
+		thiszctime = (uint16_t)elapsed;
+		SET_INTERVAL_TIMER_COUNT(0);
+	}
 	commutate();
 	commutation_interval = ((commutation_interval) + ((lastzctime + thiszctime) >> 1)) >> 1;
 	if (!eepromBuffer.auto_advance) {
@@ -29,8 +71,16 @@ RAM_FUNC void PeriodElapsedCallback()
 	waitTime = (commutation_interval >> 1) - advance;
 	if (!old_routine) {
 		enableCompInterrupts(); // enable comp interrupt
+		// Next crossing expected (commutation_interval - waitTime) from
+		// now; arm the blind-step deadline at expected + 50% grace.
+		uint32_t deadline = (commutation_interval - waitTime) + (commutation_interval >> 1);
+		if (deadline > 65535u) {
+			deadline = 65535u;
+		}
+		zc_deadline_armed = 1;
+		SET_AND_ENABLE_COM_INT((uint16_t)deadline);
 	}
-	if (zero_crosses < 10000) {
+	if (!blind && zero_crosses < 10000) {
 		zero_crosses++;
 	}
 	HWCI_PERF_ZC();
@@ -154,6 +204,8 @@ RAM_FUNC void interruptRoutine()
 #endif
 	__disable_irq();
 	maskPhaseInterrupts();
+	zc_deadline_armed = 0; // COM_TIMER now times commutation, not the missed-ZC deadline
+	zc_blind_steps = 0;
 	lastzctime = thiszctime;
 #ifdef MCU_F051
 	thiszctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
@@ -174,5 +226,8 @@ void startMotor()
 		SET_INTERVAL_TIMER_COUNT(5000);
 		running = 1;
 	}
+	DISABLE_COM_TIMER_INT(); // a stale blind-step deadline must not commutate the restart
+	zc_deadline_armed = 0;
+	zc_blind_steps = 0;
 	enableCompInterrupts();
 }

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -31,13 +31,21 @@ RAM_FUNC void PeriodElapsedCallback()
 {
 	uint8_t blind = 0;
 	DISABLE_COM_TIMER_INT(); // disable interrupt
+	if (!running || old_routine) {
+		// COM events are meaningless outside interrupt closed-loop: a
+		// stale blind-step deadline after a stop or forced restart, or a
+		// poll-mode COM_TIMER ARR write landing while the deadline's
+		// interrupt enable was still set. Legacy never ran this handler
+		// in poll mode (the enable stayed off); keep that invariant, or
+		// the cancel-race guard below re-arms COM against the poll
+		// startup and spurious commutations fight zcfoundroutine.
+		zc_deadline_armed = 0;
+		return;
+	}
 	if (zc_deadline_armed) {
 		// Deadline firing, not a commutation scheduled by an accepted
 		// zero-cross (interruptRoutine cancels the deadline first).
 		zc_deadline_armed = 0;
-		if (!running || old_routine) {
-			return; // stale deadline after a stop or forced restart
-		}
 		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT) {
 			// Position unknown for too long: stop stepping blind. Kick
 			// the INTERVAL_TIMER past the 45000 stall threshold so the

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -78,9 +78,23 @@ RAM_FUNC void commutate()
 	}
 	__enable_irq();
 	changeCompInput();
-	// No fallback to poll mode at runtime: a missed crossing is handled
-	// per-step by the blind-step deadline in PeriodElapsedCallback, and a
-	// genuinely lost rotor restarts via the stall / desync machinery.
+#ifndef NO_POLLING_START
+	// Poll re-entry, startup window only. On real hardware, PWM /
+	// comparator noise during the first start kicks can shrink
+	// commutation_interval below the changeover and hand off to interrupt
+	// mode with no usable BEMF; once old_routine is 0 the 20 kHz poll
+	// drive stops sampling entirely and the motor never starts (bench:
+	// FAULT_STUCK with zero crossings, CI pinned ~19.6k from the stall
+	// rail's restart cycle). Legacy healed that by re-asserting poll mode
+	// on every slow-average commutation; keep the self-heal while
+	// starting (zero_crosses resets on desync/stop, so recovery paths get
+	// it too). Established closed loop never exits here - a missed
+	// crossing is one blind step (PeriodElapsedCallback) and false locks
+	// are the trust rail's job (runtimeProcessDesyncCheck).
+	if (zero_crosses < 100 && average_interval > polling_mode_changeover + 500) {
+		old_routine = 1;
+	}
+#endif
 	bemfcounter = 0;
 	zcfound = 0;
 	commutation_intervals[step - 1] = commutation_interval; // just used to calulate average

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -188,4 +188,11 @@ void zcfoundroutine()
 		}
 	}
 #endif
+	if (!old_routine) {
+		// Fresh closed-loop run: a blind-step budget left over from a
+		// previous run must not shorten this one, and a stale deadline
+		// flag must not misread the first scheduled commutation.
+		zc_deadline_armed = 0;
+		zc_blind_steps = 0;
+	}
 }

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -78,11 +78,9 @@ RAM_FUNC void commutate()
 	}
 	__enable_irq();
 	changeCompInput();
-#ifndef NO_POLLING_START
-	if (average_interval > polling_mode_changeover + 500) {
-		old_routine = 1;
-	}
-#endif
+	// No fallback to poll mode at runtime: a missed crossing is handled
+	// per-step by the blind-step deadline in PeriodElapsedCallback, and a
+	// genuinely lost rotor restarts via the stall / desync machinery.
 	bemfcounter = 0;
 	zcfound = 0;
 	commutation_intervals[step - 1] = commutation_interval; // just used to calulate average
@@ -168,6 +166,10 @@ void zcfoundroutine()
 	bad_count = 0;
 
 	zero_crosses++;
+	// Poll mode is startup-only: these enter thresholds are unchanged, but
+	// once in interrupt mode there is no re-entry (see commutate) - the
+	// blind-step deadline in PeriodElapsedCallback rides through missed
+	// crossings and a genuinely lost rotor restarts through this ramp.
 #ifdef NO_POLLING_START // changes to interrupt mode after 2 zero crosses, does not re-enter
 	if (zero_crosses > 2) {
 		old_routine = 0;

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -208,5 +208,6 @@ void zcfoundroutine()
 		// flag must not misread the first scheduled commutation.
 		zc_deadline_armed = 0;
 		zc_blind_steps = 0;
+		zc_miss_bucket = 0;
 	}
 }

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -442,6 +442,21 @@ void setInput()
 			}
 		}
 	}
+	// Missed-ZC power cut (BLHeli-style): while commutating blind the
+	// rotor position is unknown - bound the energy driven into a possibly
+	// wrong phase (DRV8328 boards have no VDS trip). Applied here in the
+	// main loop rather than inside the O3 RAM_FUNC 20 kHz body (bench
+	// bisect showed adding code there disturbs F051 startup); the 20 kHz
+	// loop picks the capped setpoint up on its next tick.
+	if (!old_routine && running && zc_blind_steps >= 2) {
+		uint16_t blind_cap = (zc_blind_steps >= 4) ? 250 : 500;
+		if (blind_cap < min_startup_duty) {
+			blind_cap = min_startup_duty;
+		}
+		if (duty_cycle_setpoint > blind_cap) {
+			duty_cycle_setpoint = blind_cap;
+		}
+	}
 #endif
 }
 
@@ -609,22 +624,6 @@ RAM_FUNC void tenKhzRoutine()
 			}
 		} else {
 			duty_cycle = last_duty_cycle;
-		}
-
-		// Missed-ZC power cut (BLHeli-style): while commutating blind the
-		// rotor position is unknown, so bound the energy driven into a
-		// possibly wrong phase - on boards without a VDS trip (DRV8328)
-		// nothing else limits a wrong-phase current ramp. Cut is immediate
-		// (applied after the slew); recovery ramps back up through the
-		// normal slew once real crossings return and clear zc_blind_steps.
-		if (!old_routine && running && zc_blind_steps >= 2) {
-			uint16_t blind_cap = (zc_blind_steps >= 4) ? 250 : 500;
-			if (blind_cap < min_startup_duty) {
-				blind_cap = min_startup_duty;
-			}
-			if (duty_cycle > blind_cap) {
-				duty_cycle = blind_cap;
-			}
 		}
 
 		/* Inside !escInSineStart(): escIsDriving() ≡ running. */

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -611,6 +611,22 @@ RAM_FUNC void tenKhzRoutine()
 			duty_cycle = last_duty_cycle;
 		}
 
+		// Missed-ZC power cut (BLHeli-style): while commutating blind the
+		// rotor position is unknown, so bound the energy driven into a
+		// possibly wrong phase - on boards without a VDS trip (DRV8328)
+		// nothing else limits a wrong-phase current ramp. Cut is immediate
+		// (applied after the slew); recovery ramps back up through the
+		// normal slew once real crossings return and clear zc_blind_steps.
+		if (!old_routine && running && zc_blind_steps >= 2) {
+			uint16_t blind_cap = (zc_blind_steps >= 4) ? 250 : 500;
+			if (blind_cap < min_startup_duty) {
+				blind_cap = min_startup_duty;
+			}
+			if (duty_cycle > blind_cap) {
+				duty_cycle = blind_cap;
+			}
+		}
+
 		/* Inside !escInSineStart(): escIsDriving() ≡ running. */
 		if (escIsDriving() && input > 47) {
 			if (eepromBuffer.variable_pwm) {}

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -444,10 +444,16 @@ void setInput()
 	}
 	// Missed-ZC power cut (BLHeli-style): while commutating blind the
 	// rotor position is unknown - bound the energy driven into a possibly
-	// wrong phase (DRV8328 boards have no VDS trip). Applied here in the
-	// main loop rather than inside the O3 RAM_FUNC 20 kHz body (bench
-	// bisect showed adding code there disturbs F051 startup); the 20 kHz
-	// loop picks the capped setpoint up on its next tick.
+	// wrong phase (DRV8328 boards have no VDS trip). Applied here in
+	// setInput (on F051 that is the DShot EXTI IRQ, not the main loop)
+	// rather than inside the O3 RAM_FUNC 20 kHz body (bench bisect showed
+	// adding code there disturbs F051 startup). Pulling last_duty_cycle
+	// down as well makes the cut immediate: the 20 kHz slew limiter ramps
+	// from last_duty_cycle, so capping only the setpoint would let up to
+	// 37.5 ms of ramp-down stand between a blind step and the cap
+	// (max_ramp_startup while zero_crosses < 150 - live here, since blind
+	// stepping arms at 100). The 20 kHz tick may overwrite last_duty_cycle
+	// once before it sees the cap; the next DShot frame re-applies it.
 	if (!old_routine && running && zc_blind_steps >= 2) {
 		uint16_t blind_cap = (zc_blind_steps >= 4) ? 250 : 500;
 		if (blind_cap < min_startup_duty) {
@@ -455,6 +461,9 @@ void setInput()
 		}
 		if (duty_cycle_setpoint > blind_cap) {
 			duty_cycle_setpoint = blind_cap;
+		}
+		if (last_duty_cycle > blind_cap) {
+			last_duty_cycle = blind_cap;
 		}
 	}
 #endif

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -50,7 +50,7 @@ volatile uint32_t polling_mode_changeover;
 /* Missed-ZC blind-step fallback (bemf_zc.c) */
 volatile uint8_t zc_deadline_armed = 0;
 volatile uint8_t zc_blind_steps = 0;
-volatile uint32_t zc_blind_steps_total = 0;
+volatile uint8_t zc_miss_bucket = 0;
 volatile uint8_t ramp_divider;
 volatile uint8_t max_ramp_startup = RAMP_SPEED_STARTUP;
 volatile uint8_t max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -47,6 +47,10 @@ fastPID stallPid = { // 1khz loop time
 
 EEprom_t eepromBuffer;
 volatile uint32_t polling_mode_changeover;
+/* Missed-ZC blind-step fallback (bemf_zc.c) */
+volatile uint8_t zc_deadline_armed = 0;
+volatile uint8_t zc_blind_steps = 0;
+volatile uint32_t zc_blind_steps_total = 0;
 volatile uint8_t ramp_divider;
 volatile uint8_t max_ramp_startup = RAMP_SPEED_STARTUP;
 volatile uint8_t max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -95,7 +95,10 @@ void runtimeProcessDesyncCheck(void)
 		if (!old_routine && running) {
 			if (average_interval > polling_mode_changeover + 500) {
 				slow_avg_revs++;
-				if (slow_avg_revs >= 4) {
+				// High duty into an untrusted lock is the damage vector
+				// (wrong-phase drive; some boards have no VDS trip): bail
+				// after 2 revs instead of 4 when driving hard.
+				if (slow_avg_revs >= ((duty_cycle > 500) ? 2 : 4)) {
 					slow_avg_revs = 0;
 					old_routine = 1;
 				}

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -80,18 +80,24 @@ void runtimeProcessDesyncCheck(void)
 	if (desync_check && zero_crosses > 10) {
 		uint8_t desynced = (getAbsDif(last_average_interval, average_interval) > average_interval >> 1) &&
 				   (average_interval < 2000); // throttle resitricted before zc 20.
-		// Interrupt-ZC trust rail: with no runtime fallback to poll mode, a
-		// closed loop tracking artifact edges below usable BEMF (stable
-		// false lock: crossings keep arriving, so neither the blind-step
-		// deadline nor the jump check above can see it) must restart
-		// through the startup ramp instead. Only sustained slow averages
-		// count - a single lagging average during spool-up must not trip
-		// this, and transient dropouts are ridden out by blind steps.
+		// Interrupt-ZC trust rail: with no per-commutation fallback to poll
+		// mode, a closed loop tracking artifact edges below usable BEMF
+		// (stable false lock: crossings keep arriving, so neither the
+		// blind-step deadline nor the jump check above can see it) needs a
+		// way out. Sustained slow averages hand back to the poll path
+		// legacy-style - soft, no desync accounting - so a throttle chop
+		// decelerating through the band behaves exactly as before. A
+		// genuine false lock has a stationary rotor: poll then finds no
+		// real crossings and the INTERVAL_TIMER stall rail escalates to a
+		// full restart on its own. The 4-rev gate keeps the lagging
+		// average during spool-up from tripping this, and transient
+		// dropouts are ridden out by blind steps.
 		if (!old_routine && running) {
 			if (average_interval > polling_mode_changeover + 500) {
 				slow_avg_revs++;
 				if (slow_avg_revs >= 4) {
-					desynced = 1;
+					slow_avg_revs = 0;
+					old_routine = 1;
 				}
 			} else {
 				slow_avg_revs = 0;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -77,6 +77,16 @@ void runtimeProcessDesyncCheck(void)
 {
 	static uint8_t slow_avg_revs;
 	average_interval = e_com_time / 3;
+	// Any external zero_crosses reset (stall rail, stop path, bidir
+	// reversal) closes the evaluation gate below with slow_avg_revs
+	// holding a partial count; the leftover would then complete the
+	// trust-rail rev gate on the first evaluation of the NEXT closed-loop
+	// run, against a still-lagging average_interval. zero_crosses climbs
+	// one crossing at a time, so every re-acquisition passes through this
+	// window and clears the counter.
+	if (zero_crosses <= 10) {
+		slow_avg_revs = 0;
+	}
 	if (desync_check && zero_crosses > 10) {
 		uint8_t desynced = (getAbsDif(last_average_interval, average_interval) > average_interval >> 1) &&
 				   (average_interval < 2000); // throttle resitricted before zc 20.
@@ -100,7 +110,7 @@ void runtimeProcessDesyncCheck(void)
 				// after 2 revs instead of 4 when driving hard.
 				if (slow_avg_revs >= ((duty_cycle > 500) ? 2 : 4)) {
 					slow_avg_revs = 0;
-					old_routine = 1;
+					escToOpenLoop();
 				}
 			} else {
 				slow_avg_revs = 0;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -75,10 +75,32 @@ void runtimeUpdateVariablePwm(uint16_t *last_tim1_arr)
 
 void runtimeProcessDesyncCheck(void)
 {
+	static uint8_t slow_avg_revs;
 	average_interval = e_com_time / 3;
 	if (desync_check && zero_crosses > 10) {
-		if ((getAbsDif(last_average_interval, average_interval) > average_interval >> 1) &&
-		    (average_interval < 2000)) { // throttle resitricted before zc 20.
+		uint8_t desynced = (getAbsDif(last_average_interval, average_interval) > average_interval >> 1) &&
+				   (average_interval < 2000); // throttle resitricted before zc 20.
+		// Interrupt-ZC trust rail: with no runtime fallback to poll mode, a
+		// closed loop tracking artifact edges below usable BEMF (stable
+		// false lock: crossings keep arriving, so neither the blind-step
+		// deadline nor the jump check above can see it) must restart
+		// through the startup ramp instead. Only sustained slow averages
+		// count - a single lagging average during spool-up must not trip
+		// this, and transient dropouts are ridden out by blind steps.
+		if (!old_routine && running) {
+			if (average_interval > polling_mode_changeover + 500) {
+				slow_avg_revs++;
+				if (slow_avg_revs >= 4) {
+					desynced = 1;
+				}
+			} else {
+				slow_avg_revs = 0;
+			}
+		} else {
+			slow_avg_revs = 0;
+		}
+		if (desynced) {
+			slow_avg_revs = 0;
 			zero_crosses = 0;
 			desync_happened++;
 			if ((!eepromBuffer.bi_direction && (input > 47)) || commutation_interval > 1000) {

--- a/hwci/hwci/metrics.py
+++ b/hwci/hwci/metrics.py
@@ -253,6 +253,7 @@ def compute(run: RunResult, profile: Profile) -> dict:
     zc_isum = _col(rows, "perf_zc_interval_sum")
     zc_jmax = _col(rows, "perf_zc_jitter_max")
     zc_reject = _col(rows, "perf_zc_confirm_reject")
+    zc_blind = _col(rows, "perf_zc_blind_steps")
 
     steady_points = []
     for s in profile.segments:
@@ -292,6 +293,10 @@ def compute(run: RunResult, profile: Profile) -> dict:
             phase["peak_bin"] if phase else None)
         steady_points[-1]["zc_phase_hist"] = phase["hist"] if phase else None
 
+    zb_valid = np.where(~np.isnan(zc_blind))[0]
+    zc_blind_total = (_wrap32(zc_blind[zb_valid[0]], zc_blind[zb_valid[-1]])
+                      if zb_valid.size >= 2 else None)
+
     demag = detect_demag(run, profile)
     starts = startup_stats(run, profile)
     smoke = evaluate_smoke_gates(run, profile, demag=demag,
@@ -328,6 +333,10 @@ def compute(run: RunResult, profile: Profile) -> dict:
              if p.get("zc_jitter_max_pct") is not None), default=None),
         "demag_events": demag["event_count"],
         "bemf_timeout_samples": demag["bemf_timeout_samples"],
+        # blind (deadline-extrapolated) commutations over the whole run
+        # (struct v7+ monotonic counter; None on older firmware). Zero on a
+        # healthy loop; a short burst at commanded stop is designed teardown.
+        "zc_blind_steps_total": zc_blind_total,
         # start-attempt outcomes; None/0 unless the profile has start* segments
         "start_attempts": starts["attempts"] or None,
         "start_failures": starts["failures"] if starts["attempts"] else None,

--- a/hwci/hwci/model.py
+++ b/hwci/hwci/model.py
@@ -46,6 +46,8 @@ COLUMNS = [
     # bidirectional DShot health (struct v6+)
     "perf_dshot_rx_good", "perf_dshot_rx_bad", "perf_dshot_tx_frames",
     "perf_dshot_last_com_us", "perf_dshot_telem_mode", "perf_dshot_edt_mode",
+    # missed-ZC blind commutation counter (struct v7+)
+    "perf_zc_blind_steps",
 ]
 
 
@@ -126,6 +128,8 @@ def make_row(t: float, segment: str, throttle_cmd: float,
                 perf_dshot_telem_mode=r["dshot_telem_mode"],
                 perf_dshot_edt_mode=r["dshot_edt_mode"],
             )
+        if "zc_blind_steps" in r:  # struct v7+
+            row.update(perf_zc_blind_steps=r["zc_blind_steps"])
     return row
 
 

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 
 # ASCII "HWC1" little-endian == 0x31435748
 MAGIC = 0x31435748
-VERSION = 6
+VERSION = 7
 
 # (name, struct_code).  Order and codes must match Inc/hwci_perf.h exactly.
 # Pad fields are decoded then dropped from the public dict.
@@ -94,11 +94,16 @@ FIELDS_V6: list[tuple[str, str]] = FIELDS_V5 + [
     ("dshot_edt_mode", "B"),
 ]
 
-FIELDS = FIELDS_V6
+# v7 appends the missed-ZC blind commutation counter (HWCI_PERF_BLIND_STEP).
+FIELDS_V7: list[tuple[str, str]] = FIELDS_V6 + [
+    ("zc_blind_steps", "I"),
+]
+
+FIELDS = FIELDS_V7
 
 FIELDS_BY_VERSION: dict[int, list[tuple[str, str]]] = {
     1: FIELDS_V1, 2: FIELDS_V2, 3: FIELDS_V3, 4: FIELDS_V4,
-    5: FIELDS_V5, 6: FIELDS_V6}
+    5: FIELDS_V5, 6: FIELDS_V6, 7: FIELDS_V7}
 
 
 def _field_count(code: str) -> int:
@@ -114,7 +119,7 @@ _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
-SIZE = SIZE_BY_VERSION[VERSION]  # 168 bytes (v5: 152, v4: 148, v3: 84, v2: 80, v1: 64)
+SIZE = SIZE_BY_VERSION[VERSION]  # 172 bytes (v6: 168, v5: 152, v4: 148, v3: 84, v2: 80, v1: 64)
 _NAMES = [name for name, _ in FIELDS]
 
 # magic + version + size header, enough to pick the right layout for the rest.

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -52,7 +52,11 @@ class PerfReader:
             return
         # Pick the canonical layout matching the firmware's vintage by probing
         # for version-marker members, then verify every field of THAT layout.
-        if "esc_state" in members:
+        if "zc_blind_steps" in members:
+            fields = perf.FIELDS_V7
+        elif "dshot_rx_good" in members:
+            fields = perf.FIELDS_V6
+        elif "esc_state" in members:
             fields = perf.FIELDS_V5
         elif "zc_phase_hist" in members:
             fields = perf.FIELDS_V4

--- a/hwci/tests/test_elf.py
+++ b/hwci/tests/test_elf.py
@@ -10,7 +10,7 @@ from hwci import elf, perf  # noqa: E402
 
 def test_find_symbol(host_perf_elf):
     sym = elf.find_symbol(host_perf_elf, "hwci_perf")
-    assert sym.size == perf.SIZE == 168
+    assert sym.size == perf.SIZE == 172
 
 
 def test_dwarf_layout_matches_canonical(host_perf_elf):

--- a/hwci/tests/test_perf.py
+++ b/hwci/tests/test_perf.py
@@ -12,7 +12,8 @@ def test_layout_sizes():
     assert perf.SIZE_BY_VERSION[3] == 84
     assert perf.SIZE_BY_VERSION[4] == 148
     assert perf.SIZE_BY_VERSION[5] == 152
-    assert perf.SIZE == perf.SIZE_BY_VERSION[6] == 168
+    assert perf.SIZE_BY_VERSION[6] == 168
+    assert perf.SIZE == perf.SIZE_BY_VERSION[7] == 172
 
 
 def test_host_cmd_offset_matches_layout():
@@ -166,7 +167,7 @@ def test_v6_roundtrip_bdshot_fields():
         "dshot_last_com_us": 420,
         "dshot_telem_mode": 1,
         "dshot_edt_mode": 1,
-    })
+    }, version=6)
     assert len(blob) == 168
     r = perf.decode(blob).raw
     assert r["dshot_rx_good"] == 120000
@@ -175,4 +176,16 @@ def test_v6_roundtrip_bdshot_fields():
     assert r["dshot_last_com_us"] == 420
     assert r["dshot_telem_mode"] == 1
     assert r["dshot_edt_mode"] == 1
+    assert r["esc_state"] == 5
+    assert "zc_blind_steps" not in r
+
+
+def test_v7_roundtrip_blind_steps():
+    blob = perf.encode({
+        "esc_state": 5,
+        "zc_blind_steps": 8,
+    })
+    assert len(blob) == 172
+    r = perf.decode(blob).raw
+    assert r["zc_blind_steps"] == 8
     assert r["esc_state"] == 5


### PR DESCRIPTION
# Summary

Once the motor is in interrupt closed-loop, **a missed zero-cross costs one extrapolated step instead of a mode change**. Poll mode (`old_routine`) becomes a startup/recovery-only mechanism; established closed-loop never drops back to it. This is the BLHeli commutation philosophy (timeout commutation) implemented on AM32's comparator-interrupt architecture.

**Status: bench-validated at ≤20% throttle on ARK 4IN1 F051** (full `pr41_safe_lowspin_3a` ladder green). Higher throttle and the induced-BEMF-loss duty-cut check are still pending — see *Next testing* below.

## Motivation

AM32 runs two zero-cross detectors: sampled polling (`zcfoundroutine`, blocking, driven from the 20 kHz loop) below `POLLING_MODE_THRESHOLD`, and comparator-interrupt closed loop above it. The runtime switch between them is audible and control-relevant, and the band it happens in is not exotic — it's **multirotor idle**. On a 14-pole motor at stock T=2000, closed-loop entry is ~1,430 RPM and exit ~1,140 RPM; a low-KV heavy-lift quad idles and descends right around that band, flipping modes in flight, with poll mode's blocking waits running inside the 20 kHz control loop. A single missed crossing at speed (demag, glitch) escalates to a BEMF-timeout restart. BLHeli-family firmware has neither problem: detection timeout → blind step at extrapolated timing → resync on the next real crossing. This PR brings that per-step degradation model to AM32.

Related: #39 (raise threshold on ARK targets — directly widens this PR's closed-loop band), #40 (quality-based enter/hold — the natural next layer, see follow-ons).

## Design

1. **Missed-ZC deadline.** After each commutation, `COM_TIMER` re-arms as a deadline: expected next crossing + 50% grace. An accepted crossing cancels it by re-arming the commutation schedule (zero extra ISR entries steady-state). If it fires instead, commutate blind, taking the full elapsed time as the (late) interval measurement — timing hunts slower, the safe direction; the next real crossing resyncs immediately.
2. **Blind-step power cut.** From the 2nd consecutive blind step duty is capped at 25% (12.5% from the 4th, floored at `min_startup_duty`) — rotor position is unknown, so bound the energy; DRV8328 boards have no VDS trip. Applied to `duty_cycle_setpoint` in the main loop (not the O3 RAM_FUNC 20 kHz body).
3. **Blind-step limit.** 8 consecutive blind steps → stop, kick `INTERVAL_TIMER` past the stall threshold, and let the existing stall rail restart through normal startup on the next main-loop pass.
4. **Trust rail.** Per-rev average above `changeover+500` sustained 4 e-revs (2 when duty > 25%) → soft legacy-style handback to poll (no desync accounting). Catches stable false locks (tracking artifact edges below usable BEMF) that neither the deadline nor the desync jump-check can see; a real false lock then escalates via the stall rail since poll finds no crossings.
5. **Startup is exactly legacy.** Two guards, both bench-derived: the startup self-heal in `commutate()` (`zero_crosses < 100`) restores poll mode after noise-shrunk premature handoffs, and the deadline only arms once the loop is established (`zero_crosses ≥ 100`) so blind steps can never fight startup acquisition. Every desync/stop resets `zero_crosses`, so all re-acquisitions pass through pure-legacy behavior.
6. **`TIM14` ARR preload disabled (F051).** Found on the bench: ARPE buffered every `ARR` write one update event late. Latent for years — legacy's writers all wrote ~`waitTime`, so a stale value was indistinguishable. This PR's deadline was the first code to alternate ARR values; with preload on, commutation and deadline values arrived swapped, randomly racing genuine crossings. Fleet audit: G431 (TIM16) already has preload off; L431 has the same latent bug but is dropped from this fork.

## Testing done

**Bench (ARK 4IN1 F051, 900KV 14-pole no-prop, 25 V / 3.2 A current-limited supply, `HWCI_PERF=1`):**
- Snap starts at 8/10/15%: closed loop in **<30 ms**, 0 blind steps, 0 desyncs, CI stable (1044–1077 ticks over 6 s at 10%)
- `pr41_safe_lowspin_3a` full ladder: **all smoke gates PASS**, 0 demag events, 0 BEMF timeouts, zc jitter 2.2% (ark-release-class)
- Deadline armed throughout and never fired on a healthy loop — blind stepping is purely a missed-crossing backstop
- SWD traces of the failure modes that drove the fix history are archived in `hwci/runs/`

**SITL:** full suite green (26/26); scenario checks for low-throttle crawl, spool, chop-to-crawl match `ark-release` behavior. Known sim caveats: the sim has no standstill comparator noise and no ARPE emulation (both hardware-only findings; ARPE now matches by construction), and the `racer_5inch` model desync-churns during spool so the blind-step layer (gated at `zero_crosses ≥ 100`) rarely arms there — it settles at baseline-equivalent RPM, inside the test band.

**Builds:** `ARK_4IN1_F051` (87.5% flash), `REF_G431`, SITL.

## Next testing & tuning

- [ ] **Induced BEMF-loss test** (≤20%, current-limited): interrupt a phase / force desync, confirm the duty cut engages (`zc_blind_steps_total` counts, current bounded) and recovery is clean
- [ ] **Ladder above 20%**, then pack-level current, only after the duty-cut check
- [ ] **High-RPM A/B vs `ark-release`** (`HWCI_PERF=1`): jitter, desync counters, confirm deadline never fires on a healthy fast loop
- [ ] **Prop-on session**: demag territory — blind-step vs real demag interaction (see follow-on #3)
- [ ] **Tuning knobs**, in likelihood order: `ZC_DEADLINE_MIN_ZC` (100 — lower engages ride-through sooner after start/desync), deadline grace (50% of CI), `ZC_BLIND_STEP_LIMIT` (8), duty caps (500/250), trust-rail revs (4/2) and its duty gate (500)
- [ ] With #39's T=5000: verify crawl band stays closed-loop down to ~570 RPM and the trust rail (T+500) doesn't clip the intended band

## Follow-on PR ideas

1. **Layer #40's quality enter/hold on top** — the composite endgame: quality gating decides *when* closed-loop is trustworthy (widens the band beyond the fixed threshold), blind-step makes closed-loop *tolerant of individual misses*. #40 is bench-ready and independently valuable.
2. **Land #39** (ARK threshold raise) — directly multiplies this PR's value; the trust rail scales with it automatically.
3. **Demag interplay** — blind-step and the #24/#25 demag work both live in the missed-crossing domain; unify the response (a demag-swallowed crossing should look like one blind step with a power cut, not a separate subsystem).
4. **Mid-band PWM aliasing fix** — separate discovery from this work: the 4500–5000 RPM growl on 14-pole motors is zero-crosses quantized to the 24 kHz PWM grid going coherent near integer PWM:commutation ratios (7:1 ≈ 4900 RPM). Candidates: spread-spectrum PWM dither (±1–2% ARR), 48 kHz option, or extending the F051 `zc_grid_comp` compensation beyond its high-speed gate. Verifiable today with the `perf_zc_phase_hist` histogram.
5. **SITL fidelity** — add standstill comparator-noise and ARR-preload emulation (regression coverage for exactly the two bugs SITL missed), calibrate the racer model's spool behavior against bench data.
6. **HWCI perf struct v6** — promote `zc_blind_steps_total` from a SWD-only RAM symbol to a proper perf field so smoke gates can assert `blind_steps == 0` on healthy profiles.
7. **Upstream the ARPE find** — `am32-firmware/AM32` carries the same latent preload on F051/L431 COM timers; harmless to stock code but a landmine for anyone re-arming the COM timer (worth an upstream PR with the write-up).