### PR TITLE
fix(zc): rail desyncs that happen below acquisition

### DIFF
--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -66,9 +66,38 @@ void faultHandleBemfIntervalStall(void);
 typedef enum {
 	DESYNC_EPISODE_JUMP = 0,
 	DESYNC_EPISODE_STALL_RAIL,
+	DESYNC_EPISODE_ACQ_FAIL,
 } desync_episode_kind_t;
 
 void faultDesyncEpisodeCharge(desync_episode_kind_t kind);
+
+/*
+ * Acquisition-phase desync rail.
+ *
+ * Every other rail in the ZC path is gated on an ESTABLISHED loop: the
+ * blind-step deadline needs zero_crosses >= 100 (bemf_zc.c), the BEMF
+ * headroom governor needs > 150 (runtime_loop.c), the grind detector and
+ * miss bucket both need blind steps to exist at all, and the episode charge
+ * itself needs zc_at_desync > 100 (runtimeProcessDesyncCheck). A loop that
+ * desyncs BEFORE acquisition completes therefore accumulates no state
+ * anywhere - it restarts, reaches zc 20..50, desyncs, and repeats
+ * indefinitely with every counter reading zero.
+ *
+ * Measured on the SITL racer_5inch model at HEAD (dshot 700): ~20 desyncs
+ * per second sustained, zero_crosses never past 48, desync_episode_bucket
+ * flat at 0 after 38 desyncs, so neither the restart backoff nor the latch
+ * ever engages and the rotor limit-cycles at ~2.9k rpm indefinitely.
+ *
+ * The established-run gate is still correct for the JUMP charge - a few
+ * interval jumps while acquiring are normal startup roughness on light
+ * motors, and charging them stacks holdoff onto honest starts (the reason
+ * for that gate, see faultDesyncEpisodeCharge). What was missing is a rail
+ * scoped to the acquisition regime itself. Count early desyncs; a handful
+ * is roughness and is forgiven the moment the loop genuinely acquires,
+ * while a sustained inability to get past acquisition charges the SAME
+ * episode bucket and so inherits the existing backoff and latch.
+ */
+void faultNoteEarlyDesync(void);
 /* 1 kHz: drain bucket when closed-loop is healthy; tick restart holdoff. */
 void faultDesyncEpisodeTick1kHz(void);
 /* True while a post-desync coast is mandatory (caller must not re-start). */

