### PR TITLE
perf(f051): single-pass dshot decode, const current window, latched NVIC writes

### DIFF
--- a/Inc/adc_app.h
+++ b/Inc/adc_app.h
@@ -12,7 +12,7 @@
 /*
  * Finish the pending DMA sample, restart conversion, update:
  *   converted_degrees, degrees_celsius, battery_voltage, actual_current
- * (and smoothed_raw_current). Does not clear PROCESS_ADC_FLAG or run LVC.
+ * Does not clear PROCESS_ADC_FLAG or run LVC.
  */
 void adcAppServiceConversion(void);
 

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -143,11 +143,14 @@ extern uint16_t ADC_raw_ntc;
 extern uint16_t ADC_smoothed_input;
 extern int16_t converted_degrees;
 extern uint8_t temperature_offset;
-extern uint16_t smoothedcurrent;
-extern uint8_t readIndex;
-extern uint32_t total;
-extern uint16_t readings[];
-extern const uint8_t numReadings;
+/* Boxcar average of the raw current ADC (getSmoothedCurrent(), control_loop.c).
+ * The window is a macro, not a `const uint8_t`: Cortex-M0 has no hardware
+ * divide, and a runtime divisor pulls in the __aeabi_uidiv helper on every ADC
+ * conversion. As a compile-time constant the divide folds to a multiply-shift. */
+#define NUM_CURRENT_READINGS 50
+extern uint8_t current_read_index;
+extern uint32_t current_total;
+extern uint16_t current_readings[NUM_CURRENT_READINGS];
 extern char cell_count;
 extern uint16_t e_rpm;
 extern uint16_t k_erpm;
@@ -178,7 +181,6 @@ extern uint16_t servo_neutral;
 extern uint8_t servo_dead_band;
 extern volatile uint8_t PROCESS_ADC_FLAG;
 extern int32_t consumed_current;
-extern int32_t smoothed_raw_current;
 extern char send_esc_info_flag;
 extern uint16_t VOLTAGE_DIVIDER;
 extern char LOW_VOLTAGE_CUTOFF;

--- a/Src/adc_app.c
+++ b/Src/adc_app.c
@@ -14,7 +14,6 @@
 #include "common.h"
 
 extern int16_t converted_degrees;
-extern int32_t smoothed_raw_current;
 extern uint16_t VOLTAGE_DIVIDER;
 
 void adcAppServiceConversion(void)
@@ -59,13 +58,12 @@ void adcAppServiceConversion(void)
 
 	degrees_celsius = converted_degrees;
 
+	const int32_t smoothed_raw_current = getSmoothedCurrent();
 #ifdef NXP
 	battery_voltage = ((7 * battery_voltage) + ((ADC_raw_volts * 3300 / 65535 * VOLTAGE_DIVIDER) / 100)) / 8;
-	smoothed_raw_current = getSmoothedCurrent();
 	actual_current = (((smoothed_raw_current * 3300 / 65535) - CURRENT_OFFSET) * 100) / (MILLIVOLT_PER_AMP);
 #else
 	battery_voltage = ((7 * battery_voltage) + ((ADC_raw_volts * 3300 / 4095 * VOLTAGE_DIVIDER) / 100)) >> 3;
