### PR TITLE
fix(zc): episode-level desync rail — latch bad-tune restart loops

### DIFF
--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -49,4 +49,28 @@ void faultUpdateBemfTimeoutPolicy(void);
  */
 void faultHandleBemfIntervalStall(void);
 
+/*
+ * Episode-level desync rail (leaky bucket across restart cycles).
+ *
+ * Single desync episodes are already bounded (blind-step cap, miss bucket,
+ * demag-late power cut). A bad EEPROM tune can still loop forever:
+ * restart → spool → desync spike → restart. Each episode charges this
+ * bucket; healthy closed-loop time drains it. At the limit, latch
+ * ESC_FAULT_STUCK so drive stays off until the fault path clears.
+ *
+ * charge kinds: jump-check desync, stall-rail trip (incl. blind/miss limit
+ * handoff), and future demag-late saturation.
+ */
+typedef enum {
+	DESYNC_EPISODE_JUMP = 0,
+	DESYNC_EPISODE_STALL_RAIL,
+	DESYNC_EPISODE_BLIND_LIMIT,
+} desync_episode_kind_t;
+
+void faultDesyncEpisodeCharge(desync_episode_kind_t kind);
+/* 1 kHz: drain bucket when closed-loop is healthy; tick restart holdoff. */
+void faultDesyncEpisodeTick1kHz(void);
+/* True while a post-desync coast is mandatory (caller must not re-start). */
+uint8_t faultDesyncRestartHoldoffActive(void);
+
 #endif /* FAULTS_H_ */

--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -55,16 +55,17 @@ void faultHandleBemfIntervalStall(void);
  * Single desync episodes are already bounded (blind-step cap, miss bucket,
  * demag-late power cut). A bad EEPROM tune can still loop forever:
  * restart → spool → desync spike → restart. Each episode charges this
- * bucket; healthy closed-loop time drains it. At the limit, latch
- * ESC_FAULT_STUCK so drive stays off until the fault path clears.
+ * bucket; healthy closed-loop time drains it; zero throttle (pilot
+ * intervention) clears it. At the limit, latch ESC_FAULT_STUCK so drive
+ * stays off until the fault path clears.
  *
- * charge kinds: jump-check desync, stall-rail trip (incl. blind/miss limit
- * handoff), and future demag-late saturation.
+ * charge kinds: jump-check desync, stall-rail trip of an established run
+ * (zero_crosses > 100; includes the blind/miss limit handoff, which always
+ * follows an established closed loop), and future demag-late saturation.
  */
 typedef enum {
 	DESYNC_EPISODE_JUMP = 0,
 	DESYNC_EPISODE_STALL_RAIL,
-	DESYNC_EPISODE_BLIND_LIMIT,
 } desync_episode_kind_t;
 
 void faultDesyncEpisodeCharge(desync_episode_kind_t kind);

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -37,6 +37,9 @@ extern volatile uint8_t zc_miss_bucket;
 extern volatile uint8_t zc_pre_seen;
 extern volatile uint8_t zc_demag_run;
 extern volatile uint32_t zc_demag_accepts;
+/* Blind-grind rail (faults.c): blind steps this 100 ms window / cut hold */
+extern volatile uint8_t zc_blind_window_count;
+extern volatile uint16_t zc_grind_hold_ms;
 extern uint8_t filter_level;
 extern uint8_t bad_count;
 extern uint8_t bad_count_threshold;

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -47,6 +47,9 @@ extern uint8_t changeover_step;
 extern uint8_t stuckcounter;
 /* uint32_t always: DroneCAN telemetry and SITL stats both use 32-bit. */
 extern uint32_t desync_happened;
+/* Cross-episode desync rail (faults.c); saturating charge, time-based drain. */
+extern volatile uint8_t desync_episode_bucket;
+extern volatile uint16_t desync_restart_holdoff_ms;
 
 /* --- duty / throttle --- */
 extern volatile uint16_t duty_cycle;

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -14,7 +14,6 @@
 #include "peripherals.h"
 #include "functions.h"
 #include "eeprom.h"
