### PR TITLE
feat(hwci): bubble-search max_ramp and soft snaps for heavy props

### DIFF
--- a/hwci/hwci/profiles/ramp_snap_10inch.yaml
+++ b/hwci/hwci/profiles/ramp_snap_10inch.yaml
@@ -1,0 +1,28 @@
+# Same shape as the auto-tuner max_ramp verify step_profile (0.30 hold →
+# snap 0.95), safety raised for 900KV + 10" 3-blade on 6S so the harness
+# can observe demag/desync instead of aborting at the 5" 55 A cap.
+name: ramp_snap_10inch
+description: >
+  Spinning-state ramp/snap stress for 10" props: spool to 30%, hold, snap
+  to 95% twice (tuner max_ramp verify geometry). Host demag detection +
+  firmware bemf-timeout / blind-step counters.
+sample_rate_hz: 200
+arm_settle_s: 2.0
+demag_commutation_spike: 3.0
+demag_rpm_drop_fraction: 0.25
+
+safety:
+  max_current_a: 120.0
+  max_thrust_n: 80.0
+  # 900KV×6S no-load ~20k; 10" under load still topped 12k on a slow slew
+  max_rpm: 20000
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: spool,   throttle: 0.30, duration_s: 2.0, ramp: true}
+  - {label: hold30a, throttle: 0.30, duration_s: 2.0}
+  - {label: snap95a, throttle: 0.95, duration_s: 1.5}
+  - {label: hold30b, throttle: 0.30, duration_s: 2.0}
+  - {label: snap95b, throttle: 0.95, duration_s: 1.5}
+  - {label: hold30c, throttle: 0.30, duration_s: 2.0}
+  - {label: rampdn,  throttle: 0.00, duration_s: 1.5, ramp: true}