--- a/Mcu/SITL/tests/test_acq_desync_rail.py
+++ b/Mcu/SITL/tests/test_acq_desync_rail.py
@@ -1,0 +1,120 @@
+'''Acquisition-regime desync rail (PR #61).
+
+Every established-run rail (JUMP charge, blind/grind, stall) is gated on
+zero_crosses / zc_at_desync > 100. Without the acquisition rail, a
+restart -> short spool -> desync cycle that never clears that gate
+charges nothing and can free-run forever at low eRPM (SITL racer_5inch
+at DShot ~700: ~20 desyncs/s, zc never past ~48, bucket stuck at 0).
+
+With the rail, batches of early desyncs charge the episode machinery
+(ramp back-off, holdoff, eventual latch). Behavioral regression: on the
+racer model under hard spool, either the loop eventually acquires
+(zero_crosses past the established-run gate) or drive is killed by the
+stuck latch - it must not free-run indefinitely with zc forever below
+acquisition.
+'''
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import time
+
+import sitl_dshot as sd
+from sitl_harness import SITL_DIR, Sender, rpm_from_state, wait_for_state
+
+STATE_MAGIC_CMD = 0x5353
+ZC_STATS_MAGIC = 0x5356
+STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
+                'desync_happened', 'old_routine', 'running', 'armed',
+                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed')
+STATS_FMT = '<HBBIIIIBBBBBB'
+MODELS = os.path.join(SITL_DIR, 'models')
+
+
+def _open_ctl(sitl):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(('127.0.0.1', sitl.state_port))
+    s.settimeout(0.5)
+    return s
+
+
+def _zc_stats(ctl, retries=5):
+    for _ in range(retries):
+        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 4, 0))
+        try:
+            pkt = ctl.recv(64)
+        except socket.timeout:
+            continue
+        if len(pkt) >= struct.calcsize(STATS_FMT):
+            vals = struct.unpack_from(STATS_FMT, pkt)
+            if vals[0] == ZC_STATS_MAGIC:
+                return dict(zip(STATS_FIELDS, vals[3:]))
+    raise AssertionError('no ZC_STATS reply from SITL state port')
+
+
+def test_racer_hard_spool_cannot_desync_forever_below_acquisition(
+        sitl_factory, state_stream):
+    '''racer_5inch + DShot 700 must not free-run forever below zc 100.'''
+    path = os.path.join(MODELS, 'racer_5inch.json')
+    assert os.path.isfile(path), path
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    sim.load_model(path)
+    # async model load over UDP
+    deadline = time.time() + 3.0
+    while time.time() < deadline:
+        status = (sim.model_status or '').lower()
+        if status and 'fail' not in status and 'error' not in status:
+            if 'loading' not in status or 'racer' in status or 'ok' in status:
+                break
+        time.sleep(0.1)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    ctl = _open_ctl(sitl)
+    try:
+        time.sleep(2.2)
+        tx.value = 700
+
+        # Sample for long enough that a stuck-below-acq loop (PR description:
+        # ~20 desyncs/s, 20 early events per JUMP charge) would either get
+        # ramp-backoff help past acquisition, or pile enough charges to latch.
+        max_zc = 0
+        max_desync = 0
+        saw_running = False
+        end = None
+        t0 = time.time()
+        while time.time() - t0 < 12.0:
+            try:
+                s = _zc_stats(ctl)
+            except AssertionError:
+                time.sleep(0.05)
+                continue
+            max_zc = max(max_zc, s['zero_crosses'])
+            max_desync = max(max_desync, s['desync_happened'])
+            if s['running']:
+                saw_running = True
+            end = s
+            # Early success: established-run gate cleared after back-off
+            if s['zero_crosses'] > 100:
+                break
+            time.sleep(0.05)
+
+        assert saw_running, 'motor never entered running\n' + sitl.log_tail()
+        assert end is not None
+
+        acquired = max_zc > 100
+        # Stuck latch / fault path: drive no longer running after many desyncs
+        latched_off = (max_desync >= 20 and end['running'] == 0)
+
+        assert acquired or latched_off, (
+            'acquisition rail did not break free-desync-below-zc100: '
+            'max_zc=%d max_desync=%d end=%r\n%s'
+            % (max_zc, max_desync, end, sitl.log_tail()))
+    finally:
+        tx.value = 0
+        time.sleep(0.5)
+        tx.stop()
+        ctl.close()

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -30,6 +30,9 @@ extern void resetInputCaptureTimer(void);
 /* See the comments on the declarations in faults.h. */
 volatile uint32_t fault_stall_trips = 0;
 
+/* Acquisition-rail early-desync count (see faultNoteEarlyDesync). */
+static uint8_t acq_fail_desyncs;
+
 uint32_t faultErrorCount(void)
 {
 	return desync_happened + fault_stall_trips;
@@ -40,6 +43,7 @@ void faultErrorCountReset(void)
 	/* Per-arm cycle (DSDL: error_count resets when the motor restarts). */
 	fault_stall_trips = 0;
 	desync_happened = 0;
+	acq_fail_desyncs = 0;
 }
 
 uint8_t faultHandleStuckRotorIfNeeded(void)
@@ -167,6 +171,28 @@ void faultUpdateBemfTimeoutPolicy(void)
 #define DESYNC_BACKOFF_BASE_MS 100
 #define DESYNC_BACKOFF_STEP_MS 25
 #define DESYNC_BACKOFF_MAX_MS 500
+/*
+ * Acquisition rail (see faultNoteEarlyDesync in faults.h).
+ *
+ * 20 early desyncs with no successful acquisition in between buy one
+ * JUMP-sized charge. Deliberately conservative: a healthy hard start spends
+ * 2-4 rough desyncs acquiring, so 20 is unambiguously abnormal, while at the
+ * ~20/s rate a genuinely stuck loop produces it still charges once a second.
+ * The point of this rail is to make the failure VISIBLE to the escalation
+ * machinery, not to be the fastest path to the latch - once the first charge
+ * lands, the ramp back-off in faultDesyncEpisodeCharge starts working the
+ * actual cause and the established-run rails (which need zero_crosses > 100
+ * and so were previously unreachable) take over.
+ *
+ * This constant is a starting point from SITL and wants bench calibration
+ * against real hard starts before release.
+ *
+ * ACQ_FAIL_CLEAR_ZC is deliberately well above the 100 that arms blind
+ * stepping: the count must only be forgiven by an acquisition that actually
+ * held, not by one that reached the gate and immediately lost sync again.
+ */
+#define ACQ_FAIL_DESYNC_LIMIT 20
+#define ACQ_FAIL_CLEAR_ZC 500
 
 /*
  * Blind-GRIND rail. The episode rail above only sees DISCRETE failures
@@ -223,7 +249,10 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
 {
 #ifndef BRUSHED_MODE
 	uint8_t inc = DESYNC_EPISODE_CHARGE_STALL;
-	if (kind == DESYNC_EPISODE_JUMP) {
+	if (kind == DESYNC_EPISODE_JUMP || kind == DESYNC_EPISODE_ACQ_FAIL) {
+		/* The acquisition rail has already required ACQ_FAIL_DESYNC_LIMIT
+		 * events before getting here, so one charge per batch is the same
+		 * weight as a single established-run jump. */
 		inc = DESYNC_EPISODE_CHARGE_JUMP;
 	}
 	if ((uint16_t)desync_episode_bucket + inc > 255) {
@@ -269,9 +298,25 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
 #endif
 }
 
