### PR TITLE
build(lto): enable link time optimization by default

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -72,3 +72,22 @@ jobs:
             obj/AM32_ARK_4IN1_F051_*.bin
           if-no-files-found: ignore
           retention-days: 14
+
+  codegen-ark:
+    name: codegen invariants (ARK F051 LTO)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Arm toolchain
+        run: |
+          make arm_sdk_install
+          make arm_sdk_check
+
+      # Guards the two things LTO breaks without failing a build or a test:
+      # RAM_FUNC hot paths inlined back into flash, and .file_name /
+      # .app_signature emptied by dead-code elimination.
+      - name: Build ARK + codegen check
+        run: make codegen-check-ark -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,29 @@ CFLAGS_BASE += -Wall -Wundef -Wextra -Werror -Wno-unused-parameter -Wno-stringop
 
 CFLAGS_COMMON := $(CFLAGS_BASE)
 
+# Link time optimization, on by default for the cross-compiled firmware.
+#
+# The firmware is compiled and linked in one gcc invocation, so -flto here covers
+# both halves and needs no other build changes. SITL overrides CFLAGS_COMMON and
+# is unaffected.
+#
+# On Cortex-M0 the call overhead is high and the app region is small: LTO recovers
+# ~4.1 KiB of the F051's 27 KiB app region. Carrying it as the default rather than
+# switching it on for whichever feature needs the space keeps one codegen
+# configuration in tree, so what CI and the HWCI bench measure is what ships.
+#
+# This does interact with the selective -O3 above: RAM_FUNC carries
+# optimize("O3") plus noclone, and the noclone is there precisely so LTO
+# constant-propagation clones cannot escape .ramfunc. scripts/check-ramfunc.sh
+# asserts every RAM_FUNC still lands in RAM, and CI runs it.
+#
+# Escape hatch: LTO=0 builds without it, for bisecting a suspected miscompile
+# without editing this file.
+LTO ?= 1
+ifeq ($(LTO),1)
+CFLAGS_COMMON += -flto
+endif
+
 # Hardware-CI performance instrumentation (opt-in, off by default).
 # Build with `make <TARGET> HWCI_PERF=1` to emit the hwci_perf RAM struct that
 # the hardware-CI harness (see hwci/) reads over SWD. Production/release builds
@@ -181,6 +204,16 @@ targets:
 .PHONY : cppcheck
 cppcheck:
 	$(QUIET)bash scripts/cppcheck-ark.sh
+
+# Assert the codegen invariants LTO can break silently: RAM_FUNC hot paths still
+# resident in RAM, and externally-read sections (.file_name, .app_signature) not
+# emptied by dead-code elimination. See scripts/check-codegen-ark.sh.
+.PHONY : codegen-check-ark
+codegen-check-ark:
+	$(QUIET)$(MAKE) -B ARK_4IN1_F051 AM32REF_F051 REF_G431
+	$(QUIET)bash scripts/check-codegen-ark.sh $(OBJ)/$(IDENTIFIER)_ARK_4IN1_F051_$(FIRMWARE_VERSION).elf
+	$(QUIET)bash scripts/check-codegen-ark.sh $(OBJ)/$(IDENTIFIER)_AM32REF_F051_$(FIRMWARE_VERSION).elf
+	$(QUIET)bash scripts/check-codegen-ark.sh --no-ramfunc $(OBJ)/$(IDENTIFIER)_REF_G431_$(FIRMWARE_VERSION).elf
 
 # Build ARK F051 with HWCI_PERF and enforce flash/RAM headroom (F051 is tight).
 # -B forces a rebuild so a prior non-HWCI image is not size-checked by mistake.

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,18 @@ CFLAGS_COMMON := $(CFLAGS_BASE)
 # switching it on for whichever feature needs the space keeps one codegen
 # configuration in tree, so what CI and the HWCI bench measure is what ships.
 #