--- a/hwci/hwci/runner.py
+++ b/hwci/hwci/runner.py
@@ -90,6 +90,106 @@ def enforce_safety(limits: SafetyLimits, stand: StandSample | None,
         limits.check(current_a=telem.current_a, temp_c=telem.temperature_c)
 
 
+# Stuck-rotor latch value from firmware (Inc/esc_state.h / bemf path).
+_BEMF_STUCK_LATCH = 102
+
+
+class DesyncTripped(StandSafetyTripped):
+    """Live desync / demag detected mid-run; throttle must cut immediately."""
+
+
+class LiveDesyncWatch:
+    """Per-run state for aborting as soon as the motor loses sync.
+
+    Offline metrics detect demag after the fact; by then the profile may have
+    kept commanding high throttle into a desynced rotor for seconds. This
+    watch trips on the first clear live signal so ``run_profile`` disarms in
+    the ``finally`` block.
+    """
+
+    def __init__(self, *, rpm_drop_fraction: float = 0.25,
+                 min_drive_throttle: float = 0.20):
+        self.rpm_drop_fraction = rpm_drop_fraction
+        self.min_drive_throttle = min_drive_throttle
+        self._ref_rpm: float | None = None
+        self._prev_throttle = 0.0
+        self._spin_established = False
+        self._blind0: int | None = None
+
+    def check(self, throttle: float, stand: StandSample | None,
+              pf: PerfSample | None) -> None:
+        """Raise :class:`DesyncTripped` if the plant looks desynced."""
+        thr = float(throttle)
+
+        # --- firmware BEMF / stuck-rotor flags (perf path) ---------------
+        if pf is not None:
+            raw = pf.raw
+            bemf = int(raw.get("bemf_timeout_state") or 0)
+            running = int(raw.get("running") or 0)
+            erpm = 0
+            try:
+                erpm = int(pf.e_rpm)
+            except Exception:
+                erpm = int(raw.get("e_rpm") or 0) * 100
+            if erpm > 3000 or running:
+                self._spin_established = True
+            if bemf >= _BEMF_STUCK_LATCH:
+                raise DesyncTripped(
+                    f"stuck-rotor latch bemf_timeout={bemf}")
+            # After spin is established, any bemf_timeout while we still
+            # command drive means "cut now" — do not keep the rest of the
+            # profile running into the desync.
+            if (self._spin_established and thr >= self.min_drive_throttle
+                    and bemf >= 1):
+                raise DesyncTripped(
+                    f"firmware bemf_timeout={bemf} while throttle="
+                    f"{thr:.2f} (aborting into desync)")
+            # Burst of blind steps after established spin: closed loop is
+            # freewheeling commutations — cut if the counter jumps hard.
+            blind = raw.get("zc_blind_steps")
+            if blind is not None and self._spin_established and thr >= 0.25:
+                b = int(blind)
+                if self._blind0 is None:
+                    self._blind0 = b
+                elif b - self._blind0 >= 32:
+                    raise DesyncTripped(
+                        f"blind-step burst +{b - self._blind0} "
+                        f"(total {b}) while throttle={thr:.2f}")
+
+        # --- stand RPM collapse while throttle high and not falling ------
+        if stand is not None:
+            rpm = float(stand.rpm)
+            # Invalidate peak reference when throttle is falling (commanded
+            # coast-down is not a desync).
+            if thr + 1e-6 < self._prev_throttle:
+                self._ref_rpm = None
+            elif thr >= 0.50:
+                if rpm > 500.0:
+                    self._spin_established = True
+                if self._ref_rpm is None:
+                    if rpm > 500.0:
+                        self._ref_rpm = rpm
+                else:
+                    self._ref_rpm = max(self._ref_rpm, rpm)
+                    if (self._ref_rpm > 1000.0
+                            and rpm < self._ref_rpm * (1.0 - self.rpm_drop_fraction)):
+                        raise DesyncTripped(
+                            f"rpm collapse {rpm:.0f} < "
+                            f"{100 * (1.0 - self.rpm_drop_fraction):.0f}% of "
+                            f"peak {self._ref_rpm:.0f} at throttle={thr:.2f}")
+            # Current spiral: high current, almost no RPM, after we had spin.
+            if (self._spin_established and thr >= 0.25
+                    and stand.current_a >= 25.0 and rpm < 800.0):
+                raise DesyncTripped(
+                    f"high current {stand.current_a:.1f} A with rpm "
+                    f"{rpm:.0f} at throttle={thr:.2f}")
+
+        if thr < self.min_drive_throttle:
+            self._ref_rpm = None
+            self._blind0 = None
+        self._prev_throttle = thr
+
+
 # Default per-cell low-voltage threshold for check_battery(). Matches AM32
 # firmware's own default (Src/main.c: `low_cell_volt_cutoff = 330` -> 3.30
 # V/cell), so the harness refuses to start a test at roughly the same pack
@@ -240,6 +340,9 @@ def run_profile(profile: Profile, sources: Sources, *,
     start = time.monotonic()
     tick = 0
     prev_throttle = 0.0
+    desync_watch = LiveDesyncWatch(
+        rpm_drop_fraction=float(getattr(profile, "demag_rpm_drop_fraction", 0.25)
+                                or 0.25))
     try:
         for seg in profile.segments:
             n = max(1, round(seg.duration_s * profile.sample_rate_hz))
@@ -288,8 +391,13 @@ def run_profile(profile: Profile, sources: Sources, *,
                 # sample covers (and corrupt counter-rate math downstream).
                 t = (time.monotonic() - start) if realtime else t_sched
                 rows.append(make_row(t, seg.label, throttle, stand, tm, pf))
+                # Cut throttle immediately on live desync — do not finish the
+                # remaining profile segments into a freewheeling/desynced rotor.
+                desync_watch.check(throttle, stand, pf)
                 tick += 1
             prev_throttle = seg.throttle
+    except DesyncTripped as e:
+        aborted = f"desync: {e}"
     except StandSafetyTripped as e:
         aborted = f"safety: {e}"
     finally:

--- a/hwci/hwci/runner.py
+++ b/hwci/hwci/runner.py
@@ -114,7 +114,10 @@ class LiveDesyncWatch:
         self._ref_rpm: float | None = None
         self._prev_throttle = 0.0
         self._spin_established = False
-        self._blind0: int | None = None
+        # Previous sample's monotonic zc_blind_steps (host-diffed rate).
+        self._blind_prev: int | None = None
+        # Consecutive samples with a real blind-step burst (filters SWD glitches).
+        self._blind_burst_streak = 0
 
     def check(self, throttle: float, stand: StandSample | None,
               pf: PerfSample | None) -> None:
@@ -145,16 +148,35 @@ class LiveDesyncWatch:
                     f"firmware bemf_timeout={bemf} while throttle="
                     f"{thr:.2f} (aborting into desync)")
             # Burst of blind steps after established spin: closed loop is
-            # freewheeling commutations — cut if the counter jumps hard.
+            # freewheeling commutations. Host-diff consecutive samples (the
+            # counter is monotonic u32, like loop_iters). Ignore single-sample
+            # SWD garbage (bench: 0 -> 19e6 while RPM/eRPM were healthy) and
+            # require a short streak so one bad read cannot abort a tune.
             blind = raw.get("zc_blind_steps")
             if blind is not None and self._spin_established and thr >= 0.25:
                 b = int(blind)
-                if self._blind0 is None:
-                    self._blind0 = b
-                elif b - self._blind0 >= 32:
-                    raise DesyncTripped(
-                        f"blind-step burst +{b - self._blind0} "
-                        f"(total {b}) while throttle={thr:.2f}")
+                prev = self._blind_prev
+                self._blind_prev = b
+                if prev is not None and b >= prev:
+                    delta = b - prev
+                    # ~100 Hz sample: real grind is ~tens/sample; multi-thousand
+                    # jumps are corrupt reads, not motor behavior.
+                    if delta > 200:
+                        self._blind_burst_streak = 0
+                    elif delta >= 32:
+                        self._blind_burst_streak += 1
+                        if self._blind_burst_streak >= 2:
+                            raise DesyncTripped(
+                                f"blind-step burst +{delta}/sample "
+                                f"(streak {self._blind_burst_streak}, "
+                                f"total {b}) while throttle={thr:.2f}")
+                    else:
+                        self._blind_burst_streak = 0
+                elif prev is not None and b < prev:
+                    # Firmware counter reset (stats clear) — re-arm.
+                    self._blind_burst_streak = 0
+            else:
+                self._blind_burst_streak = 0
 
         # --- stand RPM collapse while throttle high and not falling ------
         if stand is not None:
@@ -186,7 +208,8 @@ class LiveDesyncWatch:
 
         if thr < self.min_drive_throttle:
             self._ref_rpm = None
-            self._blind0 = None
+            self._blind_prev = None
+            self._blind_burst_streak = 0
         self._prev_throttle = thr
 
 

--- a/hwci/hwci/tuner/profiles.py
+++ b/hwci/hwci/tuner/profiles.py
@@ -74,40 +74,65 @@ def startup_profile(spec: TuneSpec) -> Profile:
     })
 
 
