### PR TITLE
fix(limits): hold the low-rpm throttle ceiling across a desync

### DIFF
--- a/Inc/runtime_loop.h
+++ b/Inc/runtime_loop.h
@@ -37,4 +37,20 @@ void runtimeProcessAdcAndProtections(void);
  */
 void runtimeMotorModeTick(void);
 
+/*
+ * Post-desync throttle-ceiling hold state, exposed for observability rather
+ * than for use by other translation units. Nothing outside runtime_loop.c
+ * writes these; the SITL ZC_STATS control port reads them so a test can
+ * assert the hold actually ENGAGES.
+ *
+ * That assertion is the gate this change originally shipped without: the
+ * first revision declared these, ticked them, cleared them and read them but
+ * never assigned them, and the resulting no-op passed compilation, cppcheck,
+ * the size gate, the full SITL suite and a complete HWCI hardware suite.
+ * Internal state that no test can observe is internal state that can silently
+ * stop working.
+ */
+extern uint16_t dcm_hold_value;
+extern uint8_t dcm_hold_ms;
+
 #endif /* RUNTIME_LOOP_H_ */

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -28,16 +28,21 @@
   SITL -> client:
     u16 magic 0x5354, u8 version=1, u8 count, count * sample
     u16 magic 0x5355, u8 ok, u8 pad, message   (LOAD_MODEL reply)
-    u16 magic 0x5356, u8 version=1, u8 pad, u32 zero_crosses,
+    u16 magic 0x5356, u8 version=2, u8 pad, u32 zero_crosses,
       u32 commutation_interval, u32 dropped_edges, u32 desync_happened,
       u8 old_routine, u8 running, u8 armed, u8 zc_blind_steps,
-      u8 zc_miss_bucket, u8 zc_deadline_armed  (ZC_STATS reply)
+      u8 zc_miss_bucket, u8 zc_deadline_armed,
+      u8 dcm_hold_ms, u8 pad2, u16 dcm_hold_value  (ZC_STATS reply)
+      Fields are only ever APPENDED and the version is bumped; clients that
+      unpack a shorter prefix keep working unchanged (they length-check with
+      >=), which is why v1 readers such as test_blind_step.py need no edit.
 */
 
 #include "sitl.h"
 #include "sitl_config.h"
 #include "motor.h"
 #include "motor_runtime.h"
+#include "runtime_loop.h"
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -225,9 +230,15 @@ void sitl_state_poll(void)
 			uint8_t zc_blind_steps;
 			uint8_t zc_miss_bucket;
 			uint8_t zc_deadline_armed;
+			/* v2: post-desync throttle-ceiling hold (PR #62). Present so a
+			 * test can assert the hold ENGAGES - the first revision of that
+			 * change never armed it and the no-op passed every other gate. */
+			uint8_t dcm_hold_ms;
+			uint8_t pad2;
+			uint16_t dcm_hold_value;
 		} reply = {
 			.magic = 0x5356,
-			.version = 1,
+			.version = 2,
 			.zero_crosses = zero_crosses,
 			.commutation_interval = commutation_interval,
 			.dropped_edges = motor_zc_dropped(),
@@ -238,6 +249,8 @@ void sitl_state_poll(void)
 			.zc_blind_steps = zc_blind_steps,
 			.zc_miss_bucket = zc_miss_bucket,
 			.zc_deadline_armed = zc_deadline_armed,
+			.dcm_hold_ms = dcm_hold_ms,
+			.dcm_hold_value = dcm_hold_value,
 		};
 		sendto(fd, &reply, sizeof(reply), 0, (struct sockaddr *)&src, sizeof(src));
 	}

--- a/Mcu/SITL/tests/test_ceiling_hold.py
+++ b/Mcu/SITL/tests/test_ceiling_hold.py
@@ -87,6 +87,7 @@ def test_ceiling_hold_engages_on_desync(sitl_factory, state_stream):
         # ceiling being frozen was earned at a real rpm (k_erpm >
         # low_rpm_level), so a stationary or barely-turning rotor is not a
         # valid starting condition for this test.
+        RPM_MIN = 2000.0
         deadline = time.time() + 10.0
         pre = None
         rpm = 0.0
@@ -95,14 +96,23 @@ def test_ceiling_hold_engages_on_desync(sitl_factory, state_stream):
             if s['running'] and not s['old_routine'] and s['zero_crosses'] > 100:
                 # Short sample; poll until the rotor is clearly above idle so
                 # a single slow window on a busy CI host cannot flake out.