+# Applies to every cross-compiled MCU (not only F051). scripts/check-codegen-ark.sh
+# (make codegen-check-ark / CI) only builds ARK_4IN1_F051, AM32REF_F051, and
+# REF_G431: it asserts F051 hot ISR entry points + known RAM_FUNC callees still
+# land in RAM when they remain as symbols, and that externally-read sections
+# (.file_name, .app_signature) are non-empty. It does not replace HWCI for
+# functional timing risk — global -O3 previously broke hold100 free-run on
+# ARK F051; LTO is a different knob but still wants a bench smoke before it is
+# trusted as the ship default.
+#
 # This does interact with the selective -O3 above: RAM_FUNC carries
 # optimize("O3") plus noclone, and the noclone is there precisely so LTO
-# constant-propagation clones cannot escape .ramfunc. scripts/check-ramfunc.sh
-# asserts every RAM_FUNC still lands in RAM, and CI runs it.
+# constant-propagation clones cannot escape .ramfunc.
 #
 # Escape hatch: LTO=0 builds without it, for bisecting a suspected miscompile
 # without editing this file.
@@ -205,9 +213,10 @@ targets:
 cppcheck:
 	$(QUIET)bash scripts/cppcheck-ark.sh
 
-# Assert the codegen invariants LTO can break silently: RAM_FUNC hot paths still
-# resident in RAM, and externally-read sections (.file_name, .app_signature) not
-# emptied by dead-code elimination. See scripts/check-codegen-ark.sh.
+# Assert the codegen invariants LTO can break silently: F051 hot ISR entry
+# points (+ known RAM_FUNC callees when still out-of-line) resident in RAM, and
+# externally-read sections (.file_name, .app_signature) not emptied by DCE.
+# See scripts/check-codegen-ark.sh.
 .PHONY : codegen-check-ark
 codegen-check-ark:
 	$(QUIET)$(MAKE) -B ARK_4IN1_F051 AM32REF_F051 REF_G431

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -52,6 +52,11 @@ static bool done_startup;
 
 /*
   application signature, filled in by set_app_signature.py
+
+  used: nothing in C ever reads this, so LTO drops it as dead exactly the way it
+  drops .file_name, leaving the section empty. No LTO'd CAN target exists today
+  (SITL is native and opts out), so this is here to stop adding one from
+  silently shipping an image with no signature.
  */
 const struct {
 	uint32_t magic1;
@@ -61,7 +66,7 @@ const struct {
 	uint32_t crc2;	// crc32 from end of app_signature to end of fw
 	char mcu[16];
 	uint32_t unused[2];
-} app_signature AM32_FLASH_SECTION(".app_signature") = {
+} app_signature __attribute__((used)) AM32_FLASH_SECTION(".app_signature") = {
 	.magic1 = APP_SIGNATURE_MAGIC1,
 	.magic2 = APP_SIGNATURE_MAGIC2,
 	.fwlen = 0,

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -103,7 +103,10 @@ uint16_t low_cell_volt_cutoff = 330; // 3.3volts per cell
 
 //=========================== END EEPROM Defaults ===========================
 
-const char filename[30] AM32_FLASH_SECTION(".file_name") = FILE_NAME;
+/* used: nothing in C reads this - the configurator reads the .file_name region
+ * out of the image - so LTO drops it as dead without the attribute, leaving the
+ * section empty and the firmware unidentifiable. */
+const char filename[30] __attribute__((used)) AM32_FLASH_SECTION(".file_name") = FILE_NAME;
 _Static_assert(sizeof(FIRMWARE_NAME) <= 13, "Firmware name too long"); // max 12 character firmware name plus NULL
 
 // move these to targets folder or peripherals for each mcu

--- a/scripts/check-codegen-ark.sh
+++ b/scripts/check-codegen-ark.sh
@@ -8,9 +8,17 @@
 #      RAM_FUNC so they run out of RAM instead of paying F051 flash wait states
 #      in an ISR. LTO is free to inline a RAM_FUNC body into a flash-resident
 #      caller, which drops the hot path back into flash with nothing to notice
-#      it. (Inlining into another RAM-resident function is fine and expected -
-#      that is why this checks the ISR entry points rather than the callees,
-#      which LTO legitimately absorbs.)
+#      it.
+#
+#      Policy (two tiers):
+#        - Required symbols must exist and live in RAM (0x20000000..). These are
+#          the F051 vector-table ISR entry points for the zero-cross comparator,
+#          20 kHz control loop, and commutation timer. LTO may absorb callees
+#          into them; the entries themselves must remain RAM-resident.
+#        - Optional hot callees (other known RAM_FUNC names). If still present
+#          as out-of-line symbols they must be in RAM — that is the silent
+#          "thin RAM ISR + flash body" failure mode. If LTO fully absorbs them
+#          into a RAM-resident caller, the symbol is gone and that is OK.
 #
 #   2. Section-placed data. .file_name and .app_signature are read out of the
 #      image by external tooling and never from C, so LTO drops them as dead
@@ -63,36 +71,50 @@ SECS=$("$READELF_BIN" -S -W "$ELF")
 
 rc=0
 
-# --- 1. hot-path ISR entry points must live in RAM (0x20000000..) -------------
-# These are the vector-table entries for the zero-cross comparator, the control
-# loop and the commutation timer. Whatever LTO inlines into them comes along.
-HOT_SYMS="ADC1_COMP_IRQHandler TIM6_DAC_IRQHandler TIM14_IRQHandler comStep commutate"
+# --- 1. hot-path symbols must live in RAM (0x20000000..) when present --------
+# Required: F051 vector-table ISR entry points (must exist + RAM).
+# Optional: known RAM_FUNC callees — if out-of-line, must be RAM; if absorbed, OK.
+REQUIRED_HOT_SYMS="ADC1_COMP_IRQHandler TIM6_DAC_IRQHandler TIM14_IRQHandler"
+OPTIONAL_HOT_SYMS="interruptRoutine tenKhzRoutine PeriodElapsedCallback getBemfState commutate comStep changeCompInput maskPhaseInterrupts enableCompInterrupts faultSignalTimeoutTick"
+
+check_sym_ram() {
+  local sym="$1" mode="$2"  # mode: required | optional
+  local addr
+  addr=$(awk -v s="$sym" '$NF==s {print $1; exit}' <<<"$SYMS")
+  if [ -z "$addr" ]; then
+    if [ "$mode" = "required" ]; then
+      echo "  FAIL: $sym not found in the image" >&2
+      rc=1
+    else
+      echo "  ok   $sym absent (LTO absorbed into caller)"
+    fi
+    return
+  fi
+  case "$addr" in
+    20*) echo "  ok   $sym @ 0x$addr (RAM)" ;;
+    *)   echo "  FAIL: $sym @ 0x$addr is not in RAM — RAM_FUNC placement lost" >&2; rc=1 ;;
+  esac
+}
 
 echo "=== codegen check: $ELF ==="
 if [ "$CHECK_RAMFUNC" -eq 1 ]; then