+void faultNoteEarlyDesync(void)
+{
+#ifndef BRUSHED_MODE
+	if (++acq_fail_desyncs < ACQ_FAIL_DESYNC_LIMIT) {
+		return;
+	}
+	acq_fail_desyncs = 0;
+	faultDesyncEpisodeCharge(DESYNC_EPISODE_ACQ_FAIL);
+#endif
+}
+
 void faultDesyncEpisodeTick1kHz(void)
 {
 #ifndef BRUSHED_MODE
+	/* A loop that got solidly established did acquire, whatever roughness
+	 * it passed through on the way - forgive the whole batch. */
+	if (zero_crosses > ACQ_FAIL_CLEAR_ZC) {
+		acq_fail_desyncs = 0;
+	}
 	if (desync_restart_holdoff_ms > 0) {
 		desync_restart_holdoff_ms--;
 	}

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -122,8 +122,14 @@ void faultUpdateBemfTimeoutPolicy(void)
 		// zero_crosses > 1000 - a bad-tune cycle that respins fast between
 		// desyncs must keep accumulating (that reset defeating the stuck
 		// latch is one of the gaps this rail exists to close).
+		//
+		// Also clear the acquisition-rail partial batch: otherwise 19 early
+		// desyncs, a pilot cut, then one more early desync on the next blip
+		// would fire a JUMP-sized charge (and permanent ramp-halve) as if
+		// the cut never happened. Match episode-bucket pilot semantics.
 		desync_episode_bucket = 0;
 		desync_restart_holdoff_ms = 0;
+		acq_fail_desyncs = 0;
 	}
 	if (zero_crosses > 100 && adjusted_input < 200) {
 		bemf_timeout_happened = 0;
@@ -179,10 +185,11 @@ void faultUpdateBemfTimeoutPolicy(void)
  * 2-4 rough desyncs acquiring, so 20 is unambiguously abnormal, while at the
  * ~20/s rate a genuinely stuck loop produces it still charges once a second.
  * The point of this rail is to make the failure VISIBLE to the escalation
- * machinery, not to be the fastest path to the latch - once the first charge
- * lands, the ramp back-off in faultDesyncEpisodeCharge starts working the
- * actual cause and the established-run rails (which need zero_crosses > 100
- * and so were previously unreachable) take over.
+ * machinery (bucket, holdoff, latch), not to be the fastest path to the latch.
+ * The side effect that most helps a too-fast tune finally clear acquisition is
+ * the permanent ramp back-off inside faultDesyncEpisodeCharge; established-run
+ * rails (blind/grind/stall) still need zero_crosses > 100 and only help once
+ * the loop actually gets past that gate.
  *
  * This constant is a starting point from SITL and wants bench calibration
  * against real hard starts before release.

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -134,6 +134,13 @@ void runtimeProcessDesyncCheck(void)
 			// accounting is established-runs-only.
 			if (zc_at_desync > 100) {
 				faultDesyncEpisodeCharge(DESYNC_EPISODE_JUMP);
+			} else {
+				// Acquisition-regime desyncs are not charged directly
+				// (that is what the gate above exists to prevent), but
+				// they must not be free either: without this the loop
+				// can desync forever below zc 100 with every rail and
+				// counter reading zero. See faultNoteEarlyDesync.
+				faultNoteEarlyDesync();
 			}
 			if ((!eepromBuffer.bi_direction && (input > 47)) || commutation_interval > 1000) {
 				running = 0;


### PR DESCRIPTION
## Problem

Every rail in the ZC path is gated on an *established* loop:

| Rail | Gate |
|---|---|
| Blind-step deadline | `zero_crosses >= 100` (`bemf_zc.c:141`) |
| BEMF-headroom governor | `zero_crosses > 150` (`runtime_loop.c:289`) |
| Blind power cut / grind detector / miss bucket | need blind steps to exist |
| Episode charge | `zc_at_desync > 100` (`runtime_loop.c:135`) |

A loop that repeatedly desyncs *before* acquisition completes therefore accumulates no state anywhere. It restarts, spools briefly, desyncs, and repeats — with the escalation machinery never engaging.

Instrumented on the SITL `racer_5inch` model at `35d2567` (dshot 700): **~20 desyncs/second sustained, and `desync_episode_bucket` flat at 0 after 38 of them.** Neither the restart backoff nor the latch ever engages, and the rotor limit-cycles at ~2.9k rpm indefinitely.

> **Correction.** An earlier revision of this section claimed "`zero_crosses` never past 48". That was an artifact of a 100 ms debug print aliasing the peaks; sampled at 50 ms, base transiently reaches 102–105 between desyncs. The premise rests on `desync_episode_bucket == 0`, which is a monotonic counter and not sampling-dependent — not on the peak `zero_crosses` value. See [this comment](https://github.com/ARK-Electronics/ARK32/pull/61#issuecomment-5107506861); the bad number also invalidated the first version of the regression test.

## Change

A rail scoped to the acquisition regime. Early desyncs are counted rather than charged directly — charging them is exactly what the established-run gate correctly prevents, since a few interval jumps while acquiring are normal startup roughness. 20 of them with no successful acquisition in between buy one JUMP-sized charge on the existing episode bucket. The count is forgiven once the loop proves it acquired (`zero_crosses > 500`), and on zero throttle as pilot intervention (`63102d8`, matching episode-bucket semantics).

Escalation, backoff and latch are untouched — this only makes the failure visible to them.

## Effect

With the first charge landing, the ramp back-off in `faultDesyncEpisodeCharge` starts working the actual cause. In the same SITL run the loop reaches `zero_crosses` 735 and ~11.9k eRPM in places. Over a longer run the racer model latches (`ESC_FAULT_STUCK`) rather than grinding indefinitely — the documented intent of `DESYNC_EPISODE_LIMIT` for a tune the ESC cannot hold, but a visible behaviour change on that model.

That the ramp back-off helps this model so much also suggests the underlying cause is `racer_5inch`'s default ramp being too fast for it.

## Verification

**Static / build**
- `make size-check-ark`: PASS, 25808/27592 (+16 B vs base)
- `make cppcheck`: PASS, no error/warning
- CI: 8/8 green on `63102d8`

**Hardware (HWCI, 900KV + HQProp 10x5x3, 6S, ≤50% throttle)** — [results](https://github.com/ARK-Electronics/ARK32/pull/61#issuecomment-5107506861):

| Profile | Result |
|---|---|
| startup_reliability | PASS — 10/10, ttr_max 19.5 ms, demag 0, bemf 0 |
| low_rpm_crawl | PASS — full profile, demag 0, bemf 0 |
| staircase + 4× snap-to-50% | PASS — demag 2, bemf 72, blind 54, no stuck latch |

This answers the calibration question: `ACQ_FAIL_DESYNC_LIMIT = 20` does **not** false-trip on the intended heavy prop. Note that the rail's *counting* path almost certainly never ran — blind steps = 54 means `zero_crosses >= 100` was reached, so those desyncs went through the existing JUMP charge. The run demonstrates no-false-latch and no-regression, not the rail firing.

## Known gap: the regression test does not discriminate

`test_acq_desync_rail.py` (added in `63102d8`) **passes on `ark-release`** — verified 3/3 with `max_zc` = 102/105/102 against its `> 100` threshold. Its green CI result does not distinguish this PR from base.

The fix is to assert on the episode machinery rather than peak `zero_crosses`: after ~10 s of the racer failure mode, `desync_episode_bucket` must be nonzero (0 on base, climbing with the rail). That requires exposing `desync_episode_bucket` over the ZC-stats control port in `sitl_state.c` — the same extension needed for the #62/#63 hold assertions. Not done yet, pending sign-off on touching that shared struct.

## Needs bench

A deliberate bad-tune thrash that does **not** return throttle to zero between attempts, since the pilot-zero clear resets the batch before it can charge.