+                #
+                # RPM_MIN must clear the hold's own ARM GATE, not just idle.
+                # The gate is k_erpm > low_rpm_level, and low_rpm_level =
+                # motor_kv * poles / 3200 (settings.c) = 900 * 14 / 3200 = 3
+                # for this model, so k_erpm must reach 4. k_erpm is
+                # mech_rpm * pole_pairs / 1000, i.e. ~571 mech rpm - well
+                # above a 300 gate. Injecting the fault below the arm gate
+                # would leave the hold legitimately un-armed and fail the
+                # test against the firmware, so keep ~4x headroom.
                 rpm = rpm_from_state(sim, 0.2)
-                if rpm > 300:
+                if rpm > RPM_MIN:
                     pre = s
                     break
             time.sleep(0.05)
         assert pre is not None, (
-            'never reached established closed loop with rotor turning '
-            '(last rpm=%.0f)\n%s' % (rpm, sitl.log_tail()))
+            'never reached established closed loop above %.0f rpm '
+            '(last rpm=%.0f)\n%s' % (RPM_MIN, rpm, sitl.log_tail()))
         assert pre['dcm_hold_ms'] == 0, 'hold already armed before any desync: %r' % pre
 
         # Suppress comparator edge delivery long enough to force a desync

--- a/Mcu/SITL/tests/test_ceiling_hold.py
+++ b/Mcu/SITL/tests/test_ceiling_hold.py
@@ -1,0 +1,135 @@
+'''Post-desync throttle-ceiling hold engagement (PR #62).
+
+duty_cycle_maximum is a pure function of the live k_erpm, so a desync
+collapses the throttle ceiling in one main-loop pass while the rotor is
+still turning. The hold freezes the pre-collapse ceiling for DCM_HOLD_MS so
+re-acquisition is not starved of authority.
+
+WHY THIS TEST EXISTS: the first revision of that change declared the hold
+state, ticked it at 1 kHz, cleared it on the coast path and read it in the
+consumer - but never assigned it. dcm_hold_ms was permanently 0 and the
+feature did nothing. That no-op passed compilation (the statics are read, so
+no unused-variable diagnostic), cppcheck, the size gate, the full SITL suite
+AND a complete HWCI hardware suite, because a no-op cannot regress anything.
+
+So this asserts ENGAGEMENT, not absence of regression: after an injected
+desync, dcm_hold_ms must be observed nonzero. Remove the two assignments in
+runtimeProcessDesyncCheck and this test must fail - that mutation check is
+the whole point, and is worth re-running if the arming is ever refactored.
+'''
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import time
+
+import sitl_dshot as sd
+from sitl_harness import SITL_DIR, Sender, rpm_from_state, wait_for_state
+
+STATE_MAGIC_CMD = 0x5353
+ZC_STATS_MAGIC = 0x5356
+MODELS = os.path.join(SITL_DIR, 'models')
+
+# v2 payload: v1 fields plus the hold state. Appended-only, so a v1 reader
+# unpacking the shorter prefix is unaffected.
+STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
+                'desync_happened', 'old_routine', 'running', 'armed',
+                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'dcm_hold_ms', '_pad2', 'dcm_hold_value')
+STATS_FMT = '<HBBIIIIBBBBBBBBH'
+
+
+def _open_ctl(sitl):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(('127.0.0.1', sitl.state_port))
+    s.settimeout(0.5)
+    return s
+
+
+def _zc_stats(ctl, retries=5):
+    for _ in range(retries):
+        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 4, 0))
+        try:
+            pkt = ctl.recv(64)
+        except socket.timeout:
+            continue
+        if len(pkt) >= struct.calcsize(STATS_FMT):
+            vals = struct.unpack_from(STATS_FMT, pkt)
+            if vals[0] == ZC_STATS_MAGIC:
+                assert vals[1] >= 2, 'ZC_STATS version %d lacks hold fields' % vals[1]
+                return dict(zip(STATS_FIELDS, vals[3:]))
+    raise AssertionError('no v2 ZC_STATS reply from SITL state port')
+
+
+def _zc_fault(ctl, mode, duration_us):
+    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 3, mode, duration_us))
+
+
+def test_ceiling_hold_engages_on_desync(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    sim.load_model(os.path.join(MODELS, 'default_7inch.json'))
+    time.sleep(1.0)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    ctl = _open_ctl(sitl)
+    try:
+        time.sleep(2.2)
+        tx.value = 900
+
+        # Spin up into established closed loop: the hold only arms when the
+        # ceiling being frozen was earned at a real rpm (k_erpm >
+        # low_rpm_level), so a stationary or barely-turning rotor is not a
+        # valid starting condition for this test.
+        deadline = time.time() + 8.0
+        pre = None
+        while time.time() < deadline:
+            s = _zc_stats(ctl)
+            if s['running'] and not s['old_routine'] and s['zero_crosses'] > 100:
+                pre = s
+                break
+            time.sleep(0.05)
+        assert pre is not None, 'never reached established closed loop\n' + sitl.log_tail()
+        assert rpm_from_state(sim, 0.3) > 500, 'rotor not turning\n' + sitl.log_tail()
+        assert pre['dcm_hold_ms'] == 0, 'hold already armed before any desync: %r' % pre
+
+        # Suppress comparator edge delivery long enough to force a desync
+        # rather than a bridgeable dropout: the interval jump has to exceed
+        # the 50% jump check in runtimeProcessDesyncCheck.
+        ci_us = max(pre['commutation_interval'] // 2, 100)
+        seen_hold = 0
+        seen_value = 0
+        saw_desync = False
+        for _ in range(6):
+            _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
+            probe_end = time.time() + 0.35
+            while time.time() < probe_end:
+                s = _zc_stats(ctl)
+                seen_hold = max(seen_hold, s['dcm_hold_ms'])
+                seen_value = max(seen_value, s['dcm_hold_value'])
+                if s['desync_happened'] > pre['desync_happened']:
+                    saw_desync = True
+            if seen_hold:
+                break
+
+        assert saw_desync, (
+            'fault injection never produced a desync, so the hold was never '
+            'given a chance to arm\n' + sitl.log_tail())
+        assert seen_hold > 0, (
+            'THE HOLD NEVER ARMED. dcm_hold_ms stayed 0 across %d desyncs - '
+            'this is the exact no-op the first revision of PR #62 shipped. '
+            'Check that runtimeProcessDesyncCheck still assigns dcm_hold_ms '
+            'and dcm_hold_value in the desynced branch.\n%s'
+            % (saw_desync, sitl.log_tail()))
+        assert seen_value > 0, (
+            'dcm_hold_ms armed but dcm_hold_value is 0, so the clamp holds '
+            'nothing: %d' % seen_value)
+    finally:
+        tx.value = 0
+        time.sleep(0.3)
+        _zc_fault(ctl, mode=0, duration_us=0)
+        tx.stop()
+        ctl.close()

--- a/Mcu/SITL/tests/test_ceiling_hold.py
+++ b/Mcu/SITL/tests/test_ceiling_hold.py
@@ -71,7 +71,10 @@ def test_ceiling_hold_engages_on_desync(sitl_factory, state_stream):
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
     assert wait_for_state(sim), sitl.log_tail()
-    sim.load_model(os.path.join(MODELS, 'default_7inch.json'))
+    # Unloaded: reaches real rpm quickly under CI load. default_7inch can
+    # sit near ~450 mech RPM at mid throttle on a loaded runner and trip a
+    # brittle >500 gate after closed loop is already healthy (CI flake).
+    sim.load_model(os.path.join(MODELS, 'unloaded.json'))
     time.sleep(1.0)
 
     tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
@@ -84,16 +87,22 @@ def test_ceiling_hold_engages_on_desync(sitl_factory, state_stream):
         # ceiling being frozen was earned at a real rpm (k_erpm >
         # low_rpm_level), so a stationary or barely-turning rotor is not a
         # valid starting condition for this test.
-        deadline = time.time() + 8.0
+        deadline = time.time() + 10.0
         pre = None
+        rpm = 0.0
         while time.time() < deadline:
             s = _zc_stats(ctl)
             if s['running'] and not s['old_routine'] and s['zero_crosses'] > 100:
-                pre = s
-                break
+                # Short sample; poll until the rotor is clearly above idle so
+                # a single slow window on a busy CI host cannot flake out.
+                rpm = rpm_from_state(sim, 0.2)
+                if rpm > 300:
+                    pre = s
+                    break
             time.sleep(0.05)
-        assert pre is not None, 'never reached established closed loop\n' + sitl.log_tail()
-        assert rpm_from_state(sim, 0.3) > 500, 'rotor not turning\n' + sitl.log_tail()
+        assert pre is not None, (
+            'never reached established closed loop with rotor turning '
+            '(last rpm=%.0f)\n%s' % (rpm, sitl.log_tail()))
         assert pre['dcm_hold_ms'] == 0, 'hold already armed before any desync: %r' % pre
 
         # Suppress comparator edge delivery long enough to force a desync

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -52,8 +52,10 @@
  * carrying authority into a genuine rotor slowdown.
  */
 #define DCM_HOLD_MS 50
-static uint16_t dcm_hold_value;
-static uint8_t dcm_hold_ms;
+/* Non-static so the SITL ZC_STATS port can observe engagement; see the
+ * declaration comment in runtime_loop.h. No other TU writes these. */
+uint16_t dcm_hold_value;
+uint8_t dcm_hold_ms;
 
 void runtimeUpdateVariablePwm(uint16_t *last_tim1_arr)
 {

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -43,6 +43,18 @@
 #	define ZC_FILTER_FAST 2
 #endif
 
+/*
+ * Post-desync hold for the low-rpm throttle ceiling (runtimeMotorModeTick).
+ * Scoped to the window where the rpm ESTIMATE is known-invalid rather than
+ * applied as a general fall-rate limit: outside that window a falling
+ * k_erpm is real and the ceiling collapsing with it is the protection
+ * working, not a pathology. 50 ms covers the estimate's recovery without
+ * carrying authority into a genuine rotor slowdown.
+ */
+#define DCM_HOLD_MS 50
+static uint16_t dcm_hold_value;
+static uint8_t dcm_hold_ms;
+
 void runtimeUpdateVariablePwm(uint16_t *last_tim1_arr)
 {
 	uint16_t next_tim1_arr = tim1_arr;    // unchanged unless variable_pwm recomputes it below
@@ -385,6 +397,10 @@ void runtimeProcessAdcAndProtections(void)
 			escToFaultLvc();
 		}
 
+		if (dcm_hold_ms) {
+			dcm_hold_ms--;
+		}
+
 		PROCESS_ADC_FLAG = 0;
 #ifdef USE_ADC_INPUT
 		if (ADC_raw_input < 10) {
@@ -423,6 +439,7 @@ void runtimeMotorModeTick(void)
 		// running rpm for up to the whole holdoff.
 		e_rpm = 0;
 		k_erpm = 0;
+		dcm_hold_ms = 0; // a coast must not carry a stale ceiling into the restart
 		return;
 	}
 	if (!escInSineStart()) {
@@ -437,6 +454,36 @@ void runtimeMotorModeTick(void)
 						 throttle_max_at_high_rpm); // for more performance lower the
 									    // high_rpm_level, set to a
 									    // consvervative number in source.
+			/*
+			 * Post-desync hold (armed in runtimeProcessDesyncCheck).
+			 * The map above is a pure function of the LIVE k_erpm, so a
+			 * desync - which collapses the rpm ESTIMATE in one
+			 * main-loop pass while the rotor is still turning -
+			 * collapses the throttle ceiling with it, during exactly
+			 * the re-acquisition that needs authority. Measured on the
+			 * SITL racer_5inch model: duty_cycle_maximum drops
+			 * 1700 -> 600 the instant sync is lost, capping the
+			 * setpoint at 440 while the loop tries to re-acquire,
+			 * which weakens the re-acquisition and feeds the next
+			 * desync.
+			 *
+			 * The hold value is the ceiling the rotor had already
+			 * earned at a real rpm one pass earlier, so this can never
+			 * exceed what the live estimate would have allowed had it
+			 * survived; and it expires after DCM_HOLD_MS whether or not
+			 * the loop re-acquires. Deliberately NOT a general
+			 * fall-rate limit on duty_cycle_maximum: outside the
+			 * invalid-estimate window a falling k_erpm is real, and the
+			 * ceiling following it down is the protection working.
+			 *
+			 * Not a protection bypass: the current limit, the BEMF
+			 * headroom ceiling and the blind/demag power cut are all
+			 * applied to duty_cycle_setpoint AFTER this clamp in
+			 * setInput(), and none of them read duty_cycle_maximum.
+			 */
+			if (dcm_hold_ms && duty_cycle_maximum < dcm_hold_value) {
+				duty_cycle_maximum = dcm_hold_value;
+			}
 		} else {
 			duty_cycle_maximum = 2000;
 		}

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -133,6 +133,16 @@ void runtimeProcessDesyncCheck(void)
 		if (desynced) {
 			slow_avg_revs = 0;
 			const uint32_t zc_at_desync = zero_crosses;
+			// Freeze the throttle ceiling briefly: k_erpm is about to
+			// collapse because the ESTIMATE died, not because the rotor
+			// did, and re-deriving the ceiling from the collapsed
+			// reading caps duty during exactly the re-acquisition that
+			// needs authority. Armed only when the ceiling being held
+			// was earned at a real rpm.
+			if (k_erpm > low_rpm_level) {
+				dcm_hold_value = duty_cycle_maximum;
+				dcm_hold_ms = DCM_HOLD_MS;
+			}
 			zero_crosses = 0;
 			desync_happened++;
 			// Same established-run gate as the stall rail (see


### PR DESCRIPTION
## Problem

`duty_cycle_maximum` is a pure function of the live `k_erpm`. A desync collapses the rpm **estimate** in a single main-loop pass while the rotor is still turning, so the throttle ceiling collapses with it — during exactly the re-acquisition that needs authority.

Measured on the SITL `racer_5inch` model: the ceiling drops 1700 → 600 the instant sync is lost and caps the setpoint at 440 while the loop is trying to re-acquire, which weakens the re-acquisition and feeds the next desync.

## Change

Hold the pre-desync ceiling for 50 ms, armed only when it was earned at a real rpm (`k_erpm > low_rpm_level`) and cleared on the coast path so a restart never inherits it. The held value is what the live estimate allowed one pass earlier, so this cannot exceed what an uncollapsed estimate would have permitted, and it expires whether or not the loop re-acquires.

**Not a protection bypass:** the current limit, the BEMF-headroom ceiling and the blind/demag power cut are all applied to `duty_cycle_setpoint` *after* this clamp in `setInput()`, and none of them read `duty_cycle_maximum`.

## Design note

A general fall-rate limit on `duty_cycle_maximum` was tried first and abandoned. Outside the invalid-estimate window a falling `k_erpm` is real, and the ceiling following it down is the protection working, not a pathology — rate-limiting it unconditionally carries throttle authority into genuine rotor slowdowns.

## ⚠️ History — the first revision of this PR was a no-op

`e32c0d0` declared `dcm_hold_value` / `dcm_hold_ms`, ticked them down at 1 kHz, cleared them on the coast path and read them in the consumer — but never **assigned** them. `dcm_hold_ms` was permanently 0, so the hold never engaged. Fixed in `2f5bc7d` by arming inside the `desynced` branch of `runtimeProcessDesyncCheck` (+40 B flash over the no-op, which is the confirmation the code is real).

Everything passed on the no-op: compile (the statics are *read*, so no unused-variable diagnostic), cppcheck, the size gate, the full SITL suite, and a complete HWCI hardware suite. Worth knowing when reviewing the rest of this set — a green board proved nothing here.

## Verification

**Static / build (on `2f5bc7d`)**
- `make size-check-ark`: PASS, 25880/27592
- `make cppcheck`: PASS, no error/warning

**Hardware: VOID, needs re-running.** The HWCI results posted on this PR ([run](https://github.com/ARK-Electronics/ARK32/pull/62#issuecomment-5107248748), [retraction](https://github.com/ARK-Electronics/ARK32/pull/62#issuecomment-5107317375)) were produced against `e32c0d0` and measured base firmware. They say nothing about this change.

Those runs did usefully establish the rig's run-to-run noise floor, since #62 and #63 were both no-ops and therefore identical firmware: 19% spread on `ttr_max`, 7–8% on bemf samples, 5% on max current. Any future A/B on this plant needs n≥3 per arm before a single-digit-percent delta is meaningful.

**Superseded:** an earlier revision of this section reported a SITL safety+models subset A/B. That was measuring container timing noise, not the code. Disregard.

## Known gaps

- **No test asserts the hold engages.** This is the gap that let the no-op ship. Both this and #63 are only observable through internal state; the right fix is a SITL assertion via the ZC-stats control port that `test_blind_step.py` and `test_acq_desync_rail.py` already use — expose `dcm_hold_ms` and assert nonzero after an injected desync. Should land before any further bench time.
- **The 50 ms window is a guess.** No reacq/relock metric exists in `hwci/hwci/metrics.py`. It is self-limiting in the safe direction: once the loop re-locks, `k_erpm` recovers, the `map()` returns to its clamp and the comparison stops binding, so an over-long window is inert.

## Scope

This does **not** by itself resolve the `racer_5inch` limit cycle — it removes one positive-feedback path into it. #61 addresses the cause.

## Merge order

Conflicts textually with #63 at the same site in `runtimeProcessDesyncCheck`; whichever lands second needs a trivial rebase.