### PR TITLE
chore(release): bump firmware version to 3.0-ark

### DIFF
--- a/Inc/version.h
+++ b/Inc/version.h
@@ -3,12 +3,12 @@
  *
  * MAJOR.MINOR track the upstream AM32 base this tree is based on (EEPROM and
  * protocol still use only these two numeric fields).
- * VERSION_TAG is appended to built artifact names (e.g. 2.20-ark) so binaries
+ * VERSION_TAG is appended to built artifact names (e.g. 3.0-ark) so binaries
  * from the ARK Electronics fork are not confused with upstream AM32 builds.
  * Update this file for new releases.
  */
-#define VERSION_MAJOR 2
-#define VERSION_MINOR 20
+#define VERSION_MAJOR 3
+#define VERSION_MINOR 0
 #define VERSION_TAG "ark"
 
 #define EEPROM_VERSION 3

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ LIBS := -lnosys
 # extract version from Inc/version.h
 VERSION_MAJOR := $(shell $(FGREP) "define VERSION_MAJOR" $(MAIN_INC_DIR)/version.h | $(CUT) -d" " -f3 )
 VERSION_MINOR := $(shell $(FGREP) "define VERSION_MINOR" $(MAIN_INC_DIR)/version.h | $(CUT) -d" " -f3 )
-# optional fork tag (quoted string in version.h), e.g. ark -> 2.20-ark
+# optional fork tag (quoted string in version.h), e.g. ark -> 3.0-ark
 VERSION_TAG := $(shell $(FGREP) "define VERSION_TAG" $(MAIN_INC_DIR)/version.h | $(CUT) -d\" -f2 )
 
 # Artifact version: MAJOR.MINOR[-TAG]. TAG marks ARK-fork builds vs upstream.


### PR DESCRIPTION
## Summary
- Bump `VERSION_MAJOR`/`VERSION_MINOR` from **2.20** to **3.0** in `Inc/version.h`.
- Artifact names become `AM32_*_3.0-ark` (`VERSION_TAG` remains `"ark"`).
- `EEPROM_VERSION` is unchanged (settings-page format, not product version).

This marks the ARK release train after recent ark-release landings (desync episode rail, transient governor, jump-charge established-run gate).

## Test plan
- [x] `make ARK_4IN1_F051` produces `obj/AM32_ARK_4IN1_F051_3.0-ark.bin` / `.elf`
- [x] Size check still green (~91% flash / ~80% RAM on F051)
- [ ] After flash: configurator / boot shows 3.0; settings page major/minor rewrite is expected on first boot if EEPROM still says 2.20
- [ ] CI SITL / static analysis green on this PR