+def _step_snap_levels(spec: TuneSpec) -> tuple[float, float]:
+    """Hold / snap throttle levels for max_ramp verify.
+
+    5–7" benches keep the classic 0.30→0.95 geometry. Heavy props (low
+    ``max_rpm`` or modest current + low probe ceiling, e.g. 10" on 6S) use a
+    milder spinning-state step so verify searches certify slew limits without
+    thrashing the plant into 100 A desync loops.
+    """
+    pts = [float(v) for v in (spec.probe.points or {}).values()]
+    thr_hi = max(pts) if pts else 0.60
+    safety = spec.probe.safety or {}
+    max_rpm = float(safety.get("max_rpm") or 32000.0)
+    max_i = float(safety.get("max_current_a") or 70.0)
+    heavy = max_rpm <= 15000.0 or (max_i <= 60.0 and thr_hi <= 0.45)
+    if heavy:
+        hold = min(0.30, max(0.15, thr_hi * 0.80))
+        snap = min(0.70, max(hold + 0.20, thr_hi + 0.15))
+        if snap - hold < 0.15:
+            snap = min(0.70, hold + 0.15)
+        return hold, snap
+    return 0.30, 0.95
+
+
 def step_profile(spec: TuneSpec) -> Profile:
-    """Step-stress profile for the max_ramp constraint stage: aggressive
-    snaps into a high-current regime FROM A SPINNING STATE (0.30 hold).
+    """Step-stress profile for the max_ramp constraint stage: snaps into a
+    higher-current regime FROM A SPINNING STATE (not from a stop).
 
     Snapping from a stop (as demag_step_stress does) makes the host demag
     detector read the spool-up's long commutation intervals as spike events