-#include "faults.h"
 #include "hwci_perf.h"
 
 /*
@@ -88,11 +87,13 @@ RAM_FUNC void PeriodElapsedCallback()
 			// INTERVAL_TIMER past the 45000 stall threshold so the
 			// main-loop rail (faultHandleBemfIntervalStall) restarts
 			// through the startup path on its next pass instead of
-			// 22 ms from now. Charge the cross-episode desync
-			// bucket so a bad-tune restart loop latches off.
+			// 22 ms from now. That rail also charges the cross-episode
+			// desync bucket - do NOT charge here as well (it double-
+			// counted the episode), and the stall rail is guaranteed to
+			// see it: comparator interrupts are masked, so no accepted
+			// crossing can reset INTERVAL_TIMER before the main loop.
 			maskPhaseInterrupts();
 			SET_INTERVAL_TIMER_COUNT(46000);
-			faultDesyncEpisodeCharge(DESYNC_EPISODE_BLIND_LIMIT);
 			return;
 		}
 		blind = 1;

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -99,6 +99,9 @@ RAM_FUNC void PeriodElapsedCallback()
 		blind = 1;
 		zc_blind_steps++;
 		zc_miss_bucket += ZC_MISS_BUCKET_INC;
+		if (zc_blind_window_count < 255) {
+			zc_blind_window_count++; // grind-rate window (faults.c, 1 kHz)
+		}
 		HWCI_PERF_BLIND_STEP();
 		// Take the full elapsed time as the (late) crossing measurement
 		// and commutate now. The inflated interval feeds the average so
@@ -342,6 +345,7 @@ void startMotor()
 		zc_deadline_armed = 0;
 		zc_blind_steps = 0;
 		zc_miss_bucket = 0;
+		zc_blind_window_count = 0;
 		zc_pre_seen = 1;
 		zc_demag_run = 0;
 		commutate();

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -14,6 +14,7 @@
 #include "peripherals.h"
 #include "functions.h"
 #include "eeprom.h"
+#include "faults.h"
 #include "hwci_perf.h"
 
 /*
@@ -87,9 +88,11 @@ RAM_FUNC void PeriodElapsedCallback()
 			// INTERVAL_TIMER past the 45000 stall threshold so the
 			// main-loop rail (faultHandleBemfIntervalStall) restarts
 			// through the startup path on its next pass instead of
-			// 22 ms from now.
+			// 22 ms from now. Charge the cross-episode desync
+			// bucket so a bad-tune restart loop latches off.
 			maskPhaseInterrupts();
 			SET_INTERVAL_TIMER_COUNT(46000);
+			faultDesyncEpisodeCharge(DESYNC_EPISODE_BLIND_LIMIT);
 			return;
 		}
 		blind = 1;

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -289,7 +289,16 @@ void setInput()
 #ifndef BRUSHED_MODE
 	if (escMaySixStepThrottle()) {
 		if (input >= 47 + (80 * eepromBuffer.use_sine_start)) {
-			if (!escIsDriving()) {
+			// Re-entry into six-step happens HERE, at input-frame rate -
+			// not in runtimeMotorModeTick. The episode-rail coast (holdoff
+			// or latched fault) must gate this branch or the mode tick's
+			// running=0 and this restart chatter against each other at
+			// kHz rate, pulsing startMotor() commutations through the
+			// whole "coast". escIsFault() also covers the latch when
+			// stuck_rotor_protection is disabled in EEPROM (the
+			// faultHandleStuckRotorIfNeeded gate above honors that flag;
+			// the episode rail is independent of it).
+			if (!escIsDriving() && !escIsFault() && !faultDesyncRestartHoldoffActive()) {
 				allOff();
 				if (!old_routine) {
 					startMotor();

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -472,14 +472,18 @@ void setInput()
 	if (zc_demag_run > zc_untrusted_steps) {
 		zc_untrusted_steps = zc_demag_run;
 	}
-	if (!old_routine && running && zc_untrusted_steps >= 2) {
+	// zc_grind_hold_ms keeps the cut engaged through a blind-grind (faults.c):
+	// without it a single accepted crossing resets zc_blind_steps, the cap
+	// releases, and duty re-slews into the next spike (bench: 102 A limit
+	// cycle at 19.5% miss rate, pr48-snap-rail-1).
+	if (!old_routine && running && (zc_untrusted_steps >= 2 || zc_grind_hold_ms)) {
 		/* Fixed protective cut — do NOT raise the floor with EEPROM
 		 * min_startup_duty / startup power. A misconfigured high
 		 * startup duty is exactly what this cut must bound; scaling
 		 * it away left wrong-phase drive near full heat. Worst case
 		 * the motor coasts and the stall rail restarts (or the
 		 * episode bucket latches). */