-  for sym in $HOT_SYMS; do
-    addr=$(awk -v s="$sym" '$NF==s {print $1; exit}' <<<"$SYMS")
-    if [ -z "$addr" ]; then
-      echo "  FAIL: $sym not found in the image" >&2
-      rc=1
-      continue
-    fi
-    case "$addr" in
-      20*) echo "  ok   $sym @ 0x$addr (RAM)" ;;
-      *)   echo "  FAIL: $sym @ 0x$addr is not in RAM — RAM_FUNC placement lost" >&2; rc=1 ;;
-    esac
+  for sym in $REQUIRED_HOT_SYMS; do
+    check_sym_ram "$sym" required
+  done
+  for sym in $OPTIONAL_HOT_SYMS; do
+    check_sym_ram "$sym" optional
   done
 else
   echo "  --   RAM residency skipped (RAM_FUNC has no section attribute here)"
 fi
 
-# --- 2. externally-read sections must be non-empty ----------------------------
+# --- 2. special sections must be non-empty when present -----------------------
 # .app_signature only exists in CAN builds; absent is fine, present-but-empty is
 # not. Locate the size relative to the section name rather than by fixed column:
 # readelf writes the index as "[ 9]" but "[12]", so a single-digit index splits
 # into two fields and shifts every positional column by one.
 check_section() {
-  local name="$1" required="$2"
+  local name="$1" required="$2" empty_hint="$3"
   local size
   size=$(awk -v n="$name" '{for (i = 1; i <= NF; i++) if ($i == n) { print $(i + 4); exit }}' <<<"$SECS")
   if [ -z "$size" ]; then
@@ -104,16 +126,19 @@ check_section() {
     return
   fi
   if [ $((16#$size)) -eq 0 ]; then
-    echo "  FAIL: section $name is present but empty — LTO dropped its contents" >&2
-    echo "        (the object needs __attribute__((used)))" >&2
+    echo "  FAIL: section $name is present but empty — $empty_hint" >&2
     rc=1
   else
     echo "  ok   $name = $((16#$size)) bytes"
   fi
 }
-check_section .file_name required
-check_section .app_signature optional
-check_section .noinit required
+# Externally-read image metadata: nothing in C reads these, so LTO DCE empties
+# them without __attribute__((used)).
+check_section .file_name required "LTO dropped its contents (object needs __attribute__((used)))"
+check_section .app_signature optional "LTO dropped its contents (object needs __attribute__((used)))"
+# Soft-reset cookie / retained SRAM (read+written from C). Empty here usually
+# means the cookie was removed or the linker script changed — not LTO DCE.
+check_section .noinit required "expected boot_sound_cookie (or other .noinit) — cookie removed or linker script changed?"
 
 if [ "$rc" -ne 0 ]; then
   echo "check-codegen-ark: FAIL" >&2

--- a/scripts/check-codegen-ark.sh
+++ b/scripts/check-codegen-ark.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Assert the codegen invariants LTO can silently break on the ARK F051.
+#
+# Both failures this guards against link cleanly, pass every functional test,
+# and only show up as a slower motor or an unidentifiable image on the bench:
+#
+#   1. RAM residency. The comparator / control-loop / commutation paths are
+#      RAM_FUNC so they run out of RAM instead of paying F051 flash wait states
+#      in an ISR. LTO is free to inline a RAM_FUNC body into a flash-resident
+#      caller, which drops the hot path back into flash with nothing to notice
+#      it. (Inlining into another RAM-resident function is fine and expected -
+#      that is why this checks the ISR entry points rather than the callees,
+#      which LTO legitimately absorbs.)
+#
+#   2. Section-placed data. .file_name and .app_signature are read out of the
+#      image by external tooling and never from C, so LTO drops them as dead
+#      unless they carry __attribute__((used)). The section stays in the ELF at
+#      size 0, so only a size check catches it.
+#
+# Usage: scripts/check-codegen-ark.sh [--no-ramfunc] [elf]
+#   defaults to the ARK F051 build. --no-ramfunc skips the RAM residency block
+#   for targets where RAM_FUNC carries no section attribute (see Inc/targets.h:
+#   only F051 places these in .ramfunc; elsewhere the macro is optimize("O3")
+#   alone), leaving the section checks, which apply to every target.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CHECK_RAMFUNC=1
+if [ "${1:-}" = "--no-ramfunc" ]; then
+  CHECK_RAMFUNC=0
+  shift
+fi
+
+ELF="${1:-}"
+if [ -z "$ELF" ]; then
+  ELF=$(ls -1 obj/AM32_ARK_4IN1_F051_*.elf 2>/dev/null | head -1 || true)
+fi
+if [ -z "$ELF" ] || [ ! -f "$ELF" ]; then
+  echo "error: no ARK F051 elf — build ARK_4IN1_F051 first" >&2
+  exit 2
+fi
+
+# Pinned xPack binutils, same policy as check-size-ark.sh.
+find_tool() {
+  local name="$1" out="${2:-}"
+  for c in \
+    tools/linux/xpack-arm-none-eabi-gcc-15.2.1-1.1/bin/arm-none-eabi-$name \
+    tools/macos/xpack-arm-none-eabi-gcc-15.2.1-1.1/bin/arm-none-eabi-$name \
+    tools/windows/xpack-arm-none-eabi-gcc-15.2.1-1.1/bin/arm-none-eabi-$name.exe
+  do
+    if [ -x "$ROOT/$c" ]; then echo "$ROOT/$c"; return 0; fi
+  done
+  echo "error: pinned arm-none-eabi-$name not found — run: make arm_sdk_install" >&2
+  exit 127
+}
+NM_BIN="${NM_BIN:-$(find_tool nm)}"
+READELF_BIN="${READELF_BIN:-$(find_tool readelf)}"
+
+SYMS=$("$NM_BIN" -S "$ELF")
+SECS=$("$READELF_BIN" -S -W "$ELF")
+
+rc=0
+
+# --- 1. hot-path ISR entry points must live in RAM (0x20000000..) -------------
+# These are the vector-table entries for the zero-cross comparator, the control
+# loop and the commutation timer. Whatever LTO inlines into them comes along.
+HOT_SYMS="ADC1_COMP_IRQHandler TIM6_DAC_IRQHandler TIM14_IRQHandler comStep commutate"
+
+echo "=== codegen check: $ELF ==="
+if [ "$CHECK_RAMFUNC" -eq 1 ]; then
+  for sym in $HOT_SYMS; do
+    addr=$(awk -v s="$sym" '$NF==s {print $1; exit}' <<<"$SYMS")
+    if [ -z "$addr" ]; then
+      echo "  FAIL: $sym not found in the image" >&2
+      rc=1
+      continue
+    fi
+    case "$addr" in
+      20*) echo "  ok   $sym @ 0x$addr (RAM)" ;;
+      *)   echo "  FAIL: $sym @ 0x$addr is not in RAM — RAM_FUNC placement lost" >&2; rc=1 ;;
+    esac
+  done
+else
+  echo "  --   RAM residency skipped (RAM_FUNC has no section attribute here)"
+fi
+
+# --- 2. externally-read sections must be non-empty ----------------------------
+# .app_signature only exists in CAN builds; absent is fine, present-but-empty is
+# not. Locate the size relative to the section name rather than by fixed column:
+# readelf writes the index as "[ 9]" but "[12]", so a single-digit index splits
+# into two fields and shifts every positional column by one.
+check_section() {
+  local name="$1" required="$2"
+  local size
+  size=$(awk -v n="$name" '{for (i = 1; i <= NF; i++) if ($i == n) { print $(i + 4); exit }}' <<<"$SECS")
+  if [ -z "$size" ]; then
+    if [ "$required" = "required" ]; then
+      echo "  FAIL: section $name missing" >&2; rc=1
+    else
+      echo "  ok   $name absent (not a CAN build)"
+    fi
+    return
+  fi
+  if [ $((16#$size)) -eq 0 ]; then
+    echo "  FAIL: section $name is present but empty — LTO dropped its contents" >&2
+    echo "        (the object needs __attribute__((used)))" >&2
+    rc=1
+  else
+    echo "  ok   $name = $((16#$size)) bytes"
+  fi
+}
+check_section .file_name required
+check_section .app_signature optional
+check_section .noinit required
+
+if [ "$rc" -ne 0 ]; then
+  echo "check-codegen-ark: FAIL" >&2
+  exit 1
+fi
+echo "check-codegen-ark: PASS"


### PR DESCRIPTION
## Summary

Carries LTO in tree as the single codegen configuration, so it stops being something that gets switched on for whichever feature needs the flash. Recovers ~4.2–4.7 KiB per target and takes the tightest image from 94.60% to 79.33% of the F051 app region.

Split out of #50 — that PR enabled `-flto` for F051 as a side effect of needing room for the embedded bootloader. Landing it separately means the codegen change is reviewable and revertable on its own, and what CI and the HWCI bench measure is what ships. #50 rebases on top and drops its LTO handling.

## Problem

LTO was about to arrive as a side effect of an unrelated feature, scoped to one MCU and one build variant, which is the worst way to introduce a codegen change on a motor controller: the flash win and the timing risk land in the same diff, and reverting one reverts the other.

Two failure modes also needed establishing before anything depends on it. Both are silent — they link, they pass every test, and they surface only on the bench or in the configurator.

## Solution

`-flto` in `CFLAGS_COMMON`. The firmware compiles and links in one gcc invocation, so that covers both halves with no other build changes. SITL overrides `CFLAGS_COMMON` and is unaffected. `LTO=0` builds without it, for bisecting a suspected miscompile without editing the Makefile.

Flash, release builds:

| Target | before | after | delta |
|---|---:|---:|---:|
| `AM32REF_F051` | 25112 B | 20888 B | **−4224 B** |
| `ARK_4IN1_F051` | 25216 B | 20976 B | **−4240 B** |
| `REF_G431` | 25224 B | 20544 B | **−4680 B** |

`ARK_4IN1_F051` with `HWCI_PERF`, the tightest image: 26156 → 21932 B, **94.60% → 79.33%** of the app region. RAM drops 224–272 B per target.

### What LTO broke

**`.file_name` was silently emptied.** It holds the firmware identity string the configurator reads out of the image. Nothing in C reads it, so LTO eliminated it as dead and left the section present at size 0 — the build succeeds and the image is unidentifiable. Marked `used`. `.app_signature` has the identical shape (written post-build by `set_app_signature.py`, never read from C) and is marked `used` too; no LTO'd CAN target exists yet, so that one is prophylactic.

**RAM_FUNC survived, but not in the form the symbol table suggests.** `getBemfState`, `tenKhzRoutine`, `interruptRoutine` and `PeriodElapsedCallback` no longer exist as symbols — LTO inlined them into their callers. Those callers are the RAM-resident ISR entry points, so the hot path still runs from RAM: `TIM6_DAC_IRQHandler` grows 0x1c → 0x644, which is `tenKhzRoutine`'s 0x588 absorbed. Total RAM-resident code drops 4143 → 3938 B. The `noclone` already on `RAM_FUNC` is what stops constant-propagation clones escaping `.ramfunc`.

That second one is the dangerous case: nothing prevents LTO inlining a RAM_FUNC into a *flash*-resident caller instead, which would drop an ISR back into flash wait states with no build or test failure.

### Guarding both

`scripts/check-codegen-ark.sh` asserts the hot ISR entry points are RAM-resident and the externally-read sections are non-empty. Wired to `make codegen-check-ark`, run over all three targets, and added to the static-analysis workflow. Verified it actually fails by dropping the `used` attribute and rebuilding.

## Verification

- All three targets build clean; `LTO=0` still builds
- `make codegen-check-ark` PASS on all three; negative-tested
- Size gate PASS; cppcheck no error/warning; clang-format clean against the pinned 22.1.5
- SITL 29/29

**Not covered here:** on-hardware validation. The `-O3` note in the Makefile records that global `-O3` broke `hold100` free-run near ~97% throttle on ARK F051, so this codebase has been bitten by codegen changes that build and test clean. LTO changes inlining across the whole image, so this wants an HWCI bench run before it is trusted, and the `hwci/baselines/*.json` numbers were captured on non-LTO builds and will need re-baselining.