-    even when nothing desynced; stepping from 0.30 keeps the detector's
-    median-interval reference honest, so only a real loss of sync (bemf
-    timeouts, interval blow-up, RPM collapse) disqualifies a max_ramp value.
+    even when nothing desynced; stepping from a spinning hold keeps the
+    detector's median-interval reference honest, so only a real loss of sync
+    (bemf timeouts, interval blow-up, RPM collapse) disqualifies a max_ramp
+    value. Snap amplitude scales with the probe envelope (see
+    :func:`_step_snap_levels`).
     """
+    hold, snap = _step_snap_levels(spec)
+    # Transient headroom: light snaps stay near probe current; full 0.95 snaps
+    # still need the 5" bench 80–100 A budget.
+    cur_floor = (RAMP_TRANSIENT_MAX_CURRENT_A if snap >= 0.85
+                 else max(RAMP_TRANSIENT_MAX_CURRENT_A * 0.6,
+                          (spec.probe.safety or {}).get("max_current_a") or 0.0))
     return profile_from_dict({
         "name": "tune_step",
         "description": "inline step-stress for the max_ramp stage (auto-tuner)",
         "sample_rate_hz": 100.0,
         "segments": [
             {"label": "idle", "throttle": 0.0, "duration_s": 2.0},
-            {"label": "spool", "throttle": 0.30, "duration_s": 2.0, "ramp": True},
-            {"label": "hold30a", "throttle": 0.30, "duration_s": 2.0},
-            {"label": "snap95a", "throttle": 0.95, "duration_s": 1.5},
-            {"label": "hold30b", "throttle": 0.30, "duration_s": 2.0},
-            {"label": "snap95b", "throttle": 0.95, "duration_s": 1.5},
-            {"label": "hold30c", "throttle": 0.30, "duration_s": 2.0},
+            {"label": "spool", "throttle": hold, "duration_s": 2.0, "ramp": True},
+            {"label": "hold_a", "throttle": hold, "duration_s": 2.0},
+            {"label": "snap_a", "throttle": snap, "duration_s": 1.5},
+            {"label": "hold_b", "throttle": hold, "duration_s": 2.0},
+            {"label": "snap_b", "throttle": snap, "duration_s": 1.5},
+            {"label": "hold_c", "throttle": hold, "duration_s": 2.0},
             {"label": "rampdn", "throttle": 0.0, "duration_s": 1.5, "ramp": True},
         ],
-        # The snaps are the point of this profile, and a legitimate
-        # 0.3->0.95 snap transient can draw into the 80-100 A range on this
-        # bench (see RAMP_TRANSIENT_MAX_CURRENT_A). Probe-level current
-        # limits would abort every candidate on that transient before demag
-        # is even assessed, so give the current limit snap headroom; all
-        # other probe safety limits apply unchanged.
         "safety": {**(spec.probe.safety or {}),
                    "max_current_a": max(
                        (spec.probe.safety or {}).get("max_current_a") or 0.0,
-                       RAMP_TRANSIENT_MAX_CURRENT_A)},
+                       cur_floor)},
     })
 
 

--- a/hwci/hwci/tuner/session.py
+++ b/hwci/hwci/tuner/session.py
@@ -653,8 +653,13 @@ class Tuner:
                  f"{None if winner_val is None else {'minimum_duty_cycle': winner_val}}")
 
     def _run_ramp_measure_stage(self, stage: StageSpec) -> None:
-        """Physics-based max_ramp: measure, compute, verify with backoff,
-        fall back to lower-ranked advance values if needed."""
+        """Physics-based max_ramp: measure, compute, bubble-search verify.
+
+        Verify no longer starts at the field ceiling and multiplies down by
+        0.7 (that forced a long desync thrash on heavy props). It climbs from
+        the safe floor (exponential probe + binary refine) so failed trials
+        are rare and bounded.
+        """
         f = resolve_field("max_ramp", None)
         indices: list[int] = []
 
@@ -666,14 +671,14 @@ class Tuner:
             indices.append(e["index"])
             if e.get("disqualified"):
                 self.log(f"stage {stage.name}: measurement run disqualified "
-                         f"({e['disqualified']}); falling back to a direct "
-                         "max_ramp search from the ceiling")
+                         f"({e['disqualified']}); falling back to bubble "
+                         "search on max_ramp from the floor")
                 return None, None
             stats = mech_ramp_stats(self._trial_rows(e))
             if stats is None:
                 self.log(f"stage {stage.name}: no usable step response in "
-                         "the measurement run; falling back to a direct "
-                         "max_ramp search from the ceiling")
+                         "the measurement run; falling back to bubble "
+                         "search on max_ramp from the floor")
                 return None, None
             limit = ramp_measure_profile(self.spec).safety.max_current_a
             budget = max(0.75 * (limit or RAMP_TRANSIENT_MAX_CURRENT_A)
@@ -687,26 +692,76 @@ class Tuner:
                 f"-> max_ramp {computed}")
             return stats, computed
 
-        def verify_with_backoff(base_ov: dict, start_v: int) -> Optional[int]:
-            v = start_v
-            while True:
-                ev = self._trial(TrialPlan(
-                    stage=stage.name, kind="verify",
-                    overrides={**base_ov, "max_ramp": v},
-                    profile=step_profile(self.spec)))
-                indices.append(ev["index"])
-                if not ev.get("disqualified"):
-                    return v
-                nxt = max(f.lo, int(v * 0.7))
-                if nxt == v:
-                    return None         # already at the floor: no winner
-                self.log(f"stage {stage.name}: verify failed at max_ramp "
-                         f"{v}; backing off to {nxt}")
-                v = nxt
+        def try_verify(base_ov: dict, v: int) -> bool:
+            ev = self._trial(TrialPlan(
+                stage=stage.name, kind="verify",
+                overrides={**base_ov, "max_ramp": v},
+                profile=step_profile(self.spec)))
+            indices.append(ev["index"])
+            ok = not ev.get("disqualified")
+            if ok:
+                self.log(f"stage {stage.name}: max_ramp {v} PASS")
+            else:
+                self.log(f"stage {stage.name}: max_ramp {v} FAIL "
+                         f"({ev.get('disqualified')})")
+            return ok
+
+        def verify_bubble_search(base_ov: dict,
+                                 hint: Optional[int]) -> Optional[int]:
+            """Largest safe max_ramp via floor-first bubble + binary refine.
+
+            1. Prove ``f.lo`` is safe (else no winner).
+            2. If ``hint`` is above the floor, try it (one shot): on pass,
+               bubble up from hint; on fail, binary-search (lo, hint).
+            3. Else geometric climb from the floor until first fail, then
+               binary-search the gap.
+            """
+            if not try_verify(base_ov, f.lo):
+                return None
+            last_pass = f.lo
+            first_fail: Optional[int] = None
+
+            def bubble_up(start: int) -> int:
+                """Geometric climb from a known-good value; returns last pass."""
+                nonlocal first_fail
+                cur = start
+                while cur < f.hi:
+                    nxt = min(f.hi, max(cur + 1, int(cur * 2)))
+                    if nxt == cur:
+                        break
+                    if try_verify(base_ov, nxt):
+                        cur = nxt
+                    else:
+                        first_fail = nxt
+                        break
+                return cur
+
+            def binary_between(lo_ok: int, hi_fail: int) -> int:
+                lo, hi = lo_ok, hi_fail
+                while hi - lo > 1:
+                    mid = (lo + hi) // 2
+                    if try_verify(base_ov, mid):
+                        lo = mid
+                    else:
+                        hi = mid
+                return lo
+
+            if hint is not None and f.lo < hint <= f.hi:
+                if try_verify(base_ov, hint):
+                    last_pass = bubble_up(hint)
+                else:
+                    first_fail = hint
+                    return binary_between(last_pass, first_fail)
+            else:
+                last_pass = bubble_up(last_pass)
+
+            if first_fail is None:
+                return last_pass
+            return binary_between(last_pass, first_fail)
 
         stats, computed = measure_and_compute()
-        winner_val = verify_with_backoff(
-            self._merged(stage, {}), computed if computed is not None else f.hi)
+        winner_val = verify_bubble_search(
+            self._merged(stage, {}), computed)
 
         winner_ov: Optional[dict] = None   # None => the top incumbent won
         if winner_val is None:
@@ -719,7 +774,7 @@ class Tuner:
             for cand in candidates:
                 self.log(f"stage {stage.name}: retrying ramp certification "
                          f"at {cand or '(firmware defaults)'}")
-                wv = verify_with_backoff({**cand, **stage.fixed}, f.hi)
+                wv = verify_bubble_search({**cand, **stage.fixed}, computed)
                 if wv is not None:
                     winner_val, winner_ov = wv, cand
                     self.log(f"stage {stage.name}: {cand or '(defaults)'} "
@@ -745,6 +800,7 @@ class Tuner:
                          else {k: round(v, 3) for k, v in stats.items()}),
             "computed_max_ramp": computed,
             "used_fallback_settings": winner_ov,
+            "search": "bubble",
             "trials": indices,
         }
         self._save()

--- a/hwci/tests/test_runner_safety.py
+++ b/hwci/tests/test_runner_safety.py
@@ -76,3 +76,102 @@ def test_standless_run_completes_within_limits():
     assert result.meta["aborted"] is None
     assert len(result.rows) == 200
     assert result.rows[0]["stand_thrust_gf"] == ""  # stand columns empty
+
+
+def test_runner_aborts_on_live_bemf_desync():
+    """Once spin is established, firmware bemf_timeout must cut the run
+    immediately — not finish the remaining high-throttle segments."""
+    from hwci.perf import PerfSample
+
+    class _DummyThrottle:
+        def __init__(self):
+            self.disarmed = False
+            self.last = 0.0
+
+        def arm(self): pass
+
+        def set(self, throttle):
+            self.last = throttle
+
+        def disarm(self):
+            self.disarmed = True
+
+        def close(self): pass
+
+    n = {"i": 0}
+
+    def perf_source():
+        n["i"] += 1
+        # Establish spin for a few ticks, then latch bemf_timeout.
+        if n["i"] < 30:
+            raw = {"bemf_timeout_state": 0, "running": 1, "e_rpm": 50,
+                   "ctrl_exec_us_last": 0, "ctrl_exec_us_max": 0,
+                   "ctrl_period_us_last": 50, "ctrl_period_us_max": 50,
+                   "ctrl_period_us_min": 50, "main_loop_us_last": 0,
+                   "main_loop_us_max": 0, "input": 1000, "duty_cycle": 500,
+                   "voltage_cv": 2200, "current_ca": 500, "temperature_c": 30,
+                   "armed": 1, "loop_iters": 1, "zero_cross_count": 10,
+                   "commutation_interval": 1000, "commutation_interval_max": 1000,
+                   "update_count": n["i"], "host_cmd": 0, "magic": 1,
+                   "version": 1, "size": 0}
+        else:
+            raw = {"bemf_timeout_state": 3, "running": 1, "e_rpm": 5,
+                   "ctrl_exec_us_last": 0, "ctrl_exec_us_max": 0,
+                   "ctrl_period_us_last": 50, "ctrl_period_us_max": 50,
+                   "ctrl_period_us_min": 50, "main_loop_us_last": 0,
+                   "main_loop_us_max": 0, "input": 1000, "duty_cycle": 500,
+                   "voltage_cv": 2200, "current_ca": 5000, "temperature_c": 30,
+                   "armed": 1, "loop_iters": 1, "zero_cross_count": 10,
+                   "commutation_interval": 50000, "commutation_interval_max": 50000,
+                   "update_count": n["i"], "host_cmd": 0, "magic": 1,
+                   "version": 1, "size": 0}
+        return PerfSample(raw=raw)
+
+    thr = _DummyThrottle()
+    sources = Sources(
+        throttle=thr,
+        stand=None,
+        perf_source=perf_source,
+        telem_source=lambda: None,
+    )
+    # 5 s would be 500 samples at 100 Hz; desync at tick 30 must abort early.
+    result = run_profile(_profile(max_current_a=200.0), sources, realtime=False)
+    assert result.meta["aborted"] is not None
+    assert "desync" in result.meta["aborted"]
+    assert "bemf_timeout" in result.meta["aborted"]
+    assert thr.disarmed is True
+    assert len(result.rows) < 200  # did not run the full 2 s segment out
+
+
+def test_runner_aborts_on_rpm_collapse_while_throttle_high():
+    from hwci.flightstand.base import StandSample
+
+    class _DummyThrottle:
+        def arm(self): pass
+        def set(self, throttle): pass
+        def disarm(self): pass
+        def close(self): pass
+
+    n = {"i": 0}
+
+    def stand_read():
+        n["i"] += 1
+        rpm = 5000.0 if n["i"] < 50 else 1000.0  # collapse after peak
+        return StandSample(t=0.0, throttle=1.0, thrust_n=5.0, torque_nm=0.0,
+                           rpm=rpm, voltage_v=22.0, current_a=10.0)
+
+    class _Stand:
+        def read_sample(self):
+            return stand_read()
+
+    sources = Sources(
+        throttle=_DummyThrottle(),
+        stand=_Stand(),
+        perf_source=lambda: None,
+        telem_source=lambda: None,
+    )
+    result = run_profile(_profile(max_current_a=200.0), sources, realtime=False)
+    assert result.meta["aborted"] is not None
+    assert "desync" in result.meta["aborted"]
+    assert "rpm collapse" in result.meta["aborted"]
+    assert len(result.rows) < 200

--- a/hwci/tests/test_runner_safety.py
+++ b/hwci/tests/test_runner_safety.py
@@ -1,5 +1,7 @@
 """Runner-level (host-side) safety enforcement - must trip on ANY rig, even
 when the stand backend does no checking of its own."""
+import pytest
+
 from hwci.config import Profile, Segment
 from hwci.esc_telem.kiss import KissFrame
 from hwci.flightstand.base import SafetyLimits
@@ -141,6 +143,51 @@ def test_runner_aborts_on_live_bemf_desync():
     assert "bemf_timeout" in result.meta["aborted"]
     assert thr.disarmed is True
     assert len(result.rows) < 200  # did not run the full 2 s segment out
+
+
+def test_live_desync_ignores_single_sample_blind_swd_glitch():
+    """A one-sample garbage jump on zc_blind_steps must not abort (bench:
+    0 -> 19e6 while eRPM/RPM were healthy)."""
+    from hwci.runner import LiveDesyncWatch, DesyncTripped
+    from hwci.perf import PerfSample
+
+    w = LiveDesyncWatch()
+    # Establish spin
+    w.check(0.30, None, PerfSample(raw={
+        "bemf_timeout_state": 0, "running": 1, "e_rpm": 50,
+        "zc_blind_steps": 0,
+    }))
+    # Single corrupt SWD word — must not raise
+    w.check(0.30, None, PerfSample(raw={
+        "bemf_timeout_state": 0, "running": 1, "e_rpm": 50,
+        "zc_blind_steps": 19_595_444,
+    }))
+    # Next healthy sample
+    w.check(0.30, None, PerfSample(raw={
+        "bemf_timeout_state": 0, "running": 1, "e_rpm": 50,
+        "zc_blind_steps": 0,
+    }))
+
+
+def test_live_desync_aborts_on_sustained_blind_burst():
+    from hwci.runner import LiveDesyncWatch, DesyncTripped
+    from hwci.perf import PerfSample
+
+    w = LiveDesyncWatch()
+    w.check(0.30, None, PerfSample(raw={
+        "bemf_timeout_state": 0, "running": 1, "e_rpm": 50,
+        "zc_blind_steps": 100,
+    }))
+    with pytest.raises(DesyncTripped, match="blind-step"):
+        # Two consecutive real-sized jumps (>=32 each)
+        w.check(0.30, None, PerfSample(raw={
+            "bemf_timeout_state": 0, "running": 1, "e_rpm": 50,
+            "zc_blind_steps": 140,
+        }))
+        w.check(0.30, None, PerfSample(raw={
+            "bemf_timeout_state": 0, "running": 1, "e_rpm": 50,
+            "zc_blind_steps": 180,
+        }))
 
 
 def test_runner_aborts_on_rpm_collapse_while_throttle_high():

--- a/hwci/tests/test_tuner.py
+++ b/hwci/tests/test_tuner.py
@@ -453,21 +453,38 @@ def test_default_tune_probe_yaml_ramps_into_large_steps():
 
 def test_step_profile_current_limit_has_snap_headroom():
     from hwci.tuner import step_profile
+    # Default probe envelope (no low max_rpm) keeps the classic 0.30→0.95 snap
+    # and the full transient current budget.
     spec = tune_spec_from_dict(small_spec(
         probe={"dwell_s": 1.0,
                "safety": {"max_current_a": 40.0, "max_thrust_n": 16.0}}))
     p = step_profile(spec)
-    # deliberate 0.3->0.95 snaps can draw 80-100 A on the bench: headroom to
-    # RAMP_TRANSIENT_MAX_CURRENT_A, while the other limits pass through
-    # unchanged
     from hwci.tuner import RAMP_TRANSIENT_MAX_CURRENT_A
     assert p.safety.max_current_a == RAMP_TRANSIENT_MAX_CURRENT_A
     assert p.safety.max_thrust_n == 16.0
+    thr = [s.throttle for s in p.segments if s.label.startswith("snap")]
+    assert thr and max(thr) >= 0.90
     spec_hi = tune_spec_from_dict(small_spec(
         probe={"dwell_s": 1.0,
                "safety": {"max_current_a": RAMP_TRANSIENT_MAX_CURRENT_A + 20}}))
     assert (step_profile(spec_hi).safety.max_current_a
             == RAMP_TRANSIENT_MAX_CURRENT_A + 20)
+
+
+def test_step_profile_softens_snap_for_heavy_prop_envelope():
+    """10\"-style probe safety must not still demand 0.30→0.95 snaps."""
+    from hwci.tuner import step_profile
+    spec = tune_spec_from_dict(small_spec(
+        probe={"dwell_s": 1.0,
+               "points": {"t20": 0.20, "t35": 0.35},
+               "safety": {"max_current_a": 55.0, "max_thrust_n": 45.0,
+                          "max_rpm": 9000}}))
+    p = step_profile(spec)
+    snaps = [s.throttle for s in p.segments if s.label.startswith("snap")]
+    holds = [s.throttle for s in p.segments if s.label.startswith("hold")]
+    assert snaps and max(snaps) <= 0.70
+    assert holds and max(holds) <= 0.30
+    assert max(snaps) - max(holds) >= 0.15
 
 
 # --------------------------------------------------------------------------
