### PR TITLE
fix(advance): hold the schedule's rpm while the estimate is invalid

### DIFF
--- a/Inc/runtime_loop.h
+++ b/Inc/runtime_loop.h
@@ -38,19 +38,22 @@ void runtimeProcessAdcAndProtections(void);
 void runtimeMotorModeTick(void);
 
 /*
- * Post-desync throttle-ceiling hold state, exposed for observability rather
- * than for use by other translation units. Nothing outside runtime_loop.c
- * writes these; the SITL ZC_STATS control port reads them so a test can
- * assert the hold actually ENGAGES.
+ * Post-desync hold state, exposed for observability rather than for use by
+ * other translation units. Nothing outside runtime_loop.c writes these; the
+ * SITL ZC_STATS control port reads them so a test can assert each hold
+ * actually ENGAGES.
  *
- * That assertion is the gate this change originally shipped without: the
- * first revision declared these, ticked them, cleared them and read them but
- * never assigned them, and the resulting no-op passed compilation, cppcheck,
- * the size gate, the full SITL suite and a complete HWCI hardware suite.
- * Internal state that no test can observe is internal state that can silently
- * stop working.
+ * That assertion is the gate the first revisions of both holds shipped
+ * without: they declared the statics, ticked them, cleared them and read
+ * them but never assigned them, and the resulting no-ops passed compilation,
+ * cppcheck, the size gate, the full SITL suite and complete HWCI hardware
+ * suites. Internal state that no test can observe can silently stop working.
  */
+/* PR #62: low-rpm throttle ceiling hold */
 extern uint16_t dcm_hold_value;
 extern uint8_t dcm_hold_ms;
+/* PR #63: advance-schedule rpm hold */
+extern uint16_t adv_kerpm_hold;
+extern uint8_t adv_kerpm_hold_ms;
 
 #endif /* RUNTIME_LOOP_H_ */

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -28,14 +28,16 @@
   SITL -> client:
     u16 magic 0x5354, u8 version=1, u8 count, count * sample
     u16 magic 0x5355, u8 ok, u8 pad, message   (LOAD_MODEL reply)
-    u16 magic 0x5356, u8 version=2, u8 pad, u32 zero_crosses,
+    u16 magic 0x5356, u8 version=3, u8 pad, u32 zero_crosses,
       u32 commutation_interval, u32 dropped_edges, u32 desync_happened,
       u8 old_routine, u8 running, u8 armed, u8 zc_blind_steps,
       u8 zc_miss_bucket, u8 zc_deadline_armed,
-      u8 dcm_hold_ms, u8 pad2, u16 dcm_hold_value  (ZC_STATS reply)
-      Fields are only ever APPENDED and the version is bumped; clients that
-      unpack a shorter prefix keep working unchanged (they length-check with
-      >=), which is why v1 readers such as test_blind_step.py need no edit.
+      u8 dcm_hold_ms, u8 pad2, u16 dcm_hold_value,       (v2 PR 62)
+      u8 adv_kerpm_hold_ms, u8 pad3, u16 adv_kerpm_hold  (v3 PR 63)
+      (ZC_STATS reply). Fields are only ever APPENDED and the version is
+      bumped; clients that unpack a shorter prefix keep working unchanged
+      (they length-check with >=), which is why v1 readers such as
+      test_blind_step.py and the v2 ceiling-hold test need no edit.
 */
 
 #include "sitl.h"
@@ -230,15 +232,17 @@ void sitl_state_poll(void)
 			uint8_t zc_blind_steps;
 			uint8_t zc_miss_bucket;
 			uint8_t zc_deadline_armed;
-			/* v2: post-desync throttle-ceiling hold (PR #62). Present so a
-			 * test can assert the hold ENGAGES - the first revision of that
-			 * change never armed it and the no-op passed every other gate. */
+			/* v2: post-desync throttle-ceiling hold (PR #62). */
 			uint8_t dcm_hold_ms;
 			uint8_t pad2;
 			uint16_t dcm_hold_value;
