### PR TITLE
fix(zc): gate jump-desync episode charge on established runs

### DIFF
--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -120,9 +120,21 @@ void runtimeProcessDesyncCheck(void)
 		}
 		if (desynced) {
 			slow_avg_revs = 0;
+			const uint32_t zc_at_desync = zero_crosses;
 			zero_crosses = 0;
 			desync_happened++;
-			faultDesyncEpisodeCharge(DESYNC_EPISODE_JUMP);
+			// Same established-run gate as the stall rail (see
+			// faultHandleBemfIntervalStall): interval jumps while the
+			// loop is still acquiring (zc 11..100) are normal startup
+			// roughness on light motors - charging them stacks holdoff
+			// and ramp back-off onto honest starts until the bucket
+			// latches a motor that never got going (SITL racer model
+			// reproduces this under plain dshot spool). Legacy desync
+			// handling below still restarts; only the episode
+			// accounting is established-runs-only.
+			if (zc_at_desync > 100) {
+				faultDesyncEpisodeCharge(DESYNC_EPISODE_JUMP);
+			}
 			if ((!eepromBuffer.bi_direction && (input > 47)) || commutation_interval > 1000) {
 				running = 0;
 			}


### PR DESCRIPTION
Hotfix for the CI failure on ark-release (`test_racer_model_spins_under_dshot`, rpm=0) introduced by the #48 squash.

The interval-jump desync check arms at `zero_crosses > 10`, so honest start attempts (zc 11–100, rough poll-ZC intervals on light motors) charged the episode bucket: restart holdoff stacked onto every start until the bucket latched a motor that never got going. SITL's racer model reproduces it under a plain dshot spool — 4 jump charges during startup, then grind, then latch.

Fix is the identical established-run gate the #48 review pass already applied to the stall rail (`zero_crosses > 100`, captured before the reset). Legacy desync handling still restarts; only the episode accounting is established-runs-only.

Validation:
- Full SITL suite green (29 tests) on the PR49 branch carrying the same commit; model tests green on this branch.
- Bench non-reg (900KV + 10x5x3 6S): `prop10_first_spin` clean; `prop10_snap_demag_rail` unchanged — snap episodes at established runs still charge, bounded, no latch.

Same commit is on `feat/transient-governor` (#49), so the branches merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)