@@ -753,19 +770,16 @@ def test_e2e_measure_stage_sets_minimum_duty_cycle(tmp_path):
     assert st["winner"]["minimum_duty_cycle"] >= st["computed_minimum_duty_cycle"]
 
 
-def test_measure_stage_falls_back_to_direct_search_when_measurement_desyncs(
+def test_measure_stage_falls_back_to_bubble_search_when_measurement_desyncs(
         tmp_path):
-    """A disqualified measurement run (e.g. the unrestricted snap itself
-    desyncs) must not silently give up on the ramp stage: it should fall
-    back to the same verify+backoff search, starting from the field max,
-    that a successful measurement would have used."""
+    """A disqualified measurement run must not give up: bubble-search
+    max_ramp from the floor (not thrash down from the ceiling)."""
     import json
     spec_d = small_spec(stages=[
         {"name": "ramp", "measure": "ramp_rate", "margin": 0.8}])
-    # demag_step_threshold scaled so the unrestricted (max_ramp=255) snap
-    # desyncs on both the measure and the first verify attempt, and the
-    # backoff search only clears the sim's desync condition once max_ramp
-    # backs off to 42 (160/max_ramp scaling - see sim.py _demag_step_threshold).
+    # demag_step_threshold scaled so unrestricted (max_ramp=255) snaps
+    # desync; safe once max_ramp is low enough that
+    # jump 0.65 < 0.2*(160/max_ramp)  => max_ramp <= 49 (sim.py).
     backend = make_backend(demag_prone=True, demag_step_threshold=0.2,
                            demag_current_a=1.0)
     _, result = run_tune(tmp_path, spec_d, backend)
@@ -773,14 +787,19 @@ def test_measure_stage_falls_back_to_direct_search_when_measurement_desyncs(
     st = m["stages"]["ramp"]
     assert st["measured"] is None          # measurement itself desynced
     assert st["computed_max_ramp"] is None  # no physics to compute from
+    assert st.get("search") == "bubble"
     trials = [t for t in m["trials"] if t["stage"] == "ramp"]
     assert trials[0]["kind"] == "measure" and trials[0]["disqualified"]
     verifies = [t for t in trials if t["kind"] == "verify"]
-    # the search kept trying lower max_ramp values instead of stopping after
-    # the failed measurement
     assert len(verifies) > 1
-    assert st["winner"] == {"max_ramp": 42}
-    assert m["incumbent"]["max_ramp"] == 42
+    # Floor-first: first verify is the field lo (1), never the ceiling.
+    assert verifies[0]["overrides"]["max_ramp"] == 1
+    assert st["winner"] is not None
+    mr = st["winner"]["max_ramp"]
+    assert 1 <= mr <= 49
+    assert m["incumbent"]["max_ramp"] == mr
+    # Never probe above the first failure with a high-first 0.7 ladder.
+    assert max(t["overrides"]["max_ramp"] for t in verifies) <= 64
 
 
 def _spec_with_advance_and_ramp(**ramp_kwargs) -> dict:
@@ -934,7 +953,7 @@ def test_measure_stage_falls_back_to_alternative_advance_level(tmp_path):
             dq = ["demag events 1 > 0"]        # unrestricted snap desyncs
         elif plan.kind == "verify":
             # advance_level 18 (the efficiency winner) NEVER certifies at
-            # any max_ramp; 26 certifies once max_ramp backs off <= 80.
+            # any max_ramp; 26 certifies for max_ramp <= 80.
             if ov.get("advance_level") == 18:
                 dq = ["demag events 1 > 0"]
             elif ov.get("advance_level") == 26 and ov["max_ramp"] > 80:
@@ -951,8 +970,10 @@ def test_measure_stage_falls_back_to_alternative_advance_level(tmp_path):
 
     st = t.manifest["stages"]["ramp"]
     assert st["used_fallback_settings"] == {"advance_level": 26}
-    assert st["winner"] == {"advance_level": 26, "max_ramp": 60}
-    assert t.manifest["incumbent"] == {"advance_level": 26, "max_ramp": 60}
+    # Bubble from floor + binary refine finds the largest safe value (80),
+    # not the old 0.7-backoff ladder's first hit (60).
+    assert st["winner"] == {"advance_level": 26, "max_ramp": 80}
+    assert t.manifest["incumbent"] == {"advance_level": 26, "max_ramp": 80}
 
 
 def test_measure_stage_fallback_verifies_exactly_what_it_adopts(tmp_path):
@@ -992,8 +1013,9 @@ def test_measure_stage_fallback_verifies_exactly_what_it_adopts(tmp_path):
     t._run_measure_stage(ramp_stage)
 
     # stage.fixed (pwm_frequency=8) must have been the value actually
-    # snap-tested ...
-    assert seen_pwm_frequency_at_certify == [8]
+    # snap-tested on every verify ...
+    assert seen_pwm_frequency_at_certify
+    assert all(x == 8 for x in seen_pwm_frequency_at_certify)
     # ... and the SAME value the session adopts going forward.
     assert t.manifest["incumbent"]["pwm_frequency"] == 8
 

--- a/hwci/tunes/ark4in1-900kv-10inch.yaml
+++ b/hwci/tunes/ark4in1-900kv-10inch.yaml
@@ -1,12 +1,11 @@
 # Full auto-tune for 900KV + HQProp 10x5x3 (3-blade 10") on ARK 4IN1 (6S).
-# Same stage shape as ark4in1-2807-7035 / example.yaml; probe ceiling and
-# safety are capped for a heavy 10" load (lower eRPM, higher torque/current
-# per % throttle than 5–7" props — do not climb to 90%).
+# Efficiency probe staircase through 70%; safety sized for 10" load (not 5").
 name: ark4in1-900kv-10inch
 description: >
   Tune advance/pwm/mode/ramp/min_duty for a 900KV motor + HQProp 10x5x3 on
-  the ARK 4IN1 bench (6S). Cruise-weighted g/W at mid throttle; hard demag /
-  jitter / temp gates; min_duty crawl for DShot-idle sustain on the 10".
+  the ARK 4IN1 bench (6S). Cruise-weighted g/W through 70% throttle; hard
+  demag/jitter/temp gates; bubble-search max_ramp; min_duty crawl for DShot
+  idle on the 10".
 
 battery_cells: 6
 
@@ -18,18 +17,18 @@ thermal:
   max_start_fet_temp_c: 60.0
 
 probe:
-  # First full-tune pass aborted: default settings hit 52 A + demag at t50 on
-  # this 10"/6S setup. Cap the probe at 35% and allow short current spikes.
-  points: {t15: 0.15, t20: 0.20, t25: 0.25, t30: 0.30, t35: 0.35}
+  # Efficiency staircase to 70% (user-requested ceiling for this prop).
+  points: {t20: 0.20, t30: 0.30, t40: 0.40, t50: 0.50, t60: 0.60, t70: 0.70}
   dwell_s: 4.0
   safety:
-    max_current_a: 55.0
-    max_thrust_n: 45.0
-    max_rpm: 9000
+    max_current_a: 90.0
+    max_thrust_n: 60.0
+    max_rpm: 15000
 
 objective:
-  weights: {t15: 1.0, t20: 2.0, t25: 2.0, t30: 1.5, t35: 1.0}
-  min_power_w: 10.0
+  # Weight cruise mid-band; still score 70% lightly.
+  weights: {t20: 1.0, t30: 2.0, t40: 2.0, t50: 1.5, t60: 1.0, t70: 0.5}
+  min_power_w: 15.0
   noise_floor_pct: 2.0
 
 constraints:
@@ -74,8 +73,6 @@ stages:
     sweep: advance_level
     search: climb
     polish_radius: 4
-  # Bubble-search max_ramp from the floor + probe-scaled snap (not 0.30→0.95
-  # on heavy props). See hwci.tuner.session._run_ramp_measure_stage.
   - name: ramp
     measure: ramp_rate
     margin: 0.8
@@ -84,8 +81,6 @@ stages:
     margin: 1.15
 
 finals:
-  # Rebuild from probe.points only — do not use full efficiency_sweep (to 100%)
-  # on a 10" prop.
   profile: tune_probe
   pattern: ABBA
   repeats: 1

--- a/hwci/tunes/ark4in1-900kv-10inch.yaml
+++ b/hwci/tunes/ark4in1-900kv-10inch.yaml
@@ -1,0 +1,94 @@
+# Full auto-tune for 900KV + HQProp 10x5x3 (3-blade 10") on ARK 4IN1 (6S).
+# Same stage shape as ark4in1-2807-7035 / example.yaml; probe ceiling and
+# safety are capped for a heavy 10" load (lower eRPM, higher torque/current
+# per % throttle than 5–7" props — do not climb to 90%).
+name: ark4in1-900kv-10inch
+description: >
+  Tune advance/pwm/mode/ramp/min_duty for a 900KV motor + HQProp 10x5x3 on
+  the ARK 4IN1 bench (6S). Cruise-weighted g/W at mid throttle; hard demag /
+  jitter / temp gates; min_duty crawl for DShot-idle sustain on the 10".
+
+battery_cells: 6
+
+pack:
+  min_resting_cell_v: 3.5
+  prompt_on_swap: true
+
+thermal:
+  max_start_fet_temp_c: 60.0
+
+probe:
+  # First full-tune pass aborted: default settings hit 52 A + demag at t50 on
+  # this 10"/6S setup. Cap the probe at 35% and allow short current spikes.
+  points: {t15: 0.15, t20: 0.20, t25: 0.25, t30: 0.30, t35: 0.35}
+  dwell_s: 4.0
+  safety:
+    max_current_a: 55.0
+    max_thrust_n: 45.0
+    max_rpm: 9000
+
+objective:
+  weights: {t15: 1.0, t20: 2.0, t25: 2.0, t30: 1.5, t35: 1.0}
+  min_power_w: 10.0
+  noise_floor_pct: 2.0
+
+constraints:
+  max_demag_events: 0
+  max_bemf_timeout_samples: 0
+  jitter_max_regression_pct: 25.0
+  max_fet_temp_c: 95.0
+  max_motor_temp_c: 100.0
+  startup:
+    cycles: 5
+    max_failed: 0
+    spin_throttle: 0.12
+    min_rpm: 600
+
+anchors_every: 6
+
+parameters:
+  advance_level:
+    values: [14, 18, 22, 26, 30, 34, 38]
+    refine_step: 2
+  pwm_frequency:
+    values: [8, 16, 24, 48]
+  variable_pwm: {values: [0, 1, 2]}
+  auto_advance: {values: [0, 1]}
+
+stages:
+  - name: advance
+    sweep: advance_level
+    search: climb
+  - name: pwm
+    sweep: pwm_frequency
+    search: climb
+    fixed: {variable_pwm: 0}
+  - name: modes
+    ab_candidates:
+      - {}
+      - {variable_pwm: 1}
+      - {variable_pwm: 2}
+      - {auto_advance: 1}
+    repeats: 2
+  - name: advance_polish
+    sweep: advance_level
+    search: climb
+    polish_radius: 4
+  # Bubble-search max_ramp from the floor + probe-scaled snap (not 0.30→0.95
+  # on heavy props). See hwci.tuner.session._run_ramp_measure_stage.
+  - name: ramp
+    measure: ramp_rate
+    margin: 0.8
+  - name: min_duty
+    measure: min_duty
+    margin: 1.15
+
+finals:
+  # Rebuild from probe.points only — do not use full efficiency_sweep (to 100%)
+  # on a 10" prop.
+  profile: tune_probe
+  pattern: ABBA
+  repeats: 1
+  extra_repeats_if_close: 1
+  min_delta_pct: 1.0
+  startup_check: true


### PR DESCRIPTION
## Summary

- Replace the max_ramp verify path that started at the field ceiling and backed off by ×0.7 (long desync thrash on 10″ / high-inertia props) with a **floor-first bubble search**: prove `lo` is safe, geometric climb, binary refine to the largest safe value; optional physics hint is one probe, not a high-first ladder.
- **Scale the verify snap** to the probe envelope: classic 0.30→0.95 for 5–7″ benches; milder spinning-state steps when `max_rpm` is low or the probe ceiling is modest (e.g. 900KV + 10″).
- Add `tunes/ark4in1-900kv-10inch.yaml` (full stages including the new ramp path) and `profiles/ramp_snap_10inch.yaml` for standalone snap A/B on the 10″ bench.
- Unit tests updated/extended (`test_tuner.py`, 56 passed offline).

## Motivation

On 900KV + HQProp 10x5x3 + 6S, the old ramp stage spent dozens of trials desyncing from `max_ramp=255` downward. Steady probe trials were clean; the failure mode was the **search policy + snap geometry**, not the efficiency stack. Floor-first search and probe-scaled snaps keep certification without thrashing the plant.

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_tuner.py` (56 passed)
- [ ] Optional bench: `hwci tune --spec tunes/ark4in1-900kv-10inch.yaml --config rig.yaml --battery-cells 6`
- [ ] Optional A/B: `hwci run --profile ramp_snap_10inch --config rig.yaml --battery-cells 6` with current vs older firmware