-		uint16_t blind_cap = (zc_untrusted_steps >= 4) ? 250 : 500;
+		uint16_t blind_cap = (zc_untrusted_steps >= 4 || zc_grind_hold_ms) ? 250 : 500;
 		if (duty_cycle_setpoint > blind_cap) {
 			duty_cycle_setpoint = blind_cap;
 		}

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -464,10 +464,13 @@ void setInput()
 		zc_untrusted_steps = zc_demag_run;
 	}
 	if (!old_routine && running && zc_untrusted_steps >= 2) {
+		/* Fixed protective cut — do NOT raise the floor with EEPROM
+		 * min_startup_duty / startup power. A misconfigured high
+		 * startup duty is exactly what this cut must bound; scaling
+		 * it away left wrong-phase drive near full heat. Worst case
+		 * the motor coasts and the stall rail restarts (or the
+		 * episode bucket latches). */
 		uint16_t blind_cap = (zc_untrusted_steps >= 4) ? 250 : 500;
-		if (blind_cap < min_startup_duty) {
-			blind_cap = min_startup_duty;
-		}
 		if (duty_cycle_setpoint > blind_cap) {
 			duty_cycle_setpoint = blind_cap;
 		}
@@ -575,6 +578,7 @@ RAM_FUNC void tenKhzRoutine()
 		if (one_khz_loop_counter > PID_LOOP_DIVIDER) { // 1khz PID loop
 			PROCESS_ADC_FLAG = 1;		       // set flag to do new adc read at lower priority
 			one_khz_loop_counter = 0;
+			faultDesyncEpisodeTick1kHz();
 			if (use_current_limit && escIsDriving()) {
 				use_current_limit_adjust -=
 					(int16_t)(doPidCalculations(&currentPid, actual_current, eepromBuffer.limits.current * 2 * 100) /

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -118,6 +118,96 @@ void faultUpdateBemfTimeoutPolicy(void)
 #endif
 }
 
+/*
+ * Cross-episode desync protection. Per-episode rails (blind-step cap, miss
+ * bucket, demag-late power cut) bound a single event; this bucket bounds a
+ * *repeating* restart→desync cycle from a bad tune / wrong prop match.
+ *
+ * Charge rates are tuned so 3–5 hard episodes latch within ~1–2 s of cycling,
+ * while a couple of honest in-flight desyncs drain out in a few seconds of
+ * healthy closed-loop. Restart holdoff grows with the bucket so the FETs
+ * spend most of each cycle cooling instead of immediately re-entering the
+ * wrong-phase current spike.
+ */
+#define DESYNC_EPISODE_LIMIT 40
+#define DESYNC_EPISODE_CHARGE_JUMP 8
+#define DESYNC_EPISODE_CHARGE_STALL 12
+#define DESYNC_EPISODE_CHARGE_BLIND 12
+#define DESYNC_EPISODE_DRAIN_MS 100 /* −1 charge per this many ms of healthy CL */
+#define DESYNC_BACKOFF_BASE_MS 100
+#define DESYNC_BACKOFF_STEP_MS 50
+#define DESYNC_BACKOFF_MAX_MS 500
+
+static uint8_t desync_episode_drain_ms;
+
+static void desync_episode_apply_backoff(void)
+{
+	uint16_t hold = (uint16_t)(DESYNC_BACKOFF_BASE_MS + (uint16_t)desync_episode_bucket * DESYNC_BACKOFF_STEP_MS);
+	if (hold > DESYNC_BACKOFF_MAX_MS) {
+		hold = DESYNC_BACKOFF_MAX_MS;
+	}
+	if (hold > desync_restart_holdoff_ms) {
+		desync_restart_holdoff_ms = hold;
+	}
+}
+
+void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
+{
+#ifndef BRUSHED_MODE
+	uint8_t inc = DESYNC_EPISODE_CHARGE_STALL;
+	if (kind == DESYNC_EPISODE_JUMP) {
+		inc = DESYNC_EPISODE_CHARGE_JUMP;
+	} else if (kind == DESYNC_EPISODE_BLIND_LIMIT) {
+		inc = DESYNC_EPISODE_CHARGE_BLIND;
+	}
+	if ((uint16_t)desync_episode_bucket + inc > 255) {
+		desync_episode_bucket = 255;
+	} else {
+		desync_episode_bucket = (uint8_t)(desync_episode_bucket + inc);
+	}
+	desync_episode_drain_ms = 0;
+	desync_episode_apply_backoff();
+
+	if (desync_episode_bucket >= DESYNC_EPISODE_LIMIT) {
+		allOff();
+		maskPhaseInterrupts();
+		escToFaultStuck();
+#	ifdef USE_RGB_LED
+		setIndividualRGBLed(1, 0, 0);
+#	endif
+	}
+#else
+	(void)kind;
+#endif
+}
+
+void faultDesyncEpisodeTick1kHz(void)
+{
+#ifndef BRUSHED_MODE
+	if (desync_restart_holdoff_ms > 0) {
+		desync_restart_holdoff_ms--;
+	}
+
+	/* Drain only in established, trusted closed loop. */
+	if (escInClosedLoop() && zc_blind_steps == 0 && zc_demag_run == 0 && bemf_timeout_happened == 0 && desync_episode_bucket > 0) {
+		if (desync_episode_drain_ms < 255) {
+			desync_episode_drain_ms++;
+		}
+		if (desync_episode_drain_ms >= DESYNC_EPISODE_DRAIN_MS) {
+			desync_episode_drain_ms = 0;
+			desync_episode_bucket--;
+		}
+	} else {
+		desync_episode_drain_ms = 0;
+	}
+#endif
+}
+
+uint8_t faultDesyncRestartHoldoffActive(void)
+{
+	return (uint8_t)(desync_restart_holdoff_ms > 0);
+}
+
 void faultHandleBemfIntervalStall(void)
 {
 	/* Six-step only (not sine soft-start). */
@@ -125,8 +215,21 @@ void faultHandleBemfIntervalStall(void)
 		bemf_timeout_happened++;
 
 		maskPhaseInterrupts();
+		faultDesyncEpisodeCharge(DESYNC_EPISODE_STALL_RAIL);
+		if (escIsFault()) {
+			/* Episode rail latched: do not re-enter startup. */
+			zero_crosses = 0;
+			running = 0;
+			return;
+		}
 		escNoteStallOrDesync(1);
 		zero_crosses = 0;
+		if (faultDesyncRestartHoldoffActive()) {
+			/* Coast until holdoff expires; main loop will re-arm. */
+			running = 0;
+			allOff();
+			return;
+		}
 		zcfoundroutine();
 	}
 }

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -97,6 +97,15 @@ void faultUpdateBemfTimeoutPolicy(void)
 	if ((zero_crosses > 1000) || (adjusted_input == 0)) {
 		bemf_timeout_happened = 0;
 	}
+	if (adjusted_input == 0) {
+		// Zero throttle is pilot intervention: clear the episode rail the
+		// same way the legacy latch clears. Deliberately NOT on
+		// zero_crosses > 1000 - a bad-tune cycle that respins fast between
+		// desyncs must keep accumulating (that reset defeating the stuck
+		// latch is one of the gaps this rail exists to close).
+		desync_episode_bucket = 0;
+		desync_restart_holdoff_ms = 0;
+	}
 	if (zero_crosses > 100 && adjusted_input < 200) {
 		bemf_timeout_happened = 0;
 	}
@@ -123,26 +132,36 @@ void faultUpdateBemfTimeoutPolicy(void)
  * bucket, demag-late power cut) bound a single event; this bucket bounds a
  * *repeating* restart→desync cycle from a bad tune / wrong prop match.
  *
- * Charge rates are tuned so 3–5 hard episodes latch within ~1–2 s of cycling,
+ * Charge rates are tuned so 3-5 hard episodes latch within ~1-2 s of cycling,
  * while a couple of honest in-flight desyncs drain out in a few seconds of
- * healthy closed-loop. Restart holdoff grows with the bucket so the FETs
- * spend most of each cycle cooling instead of immediately re-entering the
- * wrong-phase current spike.
+ * healthy closed-loop (stall: 4 episodes at 12; jump: 5 at 8).
+ *
+ * The FIRST episode must restart immediately - an honest in-flight desync
+ * that coasts even 100 ms is a dropped motor on a quad - so restart holdoff
+ * only arms once the bucket shows repetition (>= MIN_BUCKET, i.e. from the
+ * second episode on) and then grows so the FETs spend most of each later
+ * cycle cooling instead of immediately re-entering the wrong-phase spike.
+ * Stall path: ep2 300 ms, ep3 500 ms, ep4 latch. Jump path: ep2 100 ms,
+ * ep3 300 ms, ep4 500 ms, ep5 latch.
  */
 #define DESYNC_EPISODE_LIMIT 40
 #define DESYNC_EPISODE_CHARGE_JUMP 8
 #define DESYNC_EPISODE_CHARGE_STALL 12
-#define DESYNC_EPISODE_CHARGE_BLIND 12
-#define DESYNC_EPISODE_DRAIN_MS 100 /* −1 charge per this many ms of healthy CL */
+#define DESYNC_EPISODE_DRAIN_MS 100  /* -1 charge per this many ms of healthy CL */
+#define DESYNC_BACKOFF_MIN_BUCKET 16 /* below this (first episode): no holdoff */
 #define DESYNC_BACKOFF_BASE_MS 100
-#define DESYNC_BACKOFF_STEP_MS 50
+#define DESYNC_BACKOFF_STEP_MS 25
 #define DESYNC_BACKOFF_MAX_MS 500
 
 static uint8_t desync_episode_drain_ms;
 
 static void desync_episode_apply_backoff(void)
 {
-	uint16_t hold = (uint16_t)(DESYNC_BACKOFF_BASE_MS + (uint16_t)desync_episode_bucket * DESYNC_BACKOFF_STEP_MS);
+	if (desync_episode_bucket < DESYNC_BACKOFF_MIN_BUCKET) {
+		return; // first episode restarts immediately (legacy behavior)
+	}
+	uint16_t hold =
+		(uint16_t)(DESYNC_BACKOFF_BASE_MS + (uint16_t)(desync_episode_bucket - DESYNC_BACKOFF_MIN_BUCKET) * DESYNC_BACKOFF_STEP_MS);
 	if (hold > DESYNC_BACKOFF_MAX_MS) {
 		hold = DESYNC_BACKOFF_MAX_MS;
 	}
@@ -157,8 +176,6 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
 	uint8_t inc = DESYNC_EPISODE_CHARGE_STALL;
 	if (kind == DESYNC_EPISODE_JUMP) {
 		inc = DESYNC_EPISODE_CHARGE_JUMP;
-	} else if (kind == DESYNC_EPISODE_BLIND_LIMIT) {
-		inc = DESYNC_EPISODE_CHARGE_BLIND;
 	}
 	if ((uint16_t)desync_episode_bucket + inc > 255) {
 		desync_episode_bucket = 255;
@@ -188,8 +205,11 @@ void faultDesyncEpisodeTick1kHz(void)
 		desync_restart_holdoff_ms--;
 	}
 
-	/* Drain only in established, trusted closed loop. */
-	if (escInClosedLoop() && zc_blind_steps == 0 && zc_demag_run == 0 && bemf_timeout_happened == 0 && desync_episode_bucket > 0) {
+	/* Drain only in established, trusted closed loop. bemf_timeout_happened
+	 * is deliberately NOT in the gate: it stays nonzero until
+	 * zero_crosses > 1000 (5-10 s at crawler rpm), which would block drain
+	 * through exactly the healthy running that should earn it. */
+	if (escInClosedLoop() && zc_blind_steps == 0 && zc_demag_run == 0 && desync_episode_bucket > 0) {
 		if (desync_episode_drain_ms < 255) {
 			desync_episode_drain_ms++;
 		}
@@ -215,7 +235,20 @@ void faultHandleBemfIntervalStall(void)
 		bemf_timeout_happened++;
 
 		maskPhaseInterrupts();
-		faultDesyncEpisodeCharge(DESYNC_EPISODE_STALL_RAIL);
+		// Charge the episode rail only when this run was ESTABLISHED
+		// before it died (the bad-tune restart->spool->desync cycle
+		// always reaches closed loop first). A start attempt that never
+		// got going is the legacy stuck-rotor rail's job, with its
+		// throttle-scaled tolerance (bemf_timeout 100 below input 150) -
+		// heavy props legitimately kick many times at low throttle, and
+		// charging those latched the ESC on the 4th kick. This gate also
+		// covers the blind/miss-limit handoff (bemf_zc kicks
+		// INTERVAL_TIMER to 46000 with comparator interrupts masked, so
+		// this rail is guaranteed to run next pass): blind stepping only
+		// arms at zero_crosses >= 100, so those episodes always charge.
+		if (zero_crosses > 100) {
+			faultDesyncEpisodeCharge(DESYNC_EPISODE_STALL_RAIL);
+		}
 		if (escIsFault()) {
 			/* Episode rail latched: do not re-enter startup. */
 			zero_crosses = 0;

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -153,7 +153,41 @@ void faultUpdateBemfTimeoutPolicy(void)
 #define DESYNC_BACKOFF_STEP_MS 25
 #define DESYNC_BACKOFF_MAX_MS 500
 
+/*
+ * Blind-GRIND rail. The episode rail above only sees DISCRETE failures
+ * (jump desync, stall trip). Bench 2026-07-23 (pr48-snap-rail-1, 900KV +
+ * 10x5x3 6S, snap 0.20->0.55): a spinning snap can drop the loop into a
+ * CONTINUOUS partial desync that sits below every threshold - 423 blind
+ * steps/s at a 19.5% miss rate (miss bucket needs >25% and net-drains;
+ * consecutive counter resets on every accepted crossing; CI step +45% is
+ * under the jump check's 50%; the stall rail never fires because blind
+ * steps keep resetting INTERVAL_TIMER) - while the power cut engages and
+ * releases in a limit cycle (one accepted crossing resets zc_blind_steps,
+ * duty re-slews at max_ramp, spike to 102 A, desync, repeat).
+ *
+ * The unambiguous signal is the blind-step RATE: healthy runs total 9-27
+ * blind steps per RUN; the grind produces 40+ per 100 ms. Sample
+ * zc_blind_window_count each 100 ms; ONE hot window holds the power cut
+ * AND forces the stall rail (mask + kick INTERVAL_TIMER, same primitives
+ * as the blind-limit handoff), which restarts the loop and charges the
+ * episode bucket (zero_crosses is far above 100 in a grind), so
+ * repetition escalates through backoff to the latch like any other
+ * episode source.
+ *
+ * Restart on the FIRST hot window, not after N consecutive: requiring
+ * consecutive hot windows is self-defeating (bench pr48-snap-rail-2) -
+ * the held cut drops the blind rate below threshold, the streak resets,
+ * no restart ever fires, and each hold expiry re-slews duty into a fresh
+ * spike (33-88 A at ~600 ms period). The detection margin carries a
+ * single-window trigger, and a false trip costs one restart plus one
+ * episode charge that drains in ~1.2 s of healthy running.
+ */
+#define GRIND_WINDOW_MS 100
+#define GRIND_WINDOW_BLIND_LIMIT 15 /* >=150 blind/s = grind; healthy bursts stay single-digit */
+#define GRIND_HOLD_MS 250
+
 static uint8_t desync_episode_drain_ms;
+static uint8_t grind_window_ms;
 
 static void desync_episode_apply_backoff(void)
 {
@@ -203,6 +237,30 @@ void faultDesyncEpisodeTick1kHz(void)
 #ifndef BRUSHED_MODE
 	if (desync_restart_holdoff_ms > 0) {
 		desync_restart_holdoff_ms--;
+	}
+	if (zc_grind_hold_ms > 0) {
+		zc_grind_hold_ms--;
+	}
+
+	/* Blind-grind window (see block comment above the constants). */
+	if (++grind_window_ms >= GRIND_WINDOW_MS) {
+		grind_window_ms = 0;
+		uint8_t blind_in_window = zc_blind_window_count;
+		zc_blind_window_count = 0; // a step between read and clear is one lost count - fine
+		if (blind_in_window >= GRIND_WINDOW_BLIND_LIMIT && running && !old_routine) {
+			// Hot window: hold the power cut (bridges the gap until the
+			// restart takes and covers any deferred path) and force the
+			// stall rail, same primitives as the blind-limit handoff in
+			// PeriodElapsedCallback: with phase interrupts masked and
+			// the deadline disarmed, nothing can reset INTERVAL_TIMER
+			// before the main loop runs faultHandleBemfIntervalStall,
+			// which restarts and charges the episode bucket.
+			zc_grind_hold_ms = GRIND_HOLD_MS;
+			maskPhaseInterrupts();
+			DISABLE_COM_TIMER_INT();
+			zc_deadline_armed = 0;
+			SET_INTERVAL_TIMER_COUNT(46000);
+		}
 	}
 
 	/* Drain only in established, trusted closed loop. bemf_timeout_happened

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -54,6 +54,9 @@ volatile uint8_t zc_miss_bucket = 0;
 volatile uint8_t zc_pre_seen = 0;
 volatile uint8_t zc_demag_run = 0;
 volatile uint32_t zc_demag_accepts = 0;
+/* Blind-grind rail (faults.c): blind steps this 100 ms window / cut hold */
+volatile uint8_t zc_blind_window_count = 0;
+volatile uint16_t zc_grind_hold_ms = 0;
 volatile uint8_t ramp_divider;
 volatile uint8_t max_ramp_startup = RAMP_SPEED_STARTUP;
 volatile uint8_t max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -113,6 +113,8 @@ uint32_t REV_Id = 0;
 uint16_t armed_timeout_count;
 uint16_t reverse_speed_threshold = 1500;
 uint32_t desync_happened = 0;
+volatile uint8_t desync_episode_bucket = 0;
+volatile uint16_t desync_restart_holdoff_ms = 0;
 char maximum_throttle_change_ramp = 1;
 
 char crawler_mode = 0; // no longer used //

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -266,13 +266,20 @@ void runtimeMotorModeTick(void)
 	/* Once per main loop: ISR flag side-effects → named esc_state (not in 20 kHz). */
 	escReconcileFromFlags();
 	stuckcounter = 0;
-	/* Post-desync coast: do not re-enter six-step until holdoff expires. */
+	/* Post-desync coast: do not re-enter six-step until holdoff expires.
+	 * (setInput's start branch is gated the same way - this alone cannot
+	 * hold the motor off, it only kills a run that was already going.) */
 	if (faultDesyncRestartHoldoffActive() || escIsFault()) {
 		if (running) {
 			running = 0;
 			allOff();
 			maskPhaseInterrupts();
 		}
+		// The early return skips the e_rpm update below; zero it so
+		// telemetry (DroneCAN) reports the coast instead of the last
+		// running rpm for up to the whole holdoff.
+		e_rpm = 0;
+		k_erpm = 0;
 		return;
 	}
 	if (!escInSineStart()) {

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -122,6 +122,7 @@ void runtimeProcessDesyncCheck(void)
 			slow_avg_revs = 0;
 			zero_crosses = 0;
 			desync_happened++;
+			faultDesyncEpisodeCharge(DESYNC_EPISODE_JUMP);
 			if ((!eepromBuffer.bi_direction && (input > 47)) || commutation_interval > 1000) {
 				running = 0;
 			}
@@ -131,6 +132,11 @@ void runtimeProcessDesyncCheck(void)
 				average_interval = 5000;
 			}
 			last_duty_cycle = min_startup_duty / 2;
+			if (faultDesyncRestartHoldoffActive() || escIsFault()) {
+				running = 0;
+				allOff();
+				maskPhaseInterrupts();
+			}
 		}
 		desync_check = 0;
 		//	}
@@ -260,6 +266,15 @@ void runtimeMotorModeTick(void)
 	/* Once per main loop: ISR flag side-effects → named esc_state (not in 20 kHz). */
 	escReconcileFromFlags();
 	stuckcounter = 0;
+	/* Post-desync coast: do not re-enter six-step until holdoff expires. */
+	if (faultDesyncRestartHoldoffActive() || escIsFault()) {
+		if (running) {
+			running = 0;
+			allOff();
+			maskPhaseInterrupts();
+		}
+		return;
+	}
 	if (!escInSineStart()) {
 		e_rpm = running * (600000 / e_com_time); // in tens of rpm
 		k_erpm = e_rpm / 10;			 // ecom time is time for one electrical revolution in microseconds

--- a/hwci/hwci/profiles/prop10_badtune_latch.yaml
+++ b/hwci/hwci/profiles/prop10_badtune_latch.yaml
@@ -1,0 +1,43 @@
+name: prop10_badtune_latch
+description: >
+  PR48 episode-rail validation on the known bad tune (advance 26 + auto_advance
+  + fixed pwm reproduced constant demag at t50 / 52 A on 900KV + 10x5x3, 6S;
+  see tune-900kv-10inch-70pct-20260723 runs). EXPECTED behavior on PR48
+  firmware: demag-late power cut bounds current far below the 52 A runaway,
+  desync episodes charge the bucket, and sustained cycling latches FAULT_STUCK
+  (bemf_timeout_samples > 0, esc_state FAULT_STUCK) during hold50/hold60. The
+  zero-throttle segment must clear the latch and the final 20% hold must spin
+  healthy. Smoke gates are off - the "failure" is the point; judge from the
+  report. Safety current is set BELOW the historic 52 A runaway so a rail
+  failure aborts the run instead of cooking the FETs. Write
+  config/prop10_badtune_adv26.bin before this run; restore
+  config/prop10_good_tuned.bin after.
+sample_rate_hz: 200
+arm_settle_s: 3.0
+pole_pairs: 7
+demag_rpm_drop_fraction: 0.25
+demag_commutation_spike: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 35.0
+  max_motor_temp_c: 80.0
+  max_rpm: 12000
+  max_thrust_n: 35.0
+
+smoke_gates:
+  enabled: false
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: ramp30,  throttle: 0.30, duration_s: 3.0, ramp: true}
+  - {label: hold30,  throttle: 0.30, duration_s: 4.0, steady: true}   # healthy reference
+  - {label: ramp50,  throttle: 0.50, duration_s: 3.0, ramp: true}
+  - {label: hold50,  throttle: 0.50, duration_s: 8.0}                 # historic failure point
+  - {label: ramp60,  throttle: 0.60, duration_s: 3.0, ramp: true}
+  - {label: hold60,  throttle: 0.60, duration_s: 6.0}                 # push through if 50 rode out
+  - {label: cut,     throttle: 0.00, duration_s: 4.0}                 # latch clear (pilot zero throttle)
+  - {label: ramp20,  throttle: 0.20, duration_s: 3.0, ramp: true}
+  - {label: hold20,  throttle: 0.20, duration_s: 4.0, steady: true}   # healthy restart after clear
+  - {label: rampdn,  throttle: 0.00, duration_s: 3.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/prop10_badtune_snap.yaml
+++ b/hwci/hwci/profiles/prop10_badtune_snap.yaml
@@ -1,0 +1,45 @@
+name: prop10_badtune_snap
+description: >
+  PR48 episode-rail validation, snap-start vector. The constant demag-late
+  lock engages on WARM snap starts (bench 2026-07-22: ~1/3 of warm, 100% of
+  hot snap starts settle ~30% slow at 8-10x current) - the slow-ramp
+  staircase (prop10_badtune_latch) does NOT reproduce it. Run this
+  immediately after a warming run, with the bad tune
+  (config/prop10_badtune_adv26.bin) written. Five stop -> snap-to-50% cycles;
+  each snap start from standstill on the hot 10" is the trigger. EXPECTED on
+  PR48: demag-late cut bounds each episode, repeated desync episodes charge
+  the bucket, latch (perf_bemf_timeout >= 102) if it cycles; final segments
+  verify zero-throttle clear + healthy restart. Safety current is far below
+  the historic 52 A lock so a rail failure aborts fast.
+sample_rate_hz: 200
+arm_settle_s: 2.0
+pole_pairs: 7
+demag_rpm_drop_fraction: 0.25
+demag_commutation_spike: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  max_current_a: 35.0
+  max_motor_temp_c: 80.0
+  max_rpm: 12000
+  max_thrust_n: 35.0
+
+smoke_gates:
+  enabled: false
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: snap50a, throttle: 0.50, duration_s: 3.0}   # snap start from standstill
+  - {label: stop_a,  throttle: 0.00, duration_s: 2.5}
+  - {label: snap50b, throttle: 0.50, duration_s: 3.0}
+  - {label: stop_b,  throttle: 0.00, duration_s: 2.5}
+  - {label: snap50c, throttle: 0.50, duration_s: 3.0}
+  - {label: stop_c,  throttle: 0.00, duration_s: 2.5}
+  - {label: snap50d, throttle: 0.50, duration_s: 3.0}
+  - {label: stop_d,  throttle: 0.00, duration_s: 2.5}
+  - {label: snap50e, throttle: 0.50, duration_s: 3.0}
+  - {label: cut,     throttle: 0.00, duration_s: 4.0}   # latch clear window
+  - {label: ramp20,  throttle: 0.20, duration_s: 3.0, ramp: true}
+  - {label: hold20,  throttle: 0.20, duration_s: 4.0, steady: true}  # healthy restart
+  - {label: rampdn,  throttle: 0.00, duration_s: 2.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/profiles/prop10_snap_demag_rail.yaml
+++ b/hwci/hwci/profiles/prop10_snap_demag_rail.yaml
@@ -1,0 +1,50 @@
+name: prop10_snap_demag_rail
+description: >
+  PR48 episode-rail validation on the real constant-demag vector for the 10"
+  prop: spinning snap transitions (tuner ramp-stage geometry). History on this
+  rig: measure snaps 0.20->0.55 drew 100-165 A with demag (spec note,
+  ark4in1-900kv-10inch), and the 12:00 tune baselines ground through t30 with
+  ~1650 blind steps / rpm halved / 40 A for a full 2 s hold without
+  recovering. Settings are NOT the trigger (failing and passing runs used the
+  same tune) - run with config/prop10_good_tuned.bin. EXPECTED on PR48: if
+  the snap desyncs, the blind cut bounds current, blind/miss-limit stall
+  episodes charge the bucket with growing coasts, and sustained cycling
+  latches FAULT_STUCK (perf_bemf_timeout >= 102); the cut segment clears the
+  latch and hold15 must spin healthy. The failure is nondeterministic - two
+  snap bites per run; repeat the run if both stay clean. Safety current sits
+  between the healthy snap transient (~40 A) and the historic runaway
+  (100+ A) so a rail failure aborts immediately.
+sample_rate_hz: 200
+arm_settle_s: 2.0
+pole_pairs: 7
+demag_rpm_drop_fraction: 0.25
+demag_commutation_spike: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  # The INITIAL snap transient on this prop is legitimately 30-75 A for
+  # tens of ms (healthy morning snap95: 67 A under a 120 A allowance) and
+  # no desync rail can act inside the first grind window - runs 1-3
+  # aborted on that transient at 60 A and proved nothing. 85 sits above
+  # the honest transient band and below the historic 100-165 A runaway.
+  max_current_a: 85.0
+  max_motor_temp_c: 80.0
+  max_rpm: 12000
+  max_thrust_n: 40.0
+
+smoke_gates:
+  enabled: false
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: spool,   throttle: 0.20, duration_s: 3.0, ramp: true}
+  - {label: hold20a, throttle: 0.20, duration_s: 3.0, steady: true}
+  - {label: snap55a, throttle: 0.55, duration_s: 3.0}   # historic 100-165 A demag vector
+  - {label: back20a, throttle: 0.20, duration_s: 3.0}   # decel re-sync stress
+  - {label: snap55b, throttle: 0.55, duration_s: 3.0}
+  - {label: back20b, throttle: 0.20, duration_s: 3.0}
+  - {label: cut,     throttle: 0.00, duration_s: 4.0}   # latch clear (pilot zero throttle)
+  - {label: ramp15,  throttle: 0.15, duration_s: 3.0, ramp: true}
+  - {label: hold15,  throttle: 0.15, duration_s: 4.0, steady: true}  # healthy restart check
+  - {label: rampdn,  throttle: 0.00, duration_s: 2.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 2.0}


### PR DESCRIPTION
## Summary

Implements the **cross-episode** half of desync protection (layers 1, 2, 4):

1. **Episode leaky bucket** — charge on jump-check desync, stall-rail trips (including blind/miss-limit handoff); drain −1 / 100 ms of healthy closed-loop; at limit latch via `escToFaultStuck()` so drive stays off.
2. **Restart backoff** — holdoff grows with the bucket (100–500 ms); stall path coasts instead of immediately re-entering startup.
3. **Fixed blind/demag duty cut** — remove `min_startup_duty` floor under the untrusted-step cap so high EEPROM startup power cannot weaken the protective cut.

Per-episode rails (8 consecutive blind steps, miss-rate bucket, demag-late power cut) are unchanged.

## Why

A bad tune (too much advance / high startup / prop mismatch) produces an infinite cycle: restart → spool → wrong-phase current spike → restart. `desync_happened` is telemetry-only; `bemf_timeout_happened` resets as soon as `zero_crosses > 1000` (often &lt;100 ms at high eRPM), so stuck-rotor never latches. The protective duty cut was also raised by `min_startup_duty`, i.e. the misconfiguration itself.

## Test plan

- [x] `make ARK_4IN1_F051 HWCI_PERF=1` + `scripts/check-size-ark.sh` PASS (93.06% flash / 85.80% RAM)
- [x] `make AM32_SITL_CAN`
- [ ] Bench: deliberately bad EEPROM (high advance + high startup) should latch stuck/desync fault after a few restart cycles, not run indefinitely
- [ ] Bench: existing snap/spool smoke profiles should not false-latch (bucket drains under healthy CL)
- [ ] Optional: hwci profile that asserts latch under bad tune (follow-up)