+			/* v3: post-desync advance-schedule rpm hold (PR #63). */
+			uint8_t adv_kerpm_hold_ms;
+			uint8_t pad3;
+			uint16_t adv_kerpm_hold;
 		} reply = {
 			.magic = 0x5356,
-			.version = 2,
+			.version = 3,
 			.zero_crosses = zero_crosses,
 			.commutation_interval = commutation_interval,
 			.dropped_edges = motor_zc_dropped(),
@@ -251,6 +255,8 @@ void sitl_state_poll(void)
 			.zc_deadline_armed = zc_deadline_armed,
 			.dcm_hold_ms = dcm_hold_ms,
 			.dcm_hold_value = dcm_hold_value,
+			.adv_kerpm_hold_ms = adv_kerpm_hold_ms,
+			.adv_kerpm_hold = adv_kerpm_hold,
 		};
 		sendto(fd, &reply, sizeof(reply), 0, (struct sockaddr *)&src, sizeof(src));
 	}

--- a/Mcu/SITL/tests/test_advance_hold.py
+++ b/Mcu/SITL/tests/test_advance_hold.py
@@ -1,0 +1,140 @@
+'''Post-desync advance-schedule rpm hold engagement (PR #63).
+
+The auto-advance curve is keyed on k_erpm, so a desync collapses the rpm
+estimate in one main-loop pass and drops the schedule to its bottom while the
+rotor is still spinning fast - under-advancing exactly where the true lag is
+highest. The hold keeps the last valid k_erpm for the schedule for
+ADV_ERPM_HOLD_MS.
+
+WHY THIS TEST EXISTS: the first revision of that change declared the hold
+state, ticked it at 1 kHz, cleared it on the coast path and read it in the
+auto-advance block - but never assigned it. adv_kerpm_hold_ms was permanently
+0 and the feature did nothing. That no-op passed compilation (the statics are
+read, so no unused-variable diagnostic), cppcheck, the size gate, the full
+SITL suite AND a complete HWCI hardware suite, because a no-op cannot
+regress anything.
+
+So this asserts ENGAGEMENT, not absence of regression: after an injected
+desync, adv_kerpm_hold_ms must be observed nonzero. Remove the two
+assignments in runtimeProcessDesyncCheck and this test must fail - that
+mutation check is the whole point.
+'''
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import time
+
+import sitl_dshot as sd
+from sitl_harness import SITL_DIR, Sender, rpm_from_state, wait_for_state
+
+STATE_MAGIC_CMD = 0x5353
+ZC_STATS_MAGIC = 0x5356
+MODELS = os.path.join(SITL_DIR, 'models')
+
+# v3 payload: v1 + dcm hold (v2 / PR #62) + advance hold (v3 / PR #63).
+# Appended-only; shorter unpackers keep working via length-check + unpack_from.
+STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
+                'desync_happened', 'old_routine', 'running', 'armed',
+                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'dcm_hold_ms', '_pad2', 'dcm_hold_value',
+                'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold')
+STATS_FMT = '<HBBIIIIBBBBBBBBHBBH'
+
+
+def _open_ctl(sitl):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(('127.0.0.1', sitl.state_port))
+    s.settimeout(0.5)
+    return s
+
+
+def _zc_stats(ctl, retries=5):
+    for _ in range(retries):
+        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 4, 0))
+        try:
+            pkt = ctl.recv(64)
+        except socket.timeout:
+            continue
+        if len(pkt) >= struct.calcsize(STATS_FMT):
+            vals = struct.unpack_from(STATS_FMT, pkt)
+            if vals[0] == ZC_STATS_MAGIC:
+                assert vals[1] >= 3, (
+                    'ZC_STATS version %d lacks advance-hold fields' % vals[1])
+                return dict(zip(STATS_FIELDS, vals[3:]))
+    raise AssertionError('no v3 ZC_STATS reply from SITL state port')
+
+
+def _zc_fault(ctl, mode, duration_us):
+    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 3, mode, duration_us))
+
+
+def test_advance_hold_engages_on_desync(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    # Unloaded: reaches real rpm quickly under CI load (default_7inch flaked
+    # the ceiling-hold test at ~462 rpm against a hard >500 gate).
+    sim.load_model(os.path.join(MODELS, 'unloaded.json'))
+    time.sleep(1.0)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    ctl = _open_ctl(sitl)
+    try:
+        time.sleep(2.2)
+        tx.value = 900
+
+        # The hold only arms with a real rpm behind it (k_erpm > 0), so wait
+        # for established closed loop before injecting anything.
+        deadline = time.time() + 10.0
+        pre = None
+        rpm = 0.0
+        while time.time() < deadline:
+            s = _zc_stats(ctl)
+            if s['running'] and not s['old_routine'] and s['zero_crosses'] > 100:
+                rpm = rpm_from_state(sim, 0.2)
+                if rpm > 300:
+                    pre = s
+                    break
+            time.sleep(0.05)
+        assert pre is not None, (
+            'never reached established closed loop with rotor turning '
+            '(last rpm=%.0f)\n%s' % (rpm, sitl.log_tail()))
+        assert pre['adv_kerpm_hold_ms'] == 0, 'hold already armed before any desync: %r' % pre
+
+        ci_us = max(pre['commutation_interval'] // 2, 100)
+        seen_hold = 0
+        seen_value = 0
+        saw_desync = False
+        for _ in range(6):
+            _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
+            probe_end = time.time() + 0.35
+            while time.time() < probe_end:
+                s = _zc_stats(ctl)
+                seen_hold = max(seen_hold, s['adv_kerpm_hold_ms'])
+                seen_value = max(seen_value, s['adv_kerpm_hold'])
+                if s['desync_happened'] > pre['desync_happened']:
+                    saw_desync = True
+            if seen_hold:
+                break
+
+        assert saw_desync, (
+            'fault injection never produced a desync, so the hold was never '
+            'given a chance to arm\n' + sitl.log_tail())
+        assert seen_hold > 0, (
+            'THE HOLD NEVER ARMED. adv_kerpm_hold_ms stayed 0 across the '
+            'injected desyncs - this is the exact no-op the first revision of '
+            'PR #63 shipped. Check that runtimeProcessDesyncCheck still '
+            'assigns adv_kerpm_hold and adv_kerpm_hold_ms in the desynced '
+            'branch.\n' + sitl.log_tail())
+        assert seen_value > 0, (
+            'adv_kerpm_hold_ms armed but adv_kerpm_hold is 0, so the schedule '
+            'holds nothing')
+    finally:
+        tx.value = 0
+        time.sleep(0.3)
+        _zc_fault(ctl, mode=0, duration_us=0)
+        tx.stop()
+        ctl.close()

--- a/Mcu/SITL/tests/test_advance_hold.py
+++ b/Mcu/SITL/tests/test_advance_hold.py
@@ -102,7 +102,23 @@ def test_advance_hold_engages_on_desync(sitl_factory, state_stream):
         assert pre is not None, (
             'never reached established closed loop with rotor turning '
             '(last rpm=%.0f)\n%s' % (rpm, sitl.log_tail()))
-        assert pre['adv_kerpm_hold_ms'] == 0, 'hold already armed before any desync: %r' % pre
+        # Spool-up on this model legitimately produces a few desyncs, so the
+        # hold may ALREADY be armed here - observed locally as
+        # adv_kerpm_hold_ms=1 with desync_happened=6 at this point. Asserting
+        # it is zero outright is therefore flaky. Wait for it to expire (it
+        # decays at 1 kHz from ADV_ERPM_HOLD_MS) so that arming seen after the
+        # injection below is caused by the injection rather than being a
+        # decaying residual - which also keeps the causal link the mutation
+        # check relies on.
+        settle = time.time() + 2.0
+        while time.time() < settle:
+            pre = _zc_stats(ctl)
+            if pre['adv_kerpm_hold_ms'] == 0:
+                break
+            time.sleep(0.01)
+        assert pre['adv_kerpm_hold_ms'] == 0, (
+            'hold never expired before injection, so a later nonzero reading '
+            'could be residual rather than caused: %r\n%s' % (pre, sitl.log_tail()))
 
         ci_us = max(pre['commutation_interval'] // 2, 100)
         seen_hold = 0

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -57,6 +57,31 @@
 uint16_t dcm_hold_value;
 uint8_t dcm_hold_ms;
 
+/*
+ * Advance-schedule rpm hold across a desync.
+ *
+ * The auto-advance curve is keyed on k_erpm (dcc655) because commutation lag
+ * is a function of speed. A desync destroys the rpm ESTIMATE in one
+ * main-loop pass while the rotor keeps turning at very nearly its previous
+ * speed, so the schedule drops straight to its bottom (level 13) at the
+ * moment the loop is trying to re-acquire against a fast-spinning rotor -
+ * under-advancing precisely where the true lag is highest.
+ *
+ * Hold the last valid k_erpm for the schedule only, for as long as the
+ * estimate is untrustworthy. Rotor speed cannot change much in this window
+ * (it is bounded by prop inertia, not by the ESC), so the held value is a
+ * far better estimate of true speed than the collapsed reading it replaces.
+ *
+ * Deliberately scoped to the advance schedule. e_rpm itself is NOT touched:
+ * it is the telemetry value (DroneCAN / KISS) and must keep reporting what
+ * the ESC actually measured. The BEMF-headroom governor also reads e_rpm but
+ * needs no equivalent, since it disarms below zero_crosses > 150 and so is
+ * already inert throughout re-acquisition.
+ */
+#define ADV_ERPM_HOLD_MS 50
+static uint16_t adv_kerpm_hold;
+static uint8_t adv_kerpm_hold_ms;
+
 void runtimeUpdateVariablePwm(uint16_t *last_tim1_arr)
 {
 	uint16_t next_tim1_arr = tim1_arr;    // unchanged unless variable_pwm recomputes it below
@@ -412,6 +437,9 @@ void runtimeProcessAdcAndProtections(void)
 		if (dcm_hold_ms) {
 			dcm_hold_ms--;
 		}
+		if (adv_kerpm_hold_ms) {
+			adv_kerpm_hold_ms--;
+		}
 
 		PROCESS_ADC_FLAG = 0;
 #ifdef USE_ADC_INPUT
@@ -451,7 +479,8 @@ void runtimeMotorModeTick(void)
 		// running rpm for up to the whole holdoff.
 		e_rpm = 0;
 		k_erpm = 0;
-		dcm_hold_ms = 0; // a coast must not carry a stale ceiling into the restart
+		dcm_hold_ms = 0;       // a coast must not carry a stale ceiling into the restart
+		adv_kerpm_hold_ms = 0; // a coast is a real slowdown, not a dead estimate
 		return;
 	}
 	if (!escInSineStart()) {
@@ -594,8 +623,14 @@ void runtimeMotorModeTick(void)
 				}
 				adv_max_kerpm = (uint16_t)(((uint32_t)advance_erpm_scale_q12 * advance_pack_v_cv) >> 12);
 			}
-			if (adv_max_kerpm > 8 && k_erpm <= (uint16_t)(adv_max_kerpm + (adv_max_kerpm >> 2))) {
-				auto_advance_level = map(k_erpm, adv_max_kerpm >> 4, adv_max_kerpm, 13, 23);
+			/* See adv_kerpm_hold: use the last trustworthy speed while
+			 * the live estimate is invalid. */
+			uint16_t adv_kerpm = k_erpm;
+			if (adv_kerpm_hold_ms && adv_kerpm_hold > adv_kerpm) {
+				adv_kerpm = adv_kerpm_hold;
+			}
+			if (adv_max_kerpm > 8 && adv_kerpm <= (uint16_t)(adv_max_kerpm + (adv_max_kerpm >> 2))) {
+				auto_advance_level = map(adv_kerpm, adv_max_kerpm >> 4, adv_max_kerpm, 13, 23);
 			} else {
 				auto_advance_level = map(duty_cycle, 100, 2000, 13, 23);
 			}

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -79,8 +79,10 @@ uint8_t dcm_hold_ms;
  * already inert throughout re-acquisition.
  */
 #define ADV_ERPM_HOLD_MS 50
-static uint16_t adv_kerpm_hold;
-static uint8_t adv_kerpm_hold_ms;
+/* Non-static so the SITL ZC_STATS port can observe engagement; see the
+ * declaration comment in runtime_loop.h. No other TU writes these. */
+uint16_t adv_kerpm_hold;
+uint8_t adv_kerpm_hold_ms;
 
 void runtimeUpdateVariablePwm(uint16_t *last_tim1_arr)
 {

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -170,6 +170,13 @@ void runtimeProcessDesyncCheck(void)
 				dcm_hold_value = duty_cycle_maximum;
 				dcm_hold_ms = DCM_HOLD_MS;
 			}
+			// k_erpm is about to collapse because the estimate died,
+			// not the rotor - keep the advance schedule on the last
+			// real speed for a bounded window.
+			if (k_erpm > 0) {
+				adv_kerpm_hold = k_erpm;
+				adv_kerpm_hold_ms = ADV_ERPM_HOLD_MS;
+			}
 			zero_crosses = 0;
 			desync_happened++;
 			// Same established-run gate as the stall rail (see


### PR DESCRIPTION
## Problem

The auto-advance curve is keyed on `k_erpm` (`dcc655`) because commutation lag is a function of speed. A desync destroys the rpm estimate in one main-loop pass while the rotor keeps turning at very nearly its previous speed, so the schedule drops straight to its bottom (level 13) at the moment the loop is re-acquiring against a fast-spinning rotor — under-advancing precisely where the true lag is highest.

## Change

Hold the last valid `k_erpm` for the schedule for 50 ms after a desync. Rotor speed in that window is bounded by prop inertia rather than by the ESC, so the held value is a better estimate of true speed than the collapsed reading it replaces. Cleared on the coast path, where a falling rpm is real.

`e_rpm` itself is untouched — it is the telemetry value (DroneCAN / KISS) and must keep reporting what the ESC measured. The BEMF-headroom governor also reads `e_rpm` but needs no equivalent: it disarms below `zero_crosses > 150` and is already inert throughout re-acquisition.

## 🛑 Not ready to merge — this change has never been exercised

**The consumer is gated on `auto_advance`; the arming is not.**

```c
if (eepromBuffer.auto_advance) {            // whole block
        if (adv_kerpm_hold_ms && adv_kerpm_hold > adv_kerpm) {
                adv_kerpm = adv_kerpm_hold; // the feature
        }
        auto_advance_level = map(adv_kerpm, ...);
}
```

and `bemf_zc.c:133` only reads `auto_advance_level` when that flag is set; otherwise `advance` comes from the fixed `temp_advance`.

`auto_advance` is **0** in the SITL seed eeprom (`DroneCAN.c` `default_settings[47]`) **and** in the 900KV `eeprom_900kv_10inch_best.bin` bench tune. So:

- **`test_advance_hold_engages_on_desync` passes on the arming only**, which is unconditional. Delete the consumer entirely and the test still passes. The mutation check I originally cited proves the arming exists, not the behaviour.
- **The [900KV HWCI retest](https://github.com/ARK-Electronics/ARK32/pull/63#issuecomment-5108471135) is inert for this PR.** It is a clean non-regression pass for `ark-release`+#61+#62 and worth having as that, but it contains no information about this change. Consistent with that, `bemf_timeout_samples` went 72 → 114 → 111 across #61/#62/#63: the dwell increase came from #62 and this PR added nothing.

No run to date has had both the feature present *and* the path enabled — the two runs that had `auto_advance 1` were against the no-op build.

**What it needs:** enable `auto_advance` in the test's eeprom, expose `auto_advance_level` over the ZC-stats port (v4), and assert it does **not** collapse toward 13 during the hold window while the rotor is still fast — with a consumer-deletion mutation that must fail. Bench-side, the 1800KV + HQProp 5136 stress tune (`auto_advance 1`) against `ark-release` on the same tune, n≥3 per arm.

## History — the first revision was a no-op

`810f081` declared the hold state, ticked it at 1 kHz, cleared it on the coast path and read it — but never **assigned** it, so `adv_kerpm_hold_ms` was permanently 0. Fixed in `5a06958`. #62 had the identical defect.

Both no-ops passed compilation (the statics are *read*, so no unused-variable diagnostic), cppcheck, the size gate, the full SITL suite, and complete HWCI hardware suites. Worth carrying forward as a review heuristic: on this codebase a green board is evidence of no regression and nothing else.

## Verification

**Static (on `da5aefe`)** — `size-check-ark` PASS 25976/27592 with #61+#62+#63 stacked; `cppcheck` clean; CI 8/8 green.

**SITL** — asserts arming only, see above. The v3 ZC-stats resolution (both #62's and this PR's hold pairs, append-only) is verified against all four existing readers.

**Hardware** — none valid. Earlier runs were against the no-op build; the recent one had the path disabled.

## Known gaps

- **The 50 ms window is a guess.** No reacq/relock metric exists in `hwci/hwci/metrics.py` to size it against.
- Rig noise floor on the 1800KV plant, measured from two identical (no-op) builds: 19% on `ttr_max`, 7–8% on bemf samples, 5% on max current. Any future A/B needs n≥3 per arm before a single-digit-percent delta means anything, and must compare against `ark-release`, not another PR.