### PR TITLE
fix(settings): correct kv-derived throttle restriction levels

### DIFF
--- a/Src/settings.c
+++ b/Src/settings.c
@@ -191,15 +191,28 @@ void loadEEpromSettings(void)
 		if (motor_kv < 300) {
 			low_rpm_throttle_limit = 0;
 		}
-		// guard divisions for an erased eeprom (motor_poles 0 or 0xff),
-		// ARM hardware division returns 0 but it is UB in C
-		uint8_t rpm_level_div = 0;
-		if (eepromBuffer.motor_poles != 0) {
-			rpm_level_div = 32 / eepromBuffer.motor_poles;
-		}
-		if (rpm_level_div != 0) {
-			low_rpm_level = motor_kv / 100 / rpm_level_div;
-			high_rpm_level = motor_kv / 12 / rpm_level_div;
+		/* Throttle-restriction envelope in kerpm, scaled from kv and pole
+		 * count. The envelope is (kv / N) * (motor_poles / 32): multiply
+		 * before dividing so the pole term keeps its fractional part -
+		 * the old "kv / N / (32 / poles)" form truncated 32/poles to an
+		 * integer (2 for the common 14-pole motor instead of 2.29, and 0
+		 * for anything above 32 poles, which zeroed the envelope and
+		 * removed the restriction entirely).
+		 *
+		 * The high divisor is 17, not the 12 that shipped in v2.20: 12
+		 * raises the erpm at which full duty is released by ~1.42x, so a
+		 * correctly configured high-kv motor stays in the restricted
+		 * region well past where it should and never reaches full thrust
+		 * (am32-firmware/AM32#405 - the community workaround of entering
+		 * 50-60% of the real kv cancels exactly this factor).
+		 *
+		 * Out-of-range pole counts (an erased eeprom reads 0 or 0xff)
+		 * leave the envelope at zero, which map() treats as "always at
+		 * the high-rpm limit" - i.e. unrestricted, as before. 2..64 is
+		 * the range the DroneCAN MOTOR_POLES parameter accepts. */
+		if (eepromBuffer.motor_poles >= 2 && eepromBuffer.motor_poles <= 64) {
+			low_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (100U * 32U);
+			high_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (17U * 32U);
 		} else {
 			low_rpm_level = 0;
 			high_rpm_level = 0;


### PR DESCRIPTION
## Summary

The low/high eRPM levels that bound the low-rpm throttle restriction were computed as `motor_kv / N / (32 / motor_poles)`, which is wrong in two ways inherited from upstream v2.20 ([am32-firmware/AM32#405](https://github.com/am32-firmware/AM32/issues/405)):

1. **The high-level divisor is `12`, where it had historically been `17`** (changed upstream in `eef9cb45`). That raises the eRPM at which full duty is released by ~1.42x, so a motor configured with its *real* kV stays inside the restricted-duty region far longer than intended and never reaches full thrust. The known community workaround — entering 50-60% of the actual motor kV — cancels exactly this factor.

2. **`32 / motor_poles` is integer division evaluated first**, so the pole term is truncated (2 instead of 2.29 for a 14-pole motor) and collapses to 0 above 32 poles. The existing zero guard turned that into an envelope of `0/0`, which `map()` reads as "always at the high-rpm limit" — silently *removing* the restriction for high pole counts rather than scaling it.

## Changes

`Src/settings.c` — one hunk. Multiply before dividing so the pole ratio keeps its precision, and restore the `17` divisor:

```c
if (eepromBuffer.motor_poles >= 2 && eepromBuffer.motor_poles <= 64) {
    low_rpm_level  = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (100U * 32U);
    high_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (17U  * 32U);
} else {
    low_rpm_level = 0;
    high_rpm_level = 0;
}
```

The pole-count guard is kept, now as an explicit `2..64` range check (the bounds the DroneCAN `MOTOR_POLES` parameter accepts). Multiply-before-divide removes the divide-by-zero on its own, but it also changes what an *erased* eeprom does: `motor_poles == 0xff` would otherwise yield `high_rpm_level = 937` kerpm for a 2000kV config, pegging duty at `throttle_max_at_low_rpm` (~20%) forever. The range check preserves today's unrestricted fallback for `0` and `0xff`.

## Effect

| kV / poles | old low/high | new low/high |
| --- | --- | --- |
| 2000 / 14 | 10 / **83** | 8 / **51** |
| 3000 / 14 | 15 / 125 | 13 / 77 |
| 2000 / 48 | 0 / **0** (unrestricted) | 30 / 176 |
| any / 0 or 255 | 0 / 0 | 0 / 0 (unchanged) |

Max computed value across the full input domain is 1202, so no `uint16_t` overflow.

**Behavior change worth flagging:** the 33-64 pole rows move in the *stricter* direction — those configs currently get no low-rpm restriction at all, which was accidental. Uncommon, and `low_rpm_throttle_limit` is already disabled below 300kV, but it is a real difference from shipped behavior.

## Verification

- `make AM32_SITL_CAN` and `make ARK_4IN1_F051` both build clean under `-Wall -Wextra -Werror`.
- F051 flash went **down** 24 bytes (24996 → 24972); a runtime division is removed. That target sits at 91% of its budget, so this was checked explicitly.
- Full SITL suite: **29 passed**. No existing test touches `rpm_level` — this is bench/flight-verifiable behavior, not covered by CI.
- `make format` per `AGENTS.md`. It also reformatted four unrelated `Mcu/` files with pre-existing drift; those were reverted to keep the diff scoped.

Draft pending bench confirmation that max thrust is restored with the real motor kV configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoD65bRT7unXhETnZ13WEq