### PR TITLE
fix(hwci): app_alive must verify liveness, not just a decodable perf magic

### DIFF
--- a/hwci/hwci/runner.py
+++ b/hwci/hwci/runner.py
@@ -375,11 +375,27 @@ def _ensure_app_alive(dbg, perf_reader: PerfReader,
     def app_alive() -> bool:
         # Only a decode failure means "bootloader/no instrumentation";
         # a debugger error is a different fault and must propagate.
+        #
+        # A decodable magic is NOT enough: RAM persists across reset, so a
+        # stale perf struct still decodes when the ESC is parked in the
+        # bootloader (signal line floated high at its last reset), and it
+        # also decodes in a half-booted app whose timer ISRs never started
+        # (seen after a vector-table force-boot). Both states arm nothing
+        # and spin nothing while looking "alive". Require the main loop to
+        # actually be advancing before trusting the app.
+        # ... and the 20 kHz/ADC path to be live: a half-booted app keeps
+        # the main loop spinning but never reads the ADC, so its reported
+        # battery voltage stays exactly 0 on a powered ESC.
         try:
-            perf_reader.read()
-            return True
+            first = perf_reader.read()
         except PerfDecodeError:
             return False
+        time.sleep(0.05)
+        try:
+            second = perf_reader.read()
+        except PerfDecodeError:
+            return False
+        return second.loop_iters != first.loop_iters and second.voltage > 0.0
 
     if app_alive():
         return

--- a/hwci/tests/test_app_alive.py
+++ b/hwci/tests/test_app_alive.py
@@ -5,6 +5,14 @@ the AM32 bootloader then never jumps to the app after a flash/power-cycle
 (observed on the ARK 4IN1 bench: perf magic reads 0x00000000, PC loops in the
 bootloader). The runner must drive zero throttle, reset, and wait for the
 app's magic instead of handing a dead perf channel to the run.
+
+A decodable magic alone is NOT liveness (both observed on the bench
+2026-07-21):
+- RAM persists across reset, so a stale perf struct still decodes while the
+  ESC is parked in the bootloader -> loop_iters frozen.
+- A half-booted app (vector-table force-boot) keeps the main loop spinning
+  but its timer ISRs/ADC never start -> loop_iters advances, voltage == 0,
+  and the ESC can never arm.
 """
 from __future__ import annotations
 
@@ -14,17 +22,33 @@ from hwci.perf import PerfDecodeError
 from hwci.runner import _ensure_app_alive
 
 
-class FakeReader:
-    """perf_reader.read() fails until the fake target has been reset."""
+class FakeSample:
+    def __init__(self, loop_iters: int, voltage: float):
+        self.loop_iters = loop_iters
+        self.voltage = voltage
 
-    def __init__(self, alive_after_resets: int):
+
+class FakeReader:
+    """Dead in a configurable way until the fake target has been reset."""
+
+    def __init__(self, alive_after_resets: int, dead_mode: str = "raise"):
         self.alive_after_resets = alive_after_resets
+        self.dead_mode = dead_mode
         self.resets = 0
+        self._iters = 0
 
     def read(self):
         if self.resets >= self.alive_after_resets:
-            return object()
-        raise PerfDecodeError("bad magic 0x00000000")
+            self._iters += 1
+            return FakeSample(self._iters, 25.2)
+        if self.dead_mode == "raise":
+            raise PerfDecodeError("bad magic 0x00000000")
+        if self.dead_mode == "frozen":
+            return FakeSample(0, 0.0)  # stale RAM: decodes, never advances
+        if self.dead_mode == "novolt":
+            self._iters += 1
+            return FakeSample(self._iters, 0.0)  # half-boot: ADC dead
+        raise AssertionError(self.dead_mode)
 
 
 class FakeDbg:
@@ -61,6 +85,26 @@ def test_stuck_in_bootloader_recovers_via_reset():
     assert reader.resets == 1
     # the signal must be DROPPED (not DShot-at-zero) before the reset so the
     # line is driven low and the bootloader jumps to the app
+    assert throttle.commands == ["quiesce"]
+
+
+def test_stale_magic_frozen_main_loop_recovers_via_reset():
+    # Bootloader resident with the previous app run's perf struct still in
+    # RAM: magic decodes but loop_iters never advances.
+    reader = FakeReader(alive_after_resets=1, dead_mode="frozen")
+    dbg, throttle = FakeDbg(reader), FakeThrottle()
+    _ensure_app_alive(dbg, reader, throttle)
+    assert reader.resets == 1
+    assert throttle.commands == ["quiesce"]
+
+
+def test_half_booted_app_zero_voltage_recovers_via_reset():
+    # Main loop advancing but ADC/20 kHz path dead (voltage exactly 0):
+    # the ESC would accept DShot yet never arm. Must be reset, not trusted.
+    reader = FakeReader(alive_after_resets=1, dead_mode="novolt")
+    dbg, throttle = FakeDbg(reader), FakeThrottle()
+    _ensure_app_alive(dbg, reader, throttle)
+    assert reader.resets == 1
     assert throttle.commands == ["quiesce"]
 
 


### PR DESCRIPTION
Found while bench-validating PR #41's rebase: two dead ESC states pass the old "perf magic decodes" check, so `_ensure_app_alive` skipped its recovery reset and handed a never-arming ESC to the run (all gates fail with `armed=0` for the full 30 s).

1. **Bootloader-resident with stale RAM** — RAM persists across reset, so the previous app run's perf struct still decodes while the ESC is parked in the bootloader (signal line floated high at its last reset, e.g. after a script tears the stand output down and the firmware's signal-loss `NVIC_SystemReset` fires). Tell: `loop_iters` frozen.
2. **Half-booted app** (vector-table force-boot, what the flash helper can leave behind) — main loop advances and DShot RX works, but the timer-ISR/ADC path never starts. Tells: reported battery voltage exactly 0, arm counter never accumulates.

`app_alive()` now requires `loop_iters` advancing across a 50 ms window **and** nonzero reported battery voltage; otherwise the existing quiesce → reset → wait recovery path runs.

Bench-verified: with the ESC deliberately in state 1, `hwci run` now auto-recovers and the `pr41_safe_lowspin_3a` profile passes (previously 0/4 gates). 318 offline tests pass (2 new regression tests, one per dead state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)