### PR TITLE
feat(hwci): auto-tune minimum_duty_cycle from low-throttle crawl

### DIFF
--- a/hwci/README.md
+++ b/hwci/README.md
@@ -202,16 +202,17 @@ staircase, the primary baseline), `demag_step_stress` (aggressive steps).
 
 Given a motor/prop on the rig, `hwci tune` automatically searches the AM32
 EEPROM settings (`advance_level`, `pwm_frequency`, `variable_pwm`,
-`auto_advance`, `max_ramp`, …) for the combination that maximizes efficiency
-(g/W), subject to hard constraints: no demag/desync/bemf timeouts, zero-cross
-jitter not regressed vs the default settings, temperatures bounded, and
-reliable startup. **No rebuild per trial**: AM32 reads its 192-byte EEprom
-page once at boot, so each trial one-shot-flashes the page over SWD (+ reset)
-and runs a ~28 s probe. The live page address is read from the firmware's
-`eeprom_address` global (the bootloader can relocate it) and the field
-offsets are cross-checked against the flashed ELF's DWARF before anything is
-written. Trial blobs are seeded from the device's current page and mutate
-only the tuned bytes, so version/identity bytes and rig calibration survive.
+`auto_advance`, `max_ramp`, `minimum_duty_cycle`, …) for the combination that
+maximizes efficiency (g/W), subject to hard constraints: no demag/desync/bemf
+timeouts, zero-cross jitter not regressed vs the default settings,
+temperatures bounded, and reliable startup. **No rebuild per trial**: AM32
+reads its 192-byte EEprom page once at boot, so each trial one-shot-flashes
+the page over SWD (+ reset) and runs a ~28 s probe. The live page address is
+read from the firmware's `eeprom_address` global (the bootloader can relocate
+it) and the field offsets are cross-checked against the flashed ELF's DWARF
+before anything is written. Trial blobs are seeded from the device's current
+page and mutate only the tuned bytes, so version/identity bytes and rig
+calibration survive.
 
 ```bash
 hwci tune --spec tunes/example.yaml --config rig.yaml --battery-cells 4 \
@@ -230,7 +231,11 @@ steady probe points (points under `min_power_w` are bench noise and never
 score); `constraints:` are hard disqualifiers, never traded against score. A
 `constraint_only: true` sweep (e.g. `max_ramp` on the step-stress profile)
 tries values in listed order and picks the first with zero failures — list
-them best-first.
+them best-first. Measure stages derive settings from physics rather than
+scoring g/W: `measure: ramp_rate` sets `max_ramp` from the powertrain step
+response; `measure: min_duty` crawls low throttle, finds the sustain floor,
+and programs `minimum_duty_cycle` (with `margin` as pack-sag headroom,
+typically 1.15) so DShot-idle commands cannot under-power a heavy prop.
 
 **Noise handling**: same-firmware g/W spread reaches ~10 % on the bench and
 the pack sags within a session, so the incumbent is re-run every

--- a/hwci/hwci/report.py
+++ b/hwci/hwci/report.py
@@ -237,6 +237,7 @@ _CONFIGURATOR_LABELS = {
     "pwm_frequency": "PWM Frequency",
     "variable_pwm": "Variable PWM",
     "max_ramp": "Ramp Speed",
+    "minimum_duty_cycle": "Minimum Duty Cycle",
     "startup_power": "Startup Power",
     "auto_advance": "Auto Timing Advance",
 }
@@ -258,6 +259,10 @@ def _configurator_value(name: str, raw) -> str | None:
         return _VARIABLE_PWM_LABELS.get(raw, str(raw))
     if name == "max_ramp":
         return f"{raw * 0.1:.1f} %/ms"
+    if name == "minimum_duty_cycle":
+        # EEPROM unit * 10 duty counts / 2000 = 0.5% per unit
+        # (Src/settings.c: minimum_duty_cycle = eeprom * 10).
+        return f"{raw * 0.5:.1f}%"
     if name == "startup_power":
         return f"{raw}%"
     if name == "auto_advance":

--- a/hwci/hwci/settings.py
+++ b/hwci/hwci/settings.py
@@ -72,6 +72,10 @@ class Field:
 EEPROM_FIELDS: dict[str, Field] = {f.name: f for f in [
     Field("max_ramp", 5, 1, 255,
           "throttle ramp limit, 0.1%/ms steps up to 25%/ms (default 160)"),
+    # loadEEpromSettings: 1..50 accepted (value*10 duty counts of 2000);
+    # 0 or >=51 fall back to zero floor (firmware default path).
+    Field("minimum_duty_cycle", 6, 1, 50,
+          "min PWM duty floor, eeprom units of 0.5% (1=0.5% .. 50=25%)"),
     Field("variable_pwm", 21, 0, 2,
           "0=fixed PWM, 1=RPM-scaled within pwm_frequency range, 2=auto range"),
     Field("advance_level", 23, 10, 42,

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -34,6 +34,7 @@ class SimSettings:
     auto_advance: int = 0
     startup_power: int = 100
     max_ramp: int = 160
+    minimum_duty_cycle: int = 1
 
     @classmethod
     def from_blob(cls, blob: bytes) -> "SimSettings":
@@ -43,7 +44,8 @@ class SimSettings:
                    variable_pwm=s.get("variable_pwm"),
                    auto_advance=s.get("auto_advance"),
                    startup_power=s.get("startup_power"),
-                   max_ramp=s.get("max_ramp"))
+                   max_ramp=s.get("max_ramp"),
+                   minimum_duty_cycle=s.get("minimum_duty_cycle"))
 
 
 @dataclass
@@ -83,6 +85,11 @@ class MotorParams:
     # (clipped to [0, 0.9]): 50 -> 0.5, 100 -> ~0.12, 150 -> 0.
     startup_fail_ref: float = 115.0
     startup_fail_scale: float = 130.0
+    # Lowest host-throttle fraction at which the plant can sustain rotation
+    # (prop aero / friction). 0 disables the model (legacy). The firmware's
+    # minimum_duty_cycle (eeprom units / 200 ≈ duty fraction) floors the
+    # effective throttle when the host commands below it - see step().
+    sustain_throttle: float = 0.0
 
 
 @dataclass
@@ -169,9 +176,25 @@ class RigSimulator:
         throttle = max(0.0, min(1.0, throttle))
         cmd_jump = throttle - self._prev_cmd
 
+        # Firmware minimum_duty_cycle floors PWM duty when the host is above
+        # zero: eeprom unit S maps to S*10 duty counts of 2000 = S/200 as a
+        # host-throttle equivalent (Src/settings.c).
+        eff_throttle = throttle
+        if self.settings is not None and throttle > 0.005:
+            floor = self.settings.minimum_duty_cycle / 200.0
+            if floor > eff_throttle:
+                eff_throttle = floor
+
         # Detect a demag/desync trigger: a big, fast throttle increase into a
         # high-current regime on a demag-prone motor.
-        target_rpm = throttle * self._rpm_max()
+        target_rpm = eff_throttle * self._rpm_max()
+
+        # Plant sustain floor: props that need more than the effective duty
+        # stall / kick-loop (RPM collapses). Disabled when sustain_throttle
+        # is 0 so legacy tests stay bit-identical.
+        if (p.sustain_throttle > 0.0 and throttle > 0.005
+                and eff_throttle < p.sustain_throttle):
+            target_rpm = 0.0
 
         # Startup reliability model (settings runs only): each stopped->spin
         # transition is a start attempt that fails with a probability set by

--- a/hwci/hwci/sim.py
+++ b/hwci/hwci/sim.py
@@ -178,9 +178,11 @@ class RigSimulator:
 
         # Firmware minimum_duty_cycle floors PWM duty when the host is above
         # zero: eeprom unit S maps to S*10 duty counts of 2000 = S/200 as a
-        # host-throttle equivalent (Src/settings.c).
+        # host-throttle equivalent (Src/settings.c). Any positive throttle
+        # must get the floor — DShot idle is thr ≈ (48-48)/1999 ≈ 0 on the
+        # Flight Stand map (tiny epsilon), far below 0.5%.
         eff_throttle = throttle
-        if self.settings is not None and throttle > 0.005:
+        if self.settings is not None and throttle > 0.0:
             floor = self.settings.minimum_duty_cycle / 200.0
             if floor > eff_throttle:
                 eff_throttle = floor
@@ -192,7 +194,7 @@ class RigSimulator:
         # Plant sustain floor: props that need more than the effective duty
         # stall / kick-loop (RPM collapses). Disabled when sustain_throttle
         # is 0 so legacy tests stay bit-identical.
-        if (p.sustain_throttle > 0.0 and throttle > 0.005
+        if (p.sustain_throttle > 0.0 and throttle > 0.0
                 and eff_throttle < p.sustain_throttle):
             target_rpm = 0.0
 

--- a/hwci/hwci/tuner/__init__.py
+++ b/hwci/hwci/tuner/__init__.py
@@ -20,7 +20,10 @@ Package layout:
 from __future__ import annotations
 
 from .backends import HwTuneBackend, SimTuneBackend, TuneBackend
-from .minduty import compute_min_duty, sustain_throttle_from_rows
+from .minduty import (compute_min_duty, compute_min_duty_for_idle,
+                      dshot_to_host_throttle, duty_counts_at_dshot,
+                      host_throttle_to_dshot, sustain_dshot_from_rows,
+                      sustain_throttle_from_rows)
 from .objective import check_constraints, objective_score, startup_stats
 from .profiles import (RAMP_TRANSIENT_MAX_CURRENT_A, high_throttle_profile,
                        min_duty_measure_profile, min_duty_verify_profile,
@@ -68,9 +71,13 @@ __all__ = [
     "climb",
     "compute_max_ramp",
     "compute_min_duty",
+    "compute_min_duty_for_idle",
     "drift_factor",
+    "dshot_to_host_throttle",
+    "duty_counts_at_dshot",
     "efficiency_argmax",
     "high_throttle_profile",
+    "host_throttle_to_dshot",
     "load_pilot_card",
     "load_tune_spec",
     "mech_ramp_stats",
@@ -85,6 +92,7 @@ __all__ = [
     "startup_profile",
     "startup_stats",
     "step_profile",
+    "sustain_dshot_from_rows",
     "sustain_throttle_from_rows",
     "tune_spec_from_dict",
     "winner_reason",

--- a/hwci/hwci/tuner/__init__.py
+++ b/hwci/hwci/tuner/__init__.py
@@ -1,16 +1,18 @@
 """Auto settings tuner: find the best AM32 EEPROM settings for a motor/prop.
 
 Given a motor/prop on the rig, ``hwci tune`` searches the AM32 settings space
-(advance_level, pwm_frequency, variable_pwm, auto_advance, max_ramp, ...) for
-the combination that maximizes efficiency (g/W) subject to hard constraints.
+(advance_level, pwm_frequency, variable_pwm, auto_advance, max_ramp,
+minimum_duty_cycle, ...) for the combination that maximizes efficiency (g/W)
+subject to hard constraints.
 
 Package layout:
 
 * :mod:`hwci.tuner.spec` -- strict YAML schema
-* :mod:`hwci.tuner.profiles` -- probe / startup / step / ramp profiles
+* :mod:`hwci.tuner.profiles` -- probe / startup / step / ramp / min-duty profiles
 * :mod:`hwci.tuner.objective` -- scoring and constraint checks
 * :mod:`hwci.tuner.search` -- climb, normalize, pick_winner
 * :mod:`hwci.tuner.ramp` -- mech step-response max_ramp physics
+* :mod:`hwci.tuner.minduty` -- low-throttle crawl → minimum_duty_cycle
 * :mod:`hwci.tuner.backends` -- sim and hardware trial backends
 * :mod:`hwci.tuner.session` -- Tuner session, resume, stages, finals
 * :mod:`hwci.tuner.report` -- markdown report builders
@@ -18,8 +20,10 @@ Package layout:
 from __future__ import annotations
 
 from .backends import HwTuneBackend, SimTuneBackend, TuneBackend
+from .minduty import compute_min_duty, sustain_throttle_from_rows
 from .objective import check_constraints, objective_score, startup_stats
 from .profiles import (RAMP_TRANSIENT_MAX_CURRENT_A, high_throttle_profile,
+                       min_duty_measure_profile, min_duty_verify_profile,
                        probe_profile, ramp_measure_profile, startup_profile,
                        step_profile)
 from .ramp import compute_max_ramp, mech_ramp_stats
@@ -63,12 +67,15 @@ __all__ = [
     "check_constraints",
     "climb",
     "compute_max_ramp",
+    "compute_min_duty",
     "drift_factor",
     "efficiency_argmax",
     "high_throttle_profile",
     "load_pilot_card",
     "load_tune_spec",
     "mech_ramp_stats",
+    "min_duty_measure_profile",
+    "min_duty_verify_profile",
     "normalize",
     "objective_score",
     "pick_winner",
@@ -78,6 +85,7 @@ __all__ = [
     "startup_profile",
     "startup_stats",
     "step_profile",
+    "sustain_throttle_from_rows",
     "tune_spec_from_dict",
     "winner_reason",
     "write_pilot_card",

--- a/hwci/hwci/tuner/minduty.py
+++ b/hwci/hwci/tuner/minduty.py
@@ -1,0 +1,115 @@
+"""Measure the lowest sustainable throttle and map it to minimum_duty_cycle.
+
+EEPROM ``minimum_duty_cycle`` (offset 6) is the PWM duty floor applied when
+the host is above zero. Firmware (Src/settings.c) multiplies the eeprom unit
+by 10 to get duty counts out of 2000, so one unit is 0.5% of full duty:
+
+    duty_fraction ≈ S / 200
+
+On a prop that needs ~2.9% duty to sustain (PR #41 crawl findings), the
+default floor of 1-4 leaves DShot idle/low commands under-powered → endless
+kick loop. The auto-tuner crawls down throttle, finds the lowest hold that
+still spins, and programs ``ceil(t * 200 * margin)`` with margin ≥ 1 for
+pack-sag headroom.
+"""
+from __future__ import annotations
+
+import math
+import statistics
+from typing import Optional
+
+
+# Host throttle fraction → continuous eeprom units (S/200 ≈ duty fraction).
+THROTTLE_TO_EEPROM = 200.0
+
+
+def _fget(r: dict, key: str) -> Optional[float]:
+    v = r.get(key)
+    try:
+        return float(v) if v not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def sustain_throttle_from_rows(
+        rows: list[dict], *,
+        min_rpm: float = 400.0,
+        pole_pairs: int = 7) -> Optional[dict]:
+    """Lowest steady-segment host throttle that sustains rotation.
+
+    Expects a descending crawl profile (spin-up, then steady holds). A hold
+    sustains when the median of stand RPM and (perf eRPM / pole_pairs) in the
+    second half of the segment is ≥ ``min_rpm``. Returns None when no hold
+    sustains (or there are no steady segments).
+    """
+    segs: dict[str, list[dict]] = {}
+    order: list[str] = []
+    for r in rows:
+        lbl = str(r.get("segment") or "")
+        if lbl not in segs:
+            segs[lbl] = []
+            order.append(lbl)
+        segs[lbl].append(r)
+
+    holds: list[tuple[float, str, float]] = []  # (throttle, label, med_rpm)
+    for lbl in order:
+        seg = segs[lbl]
+        if not seg:
+            continue
+        # Only steady-style holds: skip idle/spinup/rampdn labels that are
+        # not constant-throttle crawl points. Prefer rows tagged steady via
+        # a non-zero throttle_cmd held for the segment.
+        thr = _fget(seg[-1], "throttle_cmd")
+        if thr is None or thr < 0.015:
+            continue
+        if lbl in ("idle", "spinup", "spool", "rampdn") or lbl.startswith("r_"):
+            continue
+        tail = seg[len(seg) // 2:]
+        rpms: list[float] = []
+        for r in tail:
+            stand = _fget(r, "stand_rpm")
+            e_rpm = _fget(r, "perf_e_rpm")
+            cands = []
+            if stand is not None:
+                cands.append(stand)
+            if e_rpm is not None and pole_pairs > 0:
+                cands.append(e_rpm / pole_pairs)
+            if cands:
+                rpms.append(max(cands))
+        if not rpms:
+            continue
+        med = statistics.median(rpms)
+        holds.append((thr, lbl, med))
+
+    if not holds:
+        return None
+
+    # Prefer lower throttle when several holds pass; if none pass, None.
+    sustained = [(t, lbl, rpm) for t, lbl, rpm in holds if rpm >= min_rpm]
+    if not sustained:
+        return None
+    thr, lbl, rpm = min(sustained, key=lambda x: x[0])
+    failed = [(t, lbl, rpm) for t, lbl, rpm in holds if rpm < min_rpm]
+    return {
+        "sustain_throttle": thr,
+        "sustain_segment": lbl,
+        "sustain_rpm": rpm,
+        "holds": len(holds),
+        "failed_holds": len(failed),
+        "lowest_hold": min(t for t, _, _ in holds),
+        "highest_hold": max(t for t, _, _ in holds),
+    }
+
+
+def compute_min_duty(sustain_throttle: float, *, lo: int, hi: int,
+                     margin: float = 1.15) -> int:
+    """EEPROM ``minimum_duty_cycle`` from a measured sustain throttle.
+
+    ``margin`` ≥ 1.0 adds pack-sag / measurement headroom (1.15 ≈ +15%).
+    Clamped to the firmware-valid range.
+    """
+    if sustain_throttle <= 0:
+        return lo
+    raw = sustain_throttle * THROTTLE_TO_EEPROM * max(margin, 0.1)
+    setting = int(math.ceil(raw - 1e-9))
+    return max(lo, min(hi, setting))

--- a/hwci/hwci/tuner/minduty.py
+++ b/hwci/hwci/tuner/minduty.py
@@ -1,16 +1,25 @@
-"""Measure the lowest sustainable throttle and map it to minimum_duty_cycle.
+"""Measure plant sustain duty and map it to ``minimum_duty_cycle``.
 
-EEPROM ``minimum_duty_cycle`` (offset 6) is the PWM duty floor applied when
-the host is above zero. Firmware (Src/settings.c) multiplies the eeprom unit
-by 10 to get duty counts out of 2000, so one unit is 0.5% of full duty:
+EEPROM ``minimum_duty_cycle`` (offset 6) is the PWM duty *floor* applied at
+any non-zero throttle. Firmware (Src/settings.c) multiplies the eeprom unit
+by 10 to get duty counts out of 2000; the throttle map is then
+(Src/control_loop.c, non-sine)::
 
-    duty_fraction ≈ S / 200
+    duty = min_duty                 if input <= 47
+    duty = min_duty + (input-47)*slope   otherwise
+    slope = (2000 - min_duty) / (2047 - 47)
 
-On a prop that needs ~2.9% duty to sustain (PR #41 crawl findings), the
-default floor of 1-4 leaves DShot idle/low commands under-powered → endless
-kick loop. The auto-tuner crawls down throttle, finds the lowest hold that
-still spins, and programs ``ceil(t * 200 * margin)`` with margin ≥ 1 for
-pack-sag headroom.
+So at DShot 48 (first real step) duty ≈ floor alone. The auto-tuner must
+choose a floor high enough that **DShot idle (48)** sustains the prop — not
+merely that some mid-low host-percent hold spun during a crawl.
+
+Host throttle on the Flight Stand maps as::
+
+    DShot = 48 + throttle * (2047 - 48)   for throttle > 0
+    DShot = 0                             for throttle == 0  (disarm)
+
+so host 2% ≈ DShot 88, which is *above* the kick-loop band (≈48–65) the
+pilot cares about. Measure/verify profiles therefore speak in DShot units.
 """
 from __future__ import annotations
 
@@ -18,9 +27,86 @@ import math
 import statistics
 from typing import Optional
 
+# DShot / duty map constants matching AM32 + the Flight Stand rig mapping.
+DSHOT_IDLE = 48
+DSHOT_MAX = 2047
+DUTY_MAX = 2000
+# Host throttle just above zero maps near DShot 48; thr==0 is disarm (DShot 0).
+_HOST_EPS = 1.0 / (DSHOT_MAX - DSHOT_IDLE)   # → raw ≈ 49 if used as thr
 
-# Host throttle fraction → continuous eeprom units (S/200 ≈ duty fraction).
-THROTTLE_TO_EEPROM = 200.0
+
+def dshot_to_host_throttle(dshot: float) -> float:
+    """Host throttle fraction that commands approximately ``dshot``.
+
+    ``throttle == 0`` is reserved for disarm (DShot 0). The first real step
+    (DShot 48) is reached with a tiny positive fraction; larger values use
+    the linear esc_min..esc_max map.
+    """
+    d = float(dshot)
+    if d <= 0:
+        return 0.0
+    if d <= DSHOT_IDLE:
+        # Smallest positive step: Flight Stand raw = 48 + thr*1999.
+        # thr = 0.25/1999 keeps raw in (48, 49) so the ESC sees idle-band.
+        return 0.25 / (DSHOT_MAX - DSHOT_IDLE)
+    return (d - DSHOT_IDLE) / (DSHOT_MAX - DSHOT_IDLE)
+
+
+def host_throttle_to_dshot(throttle: float) -> float:
+    """Inverse of :func:`dshot_to_host_throttle` (0 → 0, else ≥ 48)."""
+    thr = max(0.0, min(1.0, float(throttle)))
+    if thr <= 0.0:
+        return 0.0
+    return DSHOT_IDLE + thr * (DSHOT_MAX - DSHOT_IDLE)
+
+
+def duty_counts_at_dshot(dshot: float, eeprom_s: int) -> float:
+    """Firmware duty counts (0..2000) for a DShot input and eeprom min-duty."""
+    min_duty = max(0, int(eeprom_s)) * 10
+    d = float(dshot)
+    if d <= 47:
+        return float(min_duty)
+    slope = (DUTY_MAX - min_duty) / (DSHOT_MAX - 47)
+    return min_duty + (d - 47) * slope
+
+
+def compute_min_duty_for_idle(sustain_dshot: float, *, lo: int, hi: int,
+                              margin: float = 1.15,
+                              measure_eeprom: int = 1) -> int:
+    """EEPROM ``minimum_duty_cycle`` so DShot idle duty covers the plant need.
+
+    ``sustain_dshot`` is the lowest DShot that still spun during a measure
+    run with ``measure_eeprom`` programmed (typically the floor, 1). The
+    duty at that point is the plant's sustain requirement; we raise the
+    floor until duty at :data:`DSHOT_IDLE` meets that need times ``margin``.
+    """
+    if sustain_dshot <= 0:
+        return lo
+    d_need = duty_counts_at_dshot(sustain_dshot, measure_eeprom)
+    target = d_need * max(margin, 0.1)
+    # duty(DSHOT_IDLE, S) = S*10 + (48-47)*slope ≈ S*10 + (2000-S*10)/2000
+    # Solve S*10 + (2000 - S*10)/2000 >= target  →  S*10 * 1999/2000 + 1 >= target
+    # → S*10 >= (target - 1) * 2000/1999
+    raw_counts = max(0.0, (target - 1.0) * DUTY_MAX / (DSHOT_MAX - 47))
+    setting = int(math.ceil(raw_counts / 10.0 - 1e-9))
+    # Also never go below ceil(target/10): the pure-floor approximation.
+    setting = max(setting, int(math.ceil(target / 10.0 - 1e-9)))
+    return max(lo, min(hi, setting))
+
+
+# Back-compat alias used by older tests / call sites.
+def compute_min_duty(sustain_throttle: float, *, lo: int, hi: int,
+                     margin: float = 1.15) -> int:
+    """Deprecated host-throttle form; prefer :func:`compute_min_duty_for_idle`.
+
+    Treats host throttle as duty fraction (S/200) — wrong for DShot idle
+    targeting, kept only so older unit tests and call sites keep working.
+    """
+    if sustain_throttle <= 0:
+        return lo
+    raw = sustain_throttle * 200.0 * max(margin, 0.1)
+    setting = int(math.ceil(raw - 1e-9))
+    return max(lo, min(hi, setting))
 
 
 def _fget(r: dict, key: str) -> Optional[float]:
@@ -31,16 +117,49 @@ def _fget(r: dict, key: str) -> Optional[float]:
         return None
 
 
-def sustain_throttle_from_rows(
+def _hold_is_driven(stand_rpm: float, e_rpm: Optional[float],
+                    current_a: float, *,
+                    min_rpm: float, pole_pairs: int,
+                    min_current_a: float) -> bool:
+    """True when the ESC is electrically tracking a spinning rotor.
+
+    Rejects:
+    * pure coast (stand RPM, ~0 current, eRPM collapsed)
+    * kick / false-lock (running=1 but eRPM stuck far from stand RPM)
+    Idle drive on a big prop may only draw ~0.03–0.05 A, so the current
+    floor stays low; eRPM↔stand agreement is the main gate.
+    """
+    if stand_rpm < min_rpm:
+        return False
+    if current_a < min_current_a:
+        return False
+    if e_rpm is None or pole_pairs <= 0:
+        return True
+    mech_e = e_rpm / pole_pairs
+    # Electrical path must also be above the floor (not a phantom lock at
+    # a few hundred eRPM while the prop freewheels / kick-loops).
+    if mech_e < min_rpm * 0.75:
+        return False
+    err = abs(stand_rpm - mech_e)
+    # Kick signature on this bench: stand ~350-450 RPM with eRPM stuck
+    # near 2.0-2.5k (mech ~300) — relative error 15-30%. True closed
+    # loop tracks within a few percent (see d120: 601 vs 600).
+    if err > max(80.0, 0.15 * stand_rpm):
+        return False
+    return True
+
+
+def sustain_dshot_from_rows(
         rows: list[dict], *,
         min_rpm: float = 400.0,
-        pole_pairs: int = 7) -> Optional[dict]:
-    """Lowest steady-segment host throttle that sustains rotation.
+        pole_pairs: int = 7,
+        min_current_a: float = 0.02) -> Optional[dict]:
+    """Lowest steady-segment DShot that *drives* sustained rotation.
 
-    Expects a descending crawl profile (spin-up, then steady holds). A hold
-    sustains when the median of stand RPM and (perf eRPM / pole_pairs) in the
-    second half of the segment is ≥ ``min_rpm``. Returns None when no hold
-    sustains (or there are no steady segments).
+    Segments come from ``throttle_cmd`` (→ DShot via the Flight Stand map).
+    Prefer a **descending** crawl (spin up, step down): that tests sustain
+    once spinning. An ascending-from-coast ladder tests *startup* at each
+    step and needs far more duty (startup_power boost path).
     """
     segs: dict[str, list[dict]] = {}
     order: list[str] = []
@@ -51,65 +170,71 @@ def sustain_throttle_from_rows(
             order.append(lbl)
         segs[lbl].append(r)
 
-    holds: list[tuple[float, str, float]] = []  # (throttle, label, med_rpm)
+    # (dshot, throttle, label, med_rpm, med_current, driven)
+    holds: list[tuple[float, float, str, float, float, bool]] = []
     for lbl in order:
         seg = segs[lbl]
         if not seg:
             continue
-        # Only steady-style holds: skip idle/spinup/rampdn labels that are
-        # not constant-throttle crawl points. Prefer rows tagged steady via
-        # a non-zero throttle_cmd held for the segment.
         thr = _fget(seg[-1], "throttle_cmd")
-        if thr is None or thr < 0.015:
+        if thr is None or thr <= 0.0:
             continue
-        if lbl in ("idle", "spinup", "spool", "rampdn") or lbl.startswith("r_"):
+        if lbl in ("idle", "spinup", "spool", "coast", "rampdn") \
+                or lbl.startswith("r_"):
             continue
+        dshot = host_throttle_to_dshot(thr)
         tail = seg[len(seg) // 2:]
-        rpms: list[float] = []
+        stands: list[float] = []
+        e_rpms: list[float] = []
+        currents: list[float] = []
         for r in tail:
             stand = _fget(r, "stand_rpm")
             e_rpm = _fget(r, "perf_e_rpm")
-            cands = []
+            cur = _fget(r, "stand_current_a")
             if stand is not None:
-                cands.append(stand)
-            if e_rpm is not None and pole_pairs > 0:
-                cands.append(e_rpm / pole_pairs)
-            if cands:
-                rpms.append(max(cands))
-        if not rpms:
+                stands.append(stand)
+            if e_rpm is not None:
+                e_rpms.append(e_rpm)
+            if cur is not None:
+                currents.append(abs(cur))
+        if not stands:
             continue
-        med = statistics.median(rpms)
-        holds.append((thr, lbl, med))
+        med_stand = statistics.median(stands)
+        med_e = statistics.median(e_rpms) if e_rpms else None
+        med_i = statistics.median(currents) if currents else 0.0
+        driven = _hold_is_driven(
+            med_stand, med_e, med_i,
+            min_rpm=min_rpm, pole_pairs=pole_pairs,
+            min_current_a=min_current_a)
+        holds.append((dshot, thr, lbl, med_stand, med_i, driven))
 
     if not holds:
         return None
 
-    # Prefer lower throttle when several holds pass; if none pass, None.
-    sustained = [(t, lbl, rpm) for t, lbl, rpm in holds if rpm >= min_rpm]
+    sustained = [h for h in holds if h[5]]
     if not sustained:
         return None
-    thr, lbl, rpm = min(sustained, key=lambda x: x[0])
-    failed = [(t, lbl, rpm) for t, lbl, rpm in holds if rpm < min_rpm]
+    dshot, thr, lbl, rpm, med_i, _ = min(sustained, key=lambda x: x[0])
+    failed = [h for h in holds if not h[5]]
     return {
+        "sustain_dshot": dshot,
         "sustain_throttle": thr,
         "sustain_segment": lbl,
         "sustain_rpm": rpm,
+        "sustain_current_a": med_i,
+        "sustain_duty_counts": duty_counts_at_dshot(dshot, 1),
         "holds": len(holds),
         "failed_holds": len(failed),
-        "lowest_hold": min(t for t, _, _ in holds),
-        "highest_hold": max(t for t, _, _ in holds),
+        "lowest_dshot": min(d for d, *_ in holds),
+        "highest_dshot": max(d for d, *_ in holds),
     }
 
 
-def compute_min_duty(sustain_throttle: float, *, lo: int, hi: int,
-                     margin: float = 1.15) -> int:
-    """EEPROM ``minimum_duty_cycle`` from a measured sustain throttle.
-
-    ``margin`` ≥ 1.0 adds pack-sag / measurement headroom (1.15 ≈ +15%).
-    Clamped to the firmware-valid range.
-    """
-    if sustain_throttle <= 0:
-        return lo
-    raw = sustain_throttle * THROTTLE_TO_EEPROM * max(margin, 0.1)
-    setting = int(math.ceil(raw - 1e-9))
-    return max(lo, min(hi, setting))
+# Back-compat name used by session.py / tests before the DShot rename.
+def sustain_throttle_from_rows(
+        rows: list[dict], *,
+        min_rpm: float = 400.0,
+        pole_pairs: int = 7) -> Optional[dict]:
+    """Alias of :func:`sustain_dshot_from_rows` (same return dict)."""
+    return sustain_dshot_from_rows(
+        rows, min_rpm=min_rpm, pole_pairs=pole_pairs)

--- a/hwci/hwci/tuner/profiles.py
+++ b/hwci/hwci/tuner/profiles.py
@@ -145,6 +145,67 @@ def ramp_measure_profile(spec: TuneSpec) -> Profile:
     })
 
 
+def min_duty_measure_profile(spec: TuneSpec) -> Profile:
+    """Descending crawl for the min-duty stage: spin up, step down through
+    fine low-throttle holds, park.
+
+    Holds sit in the weak-BEMF / aero-sustain band (≈2–8%) that steady
+    efficiency probes never visit. The measure trial programs
+    ``minimum_duty_cycle`` at the field floor so the firmware floor cannot
+    mask the plant's true sustain threshold; analysis then picks the lowest
+    hold that still spins.
+    """
+    safety = dict(spec.probe.safety or {})
+    # Crawl is low power; keep the probe's current/thrust caps but do not
+    # invent snap headroom (no snaps here).
+    segs = [
+        {"label": "idle",   "throttle": 0.00, "duration_s": 2.0},
+        {"label": "spinup", "throttle": 0.10, "duration_s": 3.0, "ramp": True},
+        {"label": "t08",    "throttle": 0.08, "duration_s": 3.0, "steady": True},
+        {"label": "t06",    "throttle": 0.06, "duration_s": 3.0, "steady": True},
+        {"label": "t05",    "throttle": 0.05, "duration_s": 3.0, "steady": True},
+        {"label": "t04",    "throttle": 0.04, "duration_s": 3.0, "steady": True},
+        {"label": "t035",   "throttle": 0.035, "duration_s": 3.0, "steady": True},
+        {"label": "t03",    "throttle": 0.03, "duration_s": 3.0, "steady": True},
+        {"label": "t025",   "throttle": 0.025, "duration_s": 3.0, "steady": True},
+        {"label": "t02",    "throttle": 0.02, "duration_s": 3.0, "steady": True},
+        {"label": "rampdn", "throttle": 0.00, "duration_s": 2.0, "ramp": True},
+    ]
+    return profile_from_dict({
+        "name": "tune_min_duty_measure",
+        "description": "inline low-throttle crawl for min-duty measurement "
+                       "(auto-tuner)",
+        "sample_rate_hz": 100.0,
+        "segments": segs,
+        "safety": safety or None,
+    })
+
+
+def min_duty_verify_profile(spec: TuneSpec) -> Profile:
+    """Verify a programmed minimum_duty_cycle: spin up, hold at low throttle
+    where a too-low floor would kick-loop, park.
+
+    With an adequate floor the firmware keeps duty above the plant sustain
+    threshold even when the host commands 2–3%.
+    """
+    safety = dict(spec.probe.safety or {})
+    return profile_from_dict({
+        "name": "tune_min_duty_verify",
+        "description": "inline low-throttle sustain check for min-duty "
+                       "(auto-tuner)",
+        "sample_rate_hz": 100.0,
+        "segments": [
+            {"label": "idle",   "throttle": 0.00, "duration_s": 2.0},
+            {"label": "spinup", "throttle": 0.10, "duration_s": 3.0, "ramp": True},
+            {"label": "t05",    "throttle": 0.05, "duration_s": 4.0, "steady": True},
+            {"label": "t03",    "throttle": 0.03, "duration_s": 4.0, "steady": True},
+            {"label": "t02",    "throttle": 0.02, "duration_s": 4.0, "steady": True},
+            {"label": "rampdn", "throttle": 0.00, "duration_s": 2.0, "ramp": True},
+        ],
+        "safety": safety or None,
+    })
+
+
 def high_throttle_profile(spec: TuneSpec, throttle: float,
                           dwell_s: float) -> Profile:
     """Constraint-only hold through a known desync band (e.g. t70).

--- a/hwci/hwci/tuner/profiles.py
+++ b/hwci/hwci/tuner/profiles.py
@@ -145,35 +145,45 @@ def ramp_measure_profile(spec: TuneSpec) -> Profile:
     })
 
 
-def min_duty_measure_profile(spec: TuneSpec) -> Profile:
-    """Descending crawl for the min-duty stage: spin up, step down through
-    fine low-throttle holds, park.
+def _dshot_hold(label: str, dshot: int, duration_s: float,
+                *, steady: bool = True) -> dict:
+    """Steady hold at an absolute DShot setpoint (via host throttle map)."""
+    from .minduty import dshot_to_host_throttle
+    seg = {"label": label, "throttle": dshot_to_host_throttle(dshot),
+           "duration_s": duration_s}
+    if steady:
+        seg["steady"] = True
+    return seg
 
-    Holds sit in the weak-BEMF / aero-sustain band (≈2–8%) that steady
-    efficiency probes never visit. The measure trial programs
-    ``minimum_duty_cycle`` at the field floor so the firmware floor cannot
-    mask the plant's true sustain threshold; analysis then picks the lowest
-    hold that still spins.
+
+def min_duty_measure_profile(spec: TuneSpec) -> Profile:
+    """Descending DShot crawl for min-duty: spin up, step through the idle
+    band (100 → 48), park.
+
+    Programs ``minimum_duty_cycle`` at the field floor so the firmware floor
+    cannot mask the plant; analysis finds the lowest DShot that still spins
+    and maps that duty need onto a floor that sustains at DShot 48.
     """
+    from .minduty import dshot_to_host_throttle
     safety = dict(spec.probe.safety or {})
-    # Crawl is low power; keep the probe's current/thrust caps but do not
-    # invent snap headroom (no snaps here).
-    segs = [
-        {"label": "idle",   "throttle": 0.00, "duration_s": 2.0},
-        {"label": "spinup", "throttle": 0.10, "duration_s": 3.0, "ramp": True},
-        {"label": "t08",    "throttle": 0.08, "duration_s": 3.0, "steady": True},
-        {"label": "t06",    "throttle": 0.06, "duration_s": 3.0, "steady": True},
-        {"label": "t05",    "throttle": 0.05, "duration_s": 3.0, "steady": True},
-        {"label": "t04",    "throttle": 0.04, "duration_s": 3.0, "steady": True},
-        {"label": "t035",   "throttle": 0.035, "duration_s": 3.0, "steady": True},
-        {"label": "t03",    "throttle": 0.03, "duration_s": 3.0, "steady": True},
-        {"label": "t025",   "throttle": 0.025, "duration_s": 3.0, "steady": True},
-        {"label": "t02",    "throttle": 0.02, "duration_s": 3.0, "steady": True},
-        {"label": "rampdn", "throttle": 0.00, "duration_s": 2.0, "ramp": True},
+    # Descending crawl: spin up first, then step down through the idle band.
+    # That tests *sustain* once closed-loop (what min_duty is for). Climbing
+    # from a stop tests *startup* at each DShot and needs the startup_power
+    # boost path — a different (higher) duty requirement.
+    dshots = (140, 120, 100, 80, 70, 65, 60, 55, 52, 50, 48)
+    segs: list[dict] = [
+        {"label": "idle", "throttle": 0.00, "duration_s": 2.0},
+        {"label": "spinup", "throttle": dshot_to_host_throttle(220),
+         "duration_s": 3.0, "ramp": True},
+        _dshot_hold("hold_hi", 180, 2.0),
     ]
+    for d in dshots:
+        segs.append(_dshot_hold(f"d{d}", d, 3.0))
+    segs.append({"label": "rampdn", "throttle": 0.00, "duration_s": 2.0,
+                 "ramp": True})
     return profile_from_dict({
         "name": "tune_min_duty_measure",
-        "description": "inline low-throttle crawl for min-duty measurement "
+        "description": "inline DShot-idle crawl for min-duty measurement "
                        "(auto-tuner)",
         "sample_rate_hz": 100.0,
         "segments": segs,
@@ -182,25 +192,30 @@ def min_duty_measure_profile(spec: TuneSpec) -> Profile:
 
 
 def min_duty_verify_profile(spec: TuneSpec) -> Profile:
-    """Verify a programmed minimum_duty_cycle: spin up, hold at low throttle
-    where a too-low floor would kick-loop, park.
+    """Verify a programmed minimum_duty_cycle at DShot idle.
 
-    With an adequate floor the firmware keeps duty above the plant sustain
-    threshold even when the host commands 2–3%.
+    Spin up, then hold DShot 55 / 50 / 48. With an adequate floor the
+    firmware keeps duty above the plant sustain threshold even at DShot 48
+    (first real throttle step); a too-low floor kick-loops here.
     """
+    from .minduty import dshot_to_host_throttle
     safety = dict(spec.probe.safety or {})
     return profile_from_dict({
         "name": "tune_min_duty_verify",
-        "description": "inline low-throttle sustain check for min-duty "
+        "description": "inline DShot-idle sustain check for min-duty "
                        "(auto-tuner)",
         "sample_rate_hz": 100.0,
         "segments": [
-            {"label": "idle",   "throttle": 0.00, "duration_s": 2.0},
-            {"label": "spinup", "throttle": 0.10, "duration_s": 3.0, "ramp": True},
-            {"label": "t05",    "throttle": 0.05, "duration_s": 4.0, "steady": True},
-            {"label": "t03",    "throttle": 0.03, "duration_s": 4.0, "steady": True},
-            {"label": "t02",    "throttle": 0.02, "duration_s": 4.0, "steady": True},
-            {"label": "rampdn", "throttle": 0.00, "duration_s": 2.0, "ramp": True},
+            {"label": "idle", "throttle": 0.00, "duration_s": 2.0},
+            {"label": "spinup", "throttle": dshot_to_host_throttle(220),
+             "duration_s": 3.0, "ramp": True},
+            _dshot_hold("hold_hi", 120, 2.0),
+            # Step down into idle — sustain, not cold-start at DShot 48.
+            _dshot_hold("d55", 55, 3.5),
+            _dshot_hold("d50", 50, 3.5),
+            _dshot_hold("d48", 48, 4.0),
+            {"label": "rampdn", "throttle": 0.00, "duration_s": 2.0,
+             "ramp": True},
         ],
         "safety": safety or None,
     })

--- a/hwci/hwci/tuner/session.py
+++ b/hwci/hwci/tuner/session.py
@@ -21,7 +21,9 @@ from . import report as tunereport
 from . import search as searchmod
 from .backends import TuneBackend
 from .objective import check_constraints, objective_score, startup_stats
+from .minduty import compute_min_duty, sustain_throttle_from_rows
 from .profiles import (RAMP_TRANSIENT_MAX_CURRENT_A, high_throttle_profile,
+                       min_duty_measure_profile, min_duty_verify_profile,
                        probe_profile, ramp_measure_profile, startup_profile,
                        step_profile)
 from .ramp import compute_max_ramp, mech_ramp_stats
@@ -536,6 +538,107 @@ class Tuner:
         return out
 
     def _run_measure_stage(self, stage: StageSpec) -> None:
+        if stage.measure == "min_duty":
+            self._run_min_duty_stage(stage)
+        else:
+            self._run_ramp_measure_stage(stage)
+
+    def _run_min_duty_stage(self, stage: StageSpec) -> None:
+        """Crawl-measure minimum_duty_cycle, then verify with upward backoff."""
+        f = resolve_field("minimum_duty_cycle", None)
+        indices: list[int] = []
+        # Floor the measure run so the firmware floor cannot hide the plant
+        # sustain threshold (eeprom unit 1 = 0.5% duty).
+        measure_ov = self._merged(stage, {"minimum_duty_cycle": f.lo})
+        e = self._trial(TrialPlan(
+            stage=stage.name, kind="measure",
+            overrides=measure_ov,
+            profile=min_duty_measure_profile(self.spec)))
+        indices.append(e["index"])
+        # Analyse samples even if low holds tripped demag/bemf constraints:
+        # the crawl's job is to find where sustain ends, and those failures
+        # are expected on the bottom rungs.
+        rig = getattr(self.backend, "rig", RigConfig())
+        pp = int(getattr(rig, "pole_pairs", None) or 7)
+        min_rpm = max(200.0, float(self.spec.constraints.startup.min_rpm) * 0.3)
+        stats = sustain_throttle_from_rows(
+            self._trial_rows(e), min_rpm=min_rpm, pole_pairs=pp)
+        computed: Optional[int] = None
+        if stats is None:
+            self.log(f"stage {stage.name}: no sustained crawl hold "
+                     f"(min_rpm {min_rpm:.0f}); trying verify search from "
+                     f"mid-range minimum_duty_cycle")
+            start_v = max(f.lo, (f.lo + f.hi) // 4)
+        else:
+            computed = compute_min_duty(
+                stats["sustain_throttle"], lo=f.lo, hi=f.hi,
+                margin=stage.margin)
+            self.log(
+                f"stage {stage.name}: sustain @ "
+                f"{stats['sustain_throttle'] * 100:.1f}% throttle "
+                f"({stats['sustain_segment']}, "
+                f"{stats['sustain_rpm']:.0f} rpm), "
+                f"{stats['failed_holds']}/{stats['holds']} holds failed "
+                f"-> minimum_duty_cycle {computed} "
+                f"(margin {stage.margin})")
+            start_v = computed
+
+        def verify_with_backoff(base_ov: dict, start: int) -> Optional[int]:
+            v = start
+            while True:
+                # Verify also requires the lowest hold of the verify profile
+                # to actually sustain under the programmed floor - not only
+                # "no demag DQ" (a too-low floor can look clean if the host
+                # never sits under the plant threshold long enough).
+                ev = self._trial(TrialPlan(
+                    stage=stage.name, kind="verify",
+                    overrides={**base_ov, "minimum_duty_cycle": v},
+                    profile=min_duty_verify_profile(self.spec)))
+                indices.append(ev["index"])
+                vstats = sustain_throttle_from_rows(
+                    self._trial_rows(ev), min_rpm=min_rpm, pole_pairs=pp)
+                ok = (not ev.get("disqualified")
+                      and vstats is not None
+                      and vstats["failed_holds"] == 0)
+                if ok:
+                    return v
+                nxt = min(f.hi, v + max(1, int(math.ceil(v * 0.25))))
+                if nxt == v:
+                    return None
+                why = (ev.get("disqualified")
+                       or f"{vstats['failed_holds'] if vstats else '?'} "
+                          "hold(s) below min_rpm")
+                self.log(f"stage {stage.name}: verify failed at "
+                         f"minimum_duty_cycle {v} ({why}); raising to {nxt}")
+                v = nxt
+
+        winner_val = verify_with_backoff(self._merged(stage, {}), start_v)
+        if winner_val is not None:
+            self.manifest["incumbent"] = {
+                **self.incumbent, **stage.fixed,
+                "minimum_duty_cycle": winner_val}
+        else:
+            self.log(f"stage {stage.name}: no minimum_duty_cycle in range "
+                     "passed verify; leaving incumbent unchanged")
+        measured = None
+        if stats is not None:
+            measured = {
+                k: (round(v, 4) if isinstance(v, float) else v)
+                for k, v in stats.items()
+            }
+        self.manifest["stages"][stage.name] = {
+            "winner": (None if winner_val is None
+                       else {"minimum_duty_cycle": winner_val}),
+            "winner_score": None,
+            "measured": measured,
+            "computed_minimum_duty_cycle": computed,
+            "trials": indices,
+        }
+        self._save()
+        self.log(f"stage {stage.name}: winner "
+                 f"{None if winner_val is None else {'minimum_duty_cycle': winner_val}}")
+
+    def _run_ramp_measure_stage(self, stage: StageSpec) -> None:
         """Physics-based max_ramp: measure, compute, verify with backoff,
         fall back to lower-ranked advance values if needed."""
         f = resolve_field("max_ramp", None)

--- a/hwci/hwci/tuner/session.py
+++ b/hwci/hwci/tuner/session.py
@@ -21,7 +21,8 @@ from . import report as tunereport
 from . import search as searchmod
 from .backends import TuneBackend
 from .objective import check_constraints, objective_score, startup_stats
-from .minduty import compute_min_duty, sustain_throttle_from_rows
+from .minduty import (compute_min_duty_for_idle, sustain_dshot_from_rows,
+                      sustain_throttle_from_rows)
 from .profiles import (RAMP_TRANSIENT_MAX_CURRENT_A, high_throttle_profile,
                        min_duty_measure_profile, min_duty_verify_profile,
                        probe_profile, ramp_measure_profile, startup_profile,
@@ -271,6 +272,11 @@ class Tuner:
         (trial_dir / "metrics.json").write_text(json.dumps(m, indent=2))
 
         is_startup = plan.profile.name == "tune_startup"
+        # Min-duty crawl/verify holds sit at DShot idle (~few hundred RPM on
+        # a big prop); the "failed start" min_rpm gate is for efficiency
+        # probes, not those profiles.
+        is_min_duty = plan.profile.name in (
+            "tune_min_duty_measure", "tune_min_duty_verify")
         st = (startup_stats(result, plan.profile,
                             self.spec.constraints.startup.min_rpm)
               if is_startup else None)
@@ -279,7 +285,7 @@ class Tuner:
             jitter_reference=self.manifest["jitter_reference"],
             settings_verified=bool(extra.get("settings_verified")),
             startup=st,
-            min_start_rpm=(None if is_startup
+            min_start_rpm=(None if (is_startup or is_min_duty)
                            else self.spec.constraints.startup.min_rpm))
         score = objective_score(m, self.spec.objective) if not fails else None
         summary = m.get("summary", {})
@@ -544,7 +550,7 @@ class Tuner:
             self._run_ramp_measure_stage(stage)
 
     def _run_min_duty_stage(self, stage: StageSpec) -> None:
-        """Crawl-measure minimum_duty_cycle, then verify with upward backoff."""
+        """DShot-idle measure of minimum_duty_cycle, then verify with raise."""
         f = resolve_field("minimum_duty_cycle", None)
         indices: list[int] = []
         # Floor the measure run so the firmware floor cannot hide the plant
@@ -560,54 +566,62 @@ class Tuner:
         # are expected on the bottom rungs.
         rig = getattr(self.backend, "rig", RigConfig())
         pp = int(getattr(rig, "pole_pairs", None) or 7)
-        min_rpm = max(200.0, float(self.spec.constraints.startup.min_rpm) * 0.3)
-        stats = sustain_throttle_from_rows(
+        # Kick/false-lock on this prop sits ~350-450 RPM; real idle sustain
+        # under an adequate floor is typically ≥600-800 RPM. Gate above the
+        # kick band so coast/kick cannot pass as "sustain".
+        min_rpm = max(500.0, float(self.spec.constraints.startup.min_rpm) * 0.5)
+        stats = sustain_dshot_from_rows(
             self._trial_rows(e), min_rpm=min_rpm, pole_pairs=pp)
         computed: Optional[int] = None
         if stats is None:
-            self.log(f"stage {stage.name}: no sustained crawl hold "
+            self.log(f"stage {stage.name}: no sustained DShot hold "
                      f"(min_rpm {min_rpm:.0f}); trying verify search from "
                      f"mid-range minimum_duty_cycle")
             start_v = max(f.lo, (f.lo + f.hi) // 4)
         else:
-            computed = compute_min_duty(
-                stats["sustain_throttle"], lo=f.lo, hi=f.hi,
-                margin=stage.margin)
+            computed = compute_min_duty_for_idle(
+                stats["sustain_dshot"], lo=f.lo, hi=f.hi,
+                margin=stage.margin, measure_eeprom=f.lo)
             self.log(
-                f"stage {stage.name}: sustain @ "
-                f"{stats['sustain_throttle'] * 100:.1f}% throttle "
+                f"stage {stage.name}: sustain @ DShot "
+                f"{stats['sustain_dshot']:.0f} "
                 f"({stats['sustain_segment']}, "
-                f"{stats['sustain_rpm']:.0f} rpm), "
+                f"{stats['sustain_rpm']:.0f} rpm, "
+                f"~{stats['sustain_duty_counts']:.0f}/2000 duty), "
                 f"{stats['failed_holds']}/{stats['holds']} holds failed "
                 f"-> minimum_duty_cycle {computed} "
-                f"(margin {stage.margin})")
+                f"(margin {stage.margin}, targets DShot-48 floor)")
             start_v = computed
 
         def verify_with_backoff(base_ov: dict, start: int) -> Optional[int]:
             v = start
             while True:
-                # Verify also requires the lowest hold of the verify profile
-                # to actually sustain under the programmed floor - not only
-                # "no demag DQ" (a too-low floor can look clean if the host
-                # never sits under the plant threshold long enough).
+                # Verify requires DShot 48/50/55 holds to sustain under the
+                # programmed floor — not only "no demag DQ".
                 ev = self._trial(TrialPlan(
                     stage=stage.name, kind="verify",
                     overrides={**base_ov, "minimum_duty_cycle": v},
                     profile=min_duty_verify_profile(self.spec)))
                 indices.append(ev["index"])
-                vstats = sustain_throttle_from_rows(
+                vstats = sustain_dshot_from_rows(
                     self._trial_rows(ev), min_rpm=min_rpm, pole_pairs=pp)
                 ok = (not ev.get("disqualified")
                       and vstats is not None
-                      and vstats["failed_holds"] == 0)
+                      and vstats["failed_holds"] == 0
+                      and vstats["lowest_dshot"] <= 48.5)
                 if ok:
                     return v
                 nxt = min(f.hi, v + max(1, int(math.ceil(v * 0.25))))
                 if nxt == v:
                     return None
-                why = (ev.get("disqualified")
-                       or f"{vstats['failed_holds'] if vstats else '?'} "
-                          "hold(s) below min_rpm")
+                if ev.get("disqualified"):
+                    why = ev["disqualified"]
+                elif vstats is None:
+                    why = "no sustained holds"
+                else:
+                    why = (f"{vstats['failed_holds']} hold(s) below min_rpm "
+                           f"(lowest sustained DShot "
+                           f"{vstats.get('sustain_dshot', '?')})")
                 self.log(f"stage {stage.name}: verify failed at "
                          f"minimum_duty_cycle {v} ({why}); raising to {nxt}")
                 v = nxt
@@ -619,7 +633,7 @@ class Tuner:
                 "minimum_duty_cycle": winner_val}
         else:
             self.log(f"stage {stage.name}: no minimum_duty_cycle in range "
-                     "passed verify; leaving incumbent unchanged")
+                     "passed DShot-idle verify; leaving incumbent unchanged")
         measured = None
         if stats is not None:
             measured = {

--- a/hwci/hwci/tuner/spec.py
+++ b/hwci/hwci/tuner/spec.py
@@ -101,8 +101,14 @@ class StageSpec:
     # "ramp_rate": measure the powertrain (mech time constant + transient
     # current per % of duty lead) with one instrumented step run, COMPUTE
     # max_ramp from the physics, then verify it on the step-stress profile.
+    # "min_duty": crawl down throttle, find the lowest sustained hold,
+    # COMPUTE minimum_duty_cycle (eeprom units) with pack-sag headroom,
+    # then verify on a low-throttle sustain profile.
     measure: str | None = None
-    margin: float = 0.8       # fraction of the physics-derived rate to keep
+    # ramp_rate: fraction of the physics-derived rate to keep (typically <1).
+    # min_duty: headroom multiplier on the measured sustain threshold
+    # (typically >1, e.g. 1.15 for pack sag).
+    margin: float = 0.8
     # Restrict a sweep to values within ±polish_radius (setting units) of
     # the current incumbent - used for a cheap post-modes advance re-climb.
     polish_radius: int | None = None
@@ -250,10 +256,10 @@ def tune_spec_from_dict(data: dict) -> TuneSpec:
             raise TuneSpecError(
                 f"tune spec: stage {s.name!r} needs exactly one of "
                 "'sweep', 'ab_candidates' or 'measure'")
-        if s.measure is not None and s.measure != "ramp_rate":
+        if s.measure is not None and s.measure not in ("ramp_rate", "min_duty"):
             raise TuneSpecError(
                 f"tune spec: stage {s.name!r} measure {s.measure!r} is not "
-                "'ramp_rate'")
+                "'ramp_rate' or 'min_duty'")
         if s.measure and s.constraint_only:
             raise TuneSpecError(
                 f"tune spec: stage {s.name!r}: 'measure' and "

--- a/hwci/tests/test_report.py
+++ b/hwci/tests/test_report.py
@@ -182,6 +182,13 @@ def test_configurator_value_max_ramp_is_direct_percent_per_ms():
     assert report._configurator_value("max_ramp", 1) == "0.1 %/ms"
 
 
+def test_configurator_value_minimum_duty_cycle_is_half_percent_units():
+    # EEPROM unit * 10 duty counts / 2000 = 0.5% per unit.
+    assert report._configurator_value("minimum_duty_cycle", 1) == "0.5%"
+    assert report._configurator_value("minimum_duty_cycle", 6) == "3.0%"
+    assert report._configurator_value("minimum_duty_cycle", 50) == "25.0%"
+
+
 def test_configurator_value_startup_power_is_direct_percent():
     assert report._configurator_value("startup_power", 100) == "100%"
 

--- a/hwci/tests/test_settings.py
+++ b/hwci/tests/test_settings.py
@@ -13,6 +13,7 @@ def test_default_blob_round_trips_known_fields():
     assert s.get("variable_pwm") == 1
     assert s.get("auto_advance") == 0
     assert s.get("max_ramp") == 160
+    assert s.get("minimum_duty_cycle") == 1
     assert s.get("startup_power") == 100
 
 
@@ -49,6 +50,8 @@ def test_bin_round_trip(tmp_path):
     ("auto_advance", 2),
     ("max_ramp", 0),
     ("max_ramp", 256),
+    ("minimum_duty_cycle", 0),
+    ("minimum_duty_cycle", 51),
 ])
 def test_out_of_range_values_are_refused_not_clamped(name, value):
     base = st.Settings(st.default_blob())

--- a/hwci/tests/test_sim.py
+++ b/hwci/tests/test_sim.py
@@ -127,10 +127,12 @@ def _steady_efficiency(rig, throttle=0.6, n=400, dt=0.005):
 
 def test_simsettings_decodes_the_same_blob_settings_writes():
     blob = Settings(default_blob()).apply(
-        {"advance_level": 30, "pwm_frequency": 16, "auto_advance": 1}).to_bytes()
+        {"advance_level": 30, "pwm_frequency": 16, "auto_advance": 1,
+         "minimum_duty_cycle": 6}).to_bytes()
     s = SimSettings.from_blob(blob)
     assert (s.advance_level, s.pwm_frequency, s.auto_advance) == (30, 16, 1)
     assert s.max_ramp == 160 and s.startup_power == 100
+    assert s.minimum_duty_cycle == 6
 
 
 def test_efficiency_has_interior_maximum_in_advance():
@@ -193,6 +195,20 @@ def test_low_max_ramp_prevents_step_desync():
         rig.step(0.005, 1.0)  # violent step into a high-current regime
     assert fast.desync_count >= 1
     assert slow.desync_count == 0
+
+
+def test_minimum_duty_cycle_floors_low_throttle_sustain():
+    """Plant needs 3% duty; without min_duty floor, 2% host command stalls.
+    With minimum_duty_cycle=8 (4% floor) the same command sustains."""
+    stalled = _sim_with({"minimum_duty_cycle": 1}, sustain_throttle=0.03)
+    held = _sim_with({"minimum_duty_cycle": 8}, sustain_throttle=0.03)
+    _settle(stalled, 0.10, n=80)
+    _settle(held, 0.10, n=80)
+    for _ in range(120):
+        stalled.step(0.01, 0.02)
+        held.step(0.01, 0.02)
+    assert stalled.rpm < 200.0
+    assert held.rpm > 500.0
 
 
 def test_settings_none_keeps_legacy_behaviour():

--- a/hwci/tests/test_tune_spec.py
+++ b/hwci/tests/test_tune_spec.py
@@ -31,9 +31,12 @@ def test_minimal_spec_gets_documented_defaults():
 def test_example_spec_loads():
     spec = load_tune_spec(REPO_ROOT / "hwci" / "tunes" / "example.yaml")
     assert {s.name for s in spec.stages} == {
-        "advance", "pwm", "modes", "advance_polish", "ramp"}
+        "advance", "pwm", "modes", "advance_polish", "ramp", "min_duty"}
     assert spec.parameters["advance_level"].refine_step == 2
     assert next(s for s in spec.stages if s.name == "ramp").measure == "ramp_rate"
+    md = next(s for s in spec.stages if s.name == "min_duty")
+    assert md.measure == "min_duty"
+    assert md.margin == 1.15
     polish = next(s for s in spec.stages if s.name == "advance_polish")
     assert polish.polish_radius == 4
     assert spec.finals.min_delta_pct == 1.0

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -658,30 +658,49 @@ def test_measure_stage_spec_validation():
 
 
 def test_compute_min_duty_math_and_clamping():
-    from hwci.tuner import compute_min_duty
-    # 2.9% host throttle -> 5.8 eeprom units; ceil + margin 1.0 -> 6
+    from hwci.tuner import compute_min_duty, compute_min_duty_for_idle
+    # Deprecated host-throttle form (kept for back-compat).
     assert compute_min_duty(0.029, lo=1, hi=50, margin=1.0) == 6
-    # +15% pack-sag headroom -> 7 (matches PR41 crawl recommendation)
     assert compute_min_duty(0.029, lo=1, hi=50, margin=1.15) == 7
     assert compute_min_duty(0.0, lo=1, hi=50, margin=1.15) == 1
-    assert compute_min_duty(0.5, lo=1, hi=50, margin=1.0) == 50  # clamp hi
+    assert compute_min_duty(0.5, lo=1, hi=50, margin=1.0) == 50
+    # Idle-targeted: plant needs duty at DShot 65 with floor=1 (~28 counts
+    # is low); real cliff at DShot 88 (~duty 51) with margin 1.15 → ~6.
+    assert compute_min_duty_for_idle(88, lo=1, hi=50, margin=1.0,
+                                    measure_eeprom=1) == 6
+    assert compute_min_duty_for_idle(88, lo=1, hi=50, margin=1.15,
+                                    measure_eeprom=1) == 6
+    # User observation: cliff ~DShot 55 with higher floor maps to need ~58
+    # counts; targeting DShot 48 with margin → 7.
+    # duty(55, measure_s=5) is not what measure uses; with measure_s=1
+    # duty(55)≈18 → small S. The measure finds the cliff under floor=1.
+    s = compute_min_duty_for_idle(65, lo=1, hi=50, margin=1.15,
+                                 measure_eeprom=1)
+    assert 1 <= s <= 10
 
 
-def test_sustain_throttle_from_rows_picks_lowest_passing_hold():
-    from hwci.tuner import sustain_throttle_from_rows
+def test_sustain_dshot_from_rows_picks_lowest_passing_hold():
+    from hwci.tuner import dshot_to_host_throttle, sustain_dshot_from_rows
     rows = []
-    for thr, rpm, n in ((0.08, 2000, 20), (0.04, 900, 20),
-                        (0.03, 700, 20), (0.02, 50, 20)):
+    # (dshot, stand_rpm, e_rpm, current) — d48 coasts (no current / eRPM
+    # collapse) must fail; d55 is the lowest real sustain.
+    for dshot, rpm, e_rpm, cur, n in (
+            (100, 2000, 14000, 0.3, 20),
+            (65, 900, 6300, 0.15, 20),
+            (55, 700, 4900, 0.1, 20),
+            (48, 450, 500, 0.0, 20)):   # coast / false-lock
+        thr = dshot_to_host_throttle(dshot)
         for i in range(n):
             rows.append({
-                "segment": f"t{int(thr * 1000)}",
+                "segment": f"d{dshot}",
                 "throttle_cmd": thr,
                 "stand_rpm": rpm,
-                "perf_e_rpm": rpm * 7,
+                "stand_current_a": cur,
+                "perf_e_rpm": e_rpm,
             })
-    stats = sustain_throttle_from_rows(rows, min_rpm=400.0, pole_pairs=7)
+    stats = sustain_dshot_from_rows(rows, min_rpm=400.0, pole_pairs=7)
     assert stats is not None
-    assert stats["sustain_throttle"] == pytest.approx(0.03)
+    assert stats["sustain_dshot"] == pytest.approx(55, abs=1)
     assert stats["failed_holds"] == 1
 
 
@@ -707,23 +726,26 @@ def test_e2e_measure_stage_sets_max_ramp(tmp_path):
 
 
 def test_e2e_measure_stage_sets_minimum_duty_cycle(tmp_path):
-    """Plant needs ~3% duty to sustain; measure should program min_duty
-    near ceil(0.03*200*1.15)=7 and verify should pass."""
+    """Plant needs ~3% effective duty; idle-targeted measure should raise
+    the floor so DShot 48 sustains and verify passes."""
     import json
     spec_d = small_spec(stages=[
         {"name": "min_duty", "measure": "min_duty", "margin": 1.15}])
-    backend = make_backend(demag_prone=False, sustain_throttle=0.03)
+    # 2% plant need: with floor=1, DShot ≳ 48+0.02*1999 ≈ 88 sustains in sim
+    # (host-throttle model); idle verify requires floor ≥ 4 (S/200).
+    backend = make_backend(demag_prone=False, sustain_throttle=0.02)
     _, result = run_tune(tmp_path, spec_d, backend)
     m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
     st = m["stages"]["min_duty"]
     assert st["measured"] is not None
-    assert st["measured"]["sustain_throttle"] == pytest.approx(0.03, abs=0.006)
+    # Measure finds a cliff above DShot idle; computed floor targets DShot 48.
+    assert st["measured"]["sustain_dshot"] >= 48
     assert st["computed_minimum_duty_cycle"] is not None
     from hwci.settings import resolve_field
     f = resolve_field("minimum_duty_cycle", None)
     assert f.lo <= st["computed_minimum_duty_cycle"] <= f.hi
-    # With plant at 3% and margin 1.15, expect 6-8 eeprom units.
-    assert 5 <= st["computed_minimum_duty_cycle"] <= 9
+    # Floor must clear plant need at DShot 48 (eeprom units ≥ ~4–6).
+    assert st["computed_minimum_duty_cycle"] >= 4
     kinds = [t["kind"] for t in m["trials"] if t["stage"] == "min_duty"]
     assert kinds[0] == "measure" and "verify" in kinds
     assert st["winner"] is not None

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -645,12 +645,44 @@ def test_measure_stage_spec_validation():
     with pytest.raises(TuneSpecError, match="exactly one"):
         tune_spec_from_dict(small_spec(stages=[
             {"name": "r", "measure": "ramp_rate", "sweep": "max_ramp"}]))
-    with pytest.raises(TuneSpecError, match="ramp_rate"):
+    with pytest.raises(TuneSpecError, match="ramp_rate|min_duty"):
         tune_spec_from_dict(small_spec(stages=[
             {"name": "r", "measure": "bogus"}]))
     with pytest.raises(TuneSpecError, match="margin"):
         tune_spec_from_dict(small_spec(stages=[
             {"name": "r", "measure": "ramp_rate", "margin": 5.0}]))
+    # min_duty is a first-class measure mode
+    spec = tune_spec_from_dict(small_spec(stages=[
+        {"name": "md", "measure": "min_duty", "margin": 1.15}]))
+    assert spec.stages[0].measure == "min_duty"
+
+
+def test_compute_min_duty_math_and_clamping():
+    from hwci.tuner import compute_min_duty
+    # 2.9% host throttle -> 5.8 eeprom units; ceil + margin 1.0 -> 6
+    assert compute_min_duty(0.029, lo=1, hi=50, margin=1.0) == 6
+    # +15% pack-sag headroom -> 7 (matches PR41 crawl recommendation)
+    assert compute_min_duty(0.029, lo=1, hi=50, margin=1.15) == 7
+    assert compute_min_duty(0.0, lo=1, hi=50, margin=1.15) == 1
+    assert compute_min_duty(0.5, lo=1, hi=50, margin=1.0) == 50  # clamp hi
+
+
+def test_sustain_throttle_from_rows_picks_lowest_passing_hold():
+    from hwci.tuner import sustain_throttle_from_rows
+    rows = []
+    for thr, rpm, n in ((0.08, 2000, 20), (0.04, 900, 20),
+                        (0.03, 700, 20), (0.02, 50, 20)):
+        for i in range(n):
+            rows.append({
+                "segment": f"t{int(thr * 1000)}",
+                "throttle_cmd": thr,
+                "stand_rpm": rpm,
+                "perf_e_rpm": rpm * 7,
+            })
+    stats = sustain_throttle_from_rows(rows, min_rpm=400.0, pole_pairs=7)
+    assert stats is not None
+    assert stats["sustain_throttle"] == pytest.approx(0.03)
+    assert stats["failed_holds"] == 1
 
 
 def test_e2e_measure_stage_sets_max_ramp(tmp_path):
@@ -672,6 +704,31 @@ def test_e2e_measure_stage_sets_max_ramp(tmp_path):
     assert kinds[0] == "measure" and "verify" in kinds
     if st["winner"] is not None:
         assert m["incumbent"]["max_ramp"] == st["winner"]["max_ramp"]
+
+
+def test_e2e_measure_stage_sets_minimum_duty_cycle(tmp_path):
+    """Plant needs ~3% duty to sustain; measure should program min_duty
+    near ceil(0.03*200*1.15)=7 and verify should pass."""
+    import json
+    spec_d = small_spec(stages=[
+        {"name": "min_duty", "measure": "min_duty", "margin": 1.15}])
+    backend = make_backend(demag_prone=False, sustain_throttle=0.03)
+    _, result = run_tune(tmp_path, spec_d, backend)
+    m = json.loads((tmp_path / "tune" / "manifest.json").read_text())
+    st = m["stages"]["min_duty"]
+    assert st["measured"] is not None
+    assert st["measured"]["sustain_throttle"] == pytest.approx(0.03, abs=0.006)
+    assert st["computed_minimum_duty_cycle"] is not None
+    from hwci.settings import resolve_field
+    f = resolve_field("minimum_duty_cycle", None)
+    assert f.lo <= st["computed_minimum_duty_cycle"] <= f.hi
+    # With plant at 3% and margin 1.15, expect 6-8 eeprom units.
+    assert 5 <= st["computed_minimum_duty_cycle"] <= 9
+    kinds = [t["kind"] for t in m["trials"] if t["stage"] == "min_duty"]
+    assert kinds[0] == "measure" and "verify" in kinds
+    assert st["winner"] is not None
+    assert m["incumbent"]["minimum_duty_cycle"] == st["winner"]["minimum_duty_cycle"]
+    assert st["winner"]["minimum_duty_cycle"] >= st["computed_minimum_duty_cycle"]
 
 
 def test_measure_stage_falls_back_to_direct_search_when_measurement_desyncs(

--- a/hwci/tunes/example.yaml
+++ b/hwci/tunes/example.yaml
@@ -95,6 +95,12 @@ stages:
                               # max_ramp from the physics, verify on the
                               # step-stress profile (0.7x back-off on fail)
     margin: 0.8               # keep 80% of the physics-derived rate
+  - name: min_duty
+    measure: min_duty         # crawl low throttle, find the sustain floor,
+                              # COMPUTE minimum_duty_cycle, verify (raise on
+                              # fail). Prevents DShot-idle kick loops on
+                              # props that need ~3% duty to stay spinning.
+    margin: 1.15              # +15% pack-sag / measurement headroom
 
 finals:
   profile: efficiency_sweep   # full sweep, winner vs default

--- a/hwci/tunes/min_duty_900kv_10inch.yaml
+++ b/hwci/tunes/min_duty_900kv_10inch.yaml
@@ -1,0 +1,60 @@
+# Bench-only: measure minimum_duty_cycle for 900KV + 10x5x3 on 6S.
+# No advance/pwm search — baseline + min_duty measure/verify + short finals.
+# Safety capped well below the 50–70% envelope used for propped stress work.
+name: min-duty-900kv-10inch
+description: >
+  Minimum-duty crawl for HQProp 10x5x3 on JS/generic 900KV (6S). Finds the
+  lowest sustainable throttle and programs minimum_duty_cycle with pack-sag
+  headroom so DShot idle cannot under-power the prop into a kick loop.
+
+battery_cells: 6
+
+pack:
+  min_resting_cell_v: 3.5
+  prompt_on_swap: true
+
+thermal:
+  max_start_fet_temp_c: 70.0
+
+probe:
+  # Low holds only: baseline/finals must not climb into high-current 10" territory.
+  points: {t10: 0.10, t15: 0.15, t20: 0.20}
+  dwell_s: 4.0
+  safety:
+    max_current_a: 20.0
+    max_thrust_n: 25.0
+    max_rpm: 8000
+
+objective:
+  weights: {t10: 1.0, t15: 1.0, t20: 1.0}
+  min_power_w: 5.0          # 10–20% on a 10" still has real power
+  noise_floor_pct: 2.0
+
+constraints:
+  max_demag_events: 0
+  max_bemf_timeout_samples: 0
+  jitter_max_regression_pct: 50.0   # measure-focused; do not over-gate on jitter
+  max_fet_temp_c: 90.0
+  max_motor_temp_c: 95.0
+  startup:
+    cycles: 3
+    max_failed: 0
+    spin_throttle: 0.12
+    min_rpm: 800
+
+anchors_every: 99             # single stage; no coordinate search anchors needed
+
+parameters: {}
+
+stages:
+  - name: min_duty
+    measure: min_duty
+    margin: 1.15              # +15% headroom for pack sag (PR41 crawl lesson)
+
+finals:
+  profile: tune_probe         # rebuilt from probe.points above
+  pattern: ABBA
+  repeats: 1
+  extra_repeats_if_close: 0
+  min_delta_pct: 1.0          # min_duty is not an efficiency win; expect unconfirmed
+  startup_check: true

--- a/hwci/tunes/quick.yaml
+++ b/hwci/tunes/quick.yaml
@@ -82,6 +82,9 @@ stages:
                               # step response, compute max_ramp, verify on
                               # the step-stress profile
     margin: 0.8
+  - name: min_duty
+    measure: min_duty         # crawl + compute minimum_duty_cycle + verify
+    margin: 1.15
 
 finals:
   profile: tune_probe   # short probe instead of the full efficiency sweep


### PR DESCRIPTION
## Summary
- Register EEPROM `minimum_duty_cycle` (offset 6, range 1–50) as a first-class auto-tuner field, with configurator labeling and sim plant support.
- Add `measure: min_duty` stage that sizes the duty floor for **DShot 48 idle sustain** (descending DShot crawl, cliff duty → eeprom with pack-sag margin, verify step-down to DShot 48).
- Wire into `tunes/example.yaml` / `tunes/quick.yaml`; bench-only `tunes/min_duty_900kv_10inch.yaml`; document in `hwci/README.md`.

## Test plan
- [x] Offline: related pytest suite (settings / tuner / sim / report / tune_spec / cli)
- [x] Bench (900KV + HQProp 10×5×3, 6S): `hwci tune --spec tunes/min_duty_900kv_10inch.yaml`
  - Measure cliff → **min_duty 10**; verify **PASS at DShot 48** (847 RPM / 5900 eRPM)
  - Device written 5→10; see PR comments for full tables
- [ ] Optional: pilot hand-check DShot 48–54 on stick after flash
- [ ] Confirm finals / pilot card show the setting under AM32 configurator labels when a full efficiency tune includes the stage