-	smoothed_raw_current = getSmoothedCurrent();
 	actual_current = ((smoothed_raw_current * 3300 / 41) - (CURRENT_OFFSET * 100)) / (MILLIVOLT_PER_AMP);
 #endif
 	if (actual_current < 0) {

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -62,15 +62,22 @@ int32_t doPidCalculations(struct fastPID *pidnow, int actual, int target)
 
 uint16_t getSmoothedCurrent()
 {
-	total = total - readings[readIndex];
-	readings[readIndex] = ADC_raw_current;
-	total = total + readings[readIndex];
-	readIndex = readIndex + 1;
-	if (readIndex >= numReadings) {
-		readIndex = 0;
+	// Sample once: ADC_raw_current is written by ADC_DMA_Callback(), which also
+	// runs from the DMA ISR. The sum is incremental, so the value stored in the
+	// ring and the value added here must be the same one or the running total
+	// drifts permanently when the two reads straddle an update.
+	const uint16_t sample = ADC_raw_current;
+
+	current_total -= current_readings[current_read_index];
+	current_readings[current_read_index] = sample;
+	current_total += sample;
+
+	current_read_index++;
+	if (current_read_index >= NUM_CURRENT_READINGS) {
+		current_read_index = 0;
 	}
-	smoothedcurrent = total / numReadings;
-	return smoothedcurrent;
+
+	return current_total / NUM_CURRENT_READINGS;
 }
 
 void setInput()

--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -16,8 +16,6 @@
 #	include "DroneCAN/DroneCAN.h"
 #endif
 
-int dpulse[16] = {0};
-
 const char gcr_encode_table[16] = {0b11001, 0b11011, 0b10010, 0b10011, 0b11101, 0b10101, 0b10110, 0b10111,
 				   0b11010, 0b01001, 0b01010, 0b01011, 0b11110, 0b01101, 0b01110, 0b01111};
 
@@ -72,15 +70,20 @@ void computeDshotDMA()
 	halfpulsetime = dshot_frametime >> 5;
 	if ((dshot_frametime > dshot_frametime_low) && (dshot_frametime < dshot_frametime_high)) {
 		signaltimeout = 0;
+		// Shift the 16 decoded pulses straight into one register-resident word,
+		// msb first: bit (15 - i) is pulse i. The frame layout is then
+		// [11 bit value][telem req][4 bit crc], so every field below is a
+		// shift-and-mask instead of an indexed load out of a 64 byte array.
+		uint16_t frame = 0;
 		for (int i = 0; i < 16; i++) {
 			// note that dma_buffer[] is uint32_t, we cast the difference to uint16_t to handle
 			// timer wrap correctly
 			const uint16_t pdiff = dma_buffer[(i << 1) + 1] - dma_buffer[(i << 1)];
-			dpulse[i] = (pdiff > halfpulsetime);
+			frame = (frame << 1) | (pdiff > halfpulsetime);
 		}
-		uint8_t calcCRC = ((dpulse[0] ^ dpulse[4] ^ dpulse[8]) << 3 | (dpulse[1] ^ dpulse[5] ^ dpulse[9]) << 2 |
-				   (dpulse[2] ^ dpulse[6] ^ dpulse[10]) << 1 | (dpulse[3] ^ dpulse[7] ^ dpulse[11]));
-		uint8_t checkCRC = (dpulse[12] << 3 | dpulse[13] << 2 | dpulse[14] << 1 | dpulse[15]);
+		// crc nibble is the xor of the three value nibbles
+		uint8_t calcCRC = ((frame >> 4) ^ (frame >> 8) ^ (frame >> 12)) & 0xF;
+		uint8_t checkCRC = frame & 0xF;
 
 		if (!armed) {
 			if (dshot_telemetry == 0) {
@@ -97,11 +100,10 @@ void computeDshotDMA()
 			}
 		}
 		if (dshot_telemetry) {
-			checkCRC = ~checkCRC + 16;
+			checkCRC = (~checkCRC) & 0xF;
 		}
 
-		int tocheck = (dpulse[0] << 10 | dpulse[1] << 9 | dpulse[2] << 8 | dpulse[3] << 7 | dpulse[4] << 6 | dpulse[5] << 5 |
-			       dpulse[6] << 4 | dpulse[7] << 3 | dpulse[8] << 2 | dpulse[9] << 1 | dpulse[10]);
+		int tocheck = frame >> 5; // upper 11 bits: throttle value or command
 
 		if (calcCRC == checkCRC) {
 			signaltimeout = 0;
@@ -111,7 +113,7 @@ void computeDshotDMA()
 			hwci_perf.dshot_telem_mode = (uint8_t)dshot_telemetry;
 			hwci_perf.dshot_edt_mode = dshot_extended_telemetry;
 #endif
-			if (dpulse[11] == 1) {
+			if (frame & 0x10) { // telemetry request bit
 				send_telemetry = 1;
 			}
 			if (programming_mode > 0) {

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -143,7 +143,6 @@ char brushed_direction_set = 0;
 
 volatile uint16_t tenkhzcounter = 0;
 int32_t consumed_current = 0;
-int32_t smoothed_raw_current = 0;
 int16_t actual_current = 0;
 
 char lowkv = 0;
@@ -218,11 +217,9 @@ volatile uint16_t adjusted_input = 0; // ISR-written in setInput(), read in the 
 #define TEMP30_CAL_VALUE ((uint16_t *)((uint32_t)0x1FFFF7B8))
 #define TEMP110_CAL_VALUE ((uint16_t *)((uint32_t)0x1FFFF7C2))
 
-uint16_t smoothedcurrent = 0;
-const uint8_t numReadings = 50; // the readings from the analog input
-uint8_t readIndex = 0;		// the index of the current reading
-uint32_t total = 0;
-uint16_t readings[50];
+uint8_t current_read_index = 0; // index of the oldest sample in the ring
+uint32_t current_total = 0;	// running sum of current_readings[]
+uint16_t current_readings[NUM_CURRENT_READINGS];
 
 uint8_t bemf_timeout_happened = 0;
 uint8_t changeover_step = 5;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -184,8 +184,19 @@ void runtimeSampleBemfPreLevel(void)
 void runtimeUpdateDshotIrqPriority(void)
 {
 #if !defined(MCU_G031) && !defined(NEED_INPUT_READY)
+	// This runs every main-loop pass but the scheme only flips when the ESC
+	// crosses DSHOT_PRIORITY_THRESHOLD, so latch it and skip the NVIC writes
+	// in the steady state. Single caller (main loop), so the static is safe.
+	static uint8_t applied_input_priority = 0xFF; // unknown at boot: first pass always writes
+	const uint8_t want_input_priority = (dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD));
+
+	if (want_input_priority == applied_input_priority) {
+		return;
+	}
+	applied_input_priority = want_input_priority;
+
 #	ifdef NXP
-	if (dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD)) {
+	if (want_input_priority) {
 		NVIC_SetPriority(IC_DMA_IRQ_NAME, 0);
 		NVIC_SetPriority(COM_TIMER_IRQ, 1);
 		NVIC_SetPriority(COMP0_IRQ, 1);
@@ -197,7 +208,7 @@ void runtimeUpdateDshotIrqPriority(void)
 		NVIC_SetPriority(COMP1_IRQ, 0);
 	}
 #	else
-	if (dshot_telemetry && (commutation_interval > DSHOT_PRIORITY_THRESHOLD)) {
+	if (want_input_priority) {
 		NVIC_SetPriority(IC_DMA_IRQ_NAME, 0);
 		NVIC_SetPriority(COM_TIMER_IRQ, 1);
 		NVIC_SetPriority(COMPARATOR_IRQ, 1);


### PR DESCRIPTION
## Summary

Three independent hot-path cleanups on the F051 control path, none of which changes behaviour. Together they buy back 244 B of flash and 64 B of RAM on `ARK_4IN1_F051` with `HWCI_PERF`, which matters because that target is close to the size gate.

| | before | after | delta |
|---|---:|---:|---:|
| flash | 26156 B (94.60%) | 25912 B (93.72%) | **−244 B** |
| RAM | 6872 B (85.90%) | 6808 B (85.10%) | **−64 B** |

Headroom under the 95% flash gate goes from 109 B to 353 B.

This replaces #9, #10 and #11, which targeted `main` before it became the frozen upstream mirror and so could no longer be merged or cleanly retargeted.

## Problem

Three separate bits of waste in code that runs on every DShot frame, every ADC conversion, or every main-loop pass:

- The DShot decoder scattered 16 decoded bits into an `int dpulse[16]` global, then reassembled the CRC, the 11-bit value and the telemetry-request bit out of it with 30-odd indexed loads. The array itself is 64 B of RAM that exists only between two adjacent statements.
- `getSmoothedCurrent()` divided by `numReadings`, a runtime `const uint8_t`. Cortex-M0 has no hardware divide, so every ADC conversion called into `__aeabi_uidiv`.
- `runtimeUpdateDshotIrqPriority()` rewrote the NVIC priority registers on every main-loop pass, even though the scheme only flips when the ESC crosses `DSHOT_PRIORITY_THRESHOLD`.

## Solution

**dshot** — decode in one pass into a packed `uint16_t`, msb first, so the frame is `[11 bit value][telem req][4 bit crc]`. Every field is then a shift and a mask: the CRC nibble is the xor of the three value nibbles, the value is `frame >> 5`, the telemetry request is `frame & 0x10`. `dpulse[]` is gone. `~checkCRC + 16` becomes `(~checkCRC) & 0xF`, which is the same value for the 0..15 domain and reads as the masking idiom the rest of the block now uses.

**current filter** — `NUM_CURRENT_READINGS` is a macro, so the divide folds to a multiply-shift. The sample is read once into a local: `ADC_raw_current` is written by `ADC_DMA_Callback()`, which also runs from the DMA ISR, and the sum is incremental, so the value stored in the ring and the value added to the total must be the same one or the running total drifts permanently. That held only by virtue of the variable not being `volatile`; now it holds unconditionally. `smoothed_raw_current` becomes a local in `adcAppServiceConversion()`, its only consumer.

**NVIC** — latch the applied scheme and return early when it has not changed. Single caller (the main loop), so the static is safe.

## Verification

- `make -j8` clean across all targets; `make size-check-ark` PASS (numbers above are a clean-`obj` A/B against `ark-release`)
- `cppcheck-ark.sh` PASS, no error/warning; the shadow-variable finding it raised on an earlier revision is fixed
- SITL suite 29/29, including the DShot arming, throttle and signal-loss paths that exercise the rewritten decoder
- `clang-format` clean against the CI-pinned 22.1.5