### PR TITLE
perf(zc): commutate against the predicted interval, not the lagging average

### DIFF
--- a/Inc/bemf_zc.h
+++ b/Inc/bemf_zc.h
@@ -4,10 +4,30 @@
 #ifndef BEMF_ZC_H_
 #define BEMF_ZC_H_
 
+#include <stdint.h>
+
 void PeriodElapsedCallback(void);
 void interruptRoutine(void);
 void startMotor(void);
-/* Clear the acceleration trend used for the commutation point (bemf_zc.c). */
+/* Clear the acceleration trend used for the commutation point (bemf_zc.c).
+ * Call next to every zero_crosses = 0 so a desync/coast cannot leave a
+ * stale EMA that would bias the next closed-loop run once ZC_TREND_MIN_ZC
+ * re-arms. */
 void bemfZcResetTrend(void);
+/* SITL / debug snapshots of the predictor consumer path. */
+int32_t bemfZcGetTrend(void);
+uint32_t bemfZcGetPredicted(void);
+
+/* Saturating waitTime = interval/2 - advance (never underflows). Inline so
+ * PeriodElapsedCallback (RAM_FUNC) does not call out to flash for it. */
+static inline uint16_t bemfZcWaitTimeFromInterval(uint32_t interval, uint16_t advance_ticks)
+{
+	const uint32_t half = interval >> 1;
+	if (advance_ticks >= half) {
+		return 0;
+	}
+	const uint32_t wt = half - (uint32_t)advance_ticks;
+	return (wt > 65535u) ? 65535u : (uint16_t)wt;
+}
 
 #endif /* BEMF_ZC_H_ */

--- a/Inc/bemf_zc.h
+++ b/Inc/bemf_zc.h
@@ -7,5 +7,7 @@
 void PeriodElapsedCallback(void);
 void interruptRoutine(void);
 void startMotor(void);
+/* Clear the acceleration trend used for the commutation point (bemf_zc.c). */
+void bemfZcResetTrend(void);
 
 #endif /* BEMF_ZC_H_ */

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -28,16 +28,17 @@
   SITL -> client:
     u16 magic 0x5354, u8 version=1, u8 count, count * sample
     u16 magic 0x5355, u8 ok, u8 pad, message   (LOAD_MODEL reply)
-    u16 magic 0x5356, u8 version=3, u8 pad, u32 zero_crosses,
+    u16 magic 0x5356, u8 version=4, u8 pad, u32 zero_crosses,
       u32 commutation_interval, u32 dropped_edges, u32 desync_happened,
       u8 old_routine, u8 running, u8 armed, u8 zc_blind_steps,
       u8 zc_miss_bucket, u8 zc_deadline_armed,
       u8 dcm_hold_ms, u8 pad2, u16 dcm_hold_value,       (v2 PR 62)
-      u8 adv_kerpm_hold_ms, u8 pad3, u16 adv_kerpm_hold  (v3 PR 63)
+      u8 adv_kerpm_hold_ms, u8 pad3, u16 adv_kerpm_hold, (v3 PR 63)
+      i32 zc_trend, u32 zc_predicted, u16 waitTime, u16 advance (v4 PR 64)
       (ZC_STATS reply). Fields are only ever APPENDED and the version is
       bumped; clients that unpack a shorter prefix keep working unchanged
       (they length-check with >=), which is why v1 readers such as
-      test_blind_step.py and the v2 ceiling-hold test need no edit.
+      test_blind_step.py and the v2/v3 hold tests need no edit.
 */
 
 #include "sitl.h"
@@ -45,6 +46,7 @@
 #include "motor.h"
 #include "motor_runtime.h"
 #include "runtime_loop.h"
+#include "bemf_zc.h"
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -240,9 +242,14 @@ void sitl_state_poll(void)
 			uint8_t adv_kerpm_hold_ms;
 			uint8_t pad3;
 			uint16_t adv_kerpm_hold;
+			/* v4: accel-predictor consumer path (PR #64). */
+			int32_t zc_trend;
+			uint32_t zc_predicted;
+			uint16_t wait_time;
+			uint16_t advance_val;
 		} reply = {
 			.magic = 0x5356,
-			.version = 3,
+			.version = 4,
 			.zero_crosses = zero_crosses,
 			.commutation_interval = commutation_interval,
 			.dropped_edges = motor_zc_dropped(),
@@ -257,6 +264,10 @@ void sitl_state_poll(void)
 			.dcm_hold_value = dcm_hold_value,
 			.adv_kerpm_hold_ms = adv_kerpm_hold_ms,
 			.adv_kerpm_hold = adv_kerpm_hold,
+			.zc_trend = bemfZcGetTrend(),
+			.zc_predicted = bemfZcGetPredicted(),
+			.wait_time = waitTime,
+			.advance_val = advance,
 		};
 		sendto(fd, &reply, sizeof(reply), 0, (struct sockaddr *)&src, sizeof(src));
 	}

--- a/Mcu/SITL/tests/test_accel_predictor.py
+++ b/Mcu/SITL/tests/test_accel_predictor.py
@@ -1,0 +1,211 @@
+'''Accel-predictor consumer path engagement (PR #64).
+
+commutation_interval is a lag filter; advance/waitTime are derived from a
+one-step prediction (CI + clamp(zc_trend)) so the commutation point does not
+trail under constant angular acceleration.
+
+WHY THIS TEST EXISTS: the first class of "looks wired, does nothing" bugs on
+this fork (#63 hold never assigned; auto_advance schedule never consumed)
+pass the full SITL suite because a no-op cannot regress anything. This asserts
+ENGAGEMENT of the consumer path:
+
+  1. zc_trend moves during spool (EMA of interval steps is live)
+  2. once zero_crosses >= 20, zc_predicted == CI + clamp(zc_trend, +-CI/2)
+  3. waitTime == sat(predicted/2 - advance) using the *exported* predicted
+     and advance — if advance/waitTime still key on lagging CI while predicted
+     is only computed for show, this equality fails when predicted != CI
+  4. after an injected desync that zeros zero_crosses, zc_trend is cleared
+     (stale-trend hygiene next to every zero_crosses = 0)
+
+Remove the predicted assignment into advance/waitTime, or drop bemfZcResetTrend
+on the desync path, and this test must fail.
+'''
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import time
+
+import sitl_dshot as sd
+from sitl_harness import SITL_DIR, Sender, rpm_from_state, wait_for_state
+
+STATE_MAGIC_CMD = 0x5353
+ZC_STATS_MAGIC = 0x5356
+MODELS = os.path.join(SITL_DIR, 'models')
+ZC_TREND_MIN_ZC = 20
+
+# v4 payload: v3 + accel-predictor consumer fields.
+STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
+                'desync_happened', 'old_routine', 'running', 'armed',
+                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'dcm_hold_ms', '_pad2', 'dcm_hold_value',
+                'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold',
+                'zc_trend', 'zc_predicted', 'wait_time', 'advance')
+# v3 ends ...HBBH; v4 appends iIHH (trend, predicted, waitTime, advance).
+STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHH'
+
+
+def _open_ctl(sitl):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(('127.0.0.1', sitl.state_port))
+    s.settimeout(0.5)
+    return s
+
+
+def _zc_stats(ctl, retries=5):
+    for _ in range(retries):
+        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 4, 0))
+        try:
+            pkt = ctl.recv(64)
+        except socket.timeout:
+            continue
+        if len(pkt) >= struct.calcsize(STATS_FMT):
+            vals = struct.unpack_from(STATS_FMT, pkt)
+            if vals[0] == ZC_STATS_MAGIC:
+                assert vals[1] >= 4, (
+                    'ZC_STATS version %d lacks accel-predictor fields' % vals[1])
+                return dict(zip(STATS_FIELDS, vals[3:]))
+    raise AssertionError('no v4 ZC_STATS reply from SITL state port')
+
+
+def _zc_fault(ctl, mode, duration_us):
+    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 3, mode, duration_us))
+
+
+def _clamp_corr(trend: int, ci: int) -> int:
+    limit = ci >> 1
+    if trend > limit:
+        return limit
+    if trend < -limit:
+        return -limit
+    return trend
+
+
+def _expected_wait(predicted: int, advance: int) -> int:
+    half = predicted >> 1
+    if advance >= half:
+        return 0
+    wt = half - advance
+    return 65535 if wt > 65535 else wt
+
+
+def test_accel_predictor_consumer_path(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    # Unloaded: long, clean acceleration window under CI load.
+    sim.load_model(os.path.join(MODELS, 'unloaded.json'))
+    time.sleep(1.0)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    ctl = _open_ctl(sitl)
+    try:
+        time.sleep(2.2)
+        tx.value = 2000  # full stick — sustained accel for the EMA
+
+        deadline = time.time() + 12.0
+        saw_trend = False
+        saw_applied = False
+        samples_checked = 0
+        last = None
+
+        while time.time() < deadline:
+            s = _zc_stats(ctl)
+            last = s
+            if not (s['running'] and not s['old_routine']):
+                time.sleep(0.02)
+                continue
+
+            if s['zc_trend'] != 0:
+                saw_trend = True
+
+            if s['zero_crosses'] >= ZC_TREND_MIN_ZC:
+                ci = int(s['commutation_interval'])
+                trend = int(s['zc_trend'])
+                predicted = int(s['zc_predicted'])
+                advance = int(s['advance'])
+                wait_time = int(s['wait_time'])
+
+                expect_pred = (ci + _clamp_corr(trend, ci)) & 0xFFFFFFFF
+                assert predicted == expect_pred, (
+                    'zc_predicted is not CI + clamp(zc_trend): '
+                    'ci=%d trend=%d predicted=%d expect=%d\n%s' % (
+                        ci, trend, predicted, expect_pred, sitl.log_tail()))
+
+                expect_wt = _expected_wait(predicted, advance)
+                assert wait_time == expect_wt, (
+                    'waitTime is not sat(predicted/2 - advance) — the consumer '
+                    'path is not using the predicted interval for the '
+                    'commutation point. predicted=%d advance=%d wait=%d '
+                    'expect=%d ci=%d\n%s' % (
+                        predicted, advance, wait_time, expect_wt, ci,
+                        sitl.log_tail()))
+
+                samples_checked += 1
+                if predicted != ci:
+                    saw_applied = True
+
+                # Enough consistent samples and a real correction once.
+                if samples_checked >= 8 and saw_applied and saw_trend:
+                    break
+
+            time.sleep(0.01)
+
+        assert saw_trend, (
+            'zc_trend never moved during spool — the EMA is not live '
+            '(or closed loop never ran). last=%r\n%s' % (last, sitl.log_tail()))
+        assert samples_checked >= 8, (
+            'never collected enough closed-loop samples with '
+            'zero_crosses >= %d to validate the consumer path (got %d). '
+            'last=%r\n%s' % (ZC_TREND_MIN_ZC, samples_checked, last,
+                             sitl.log_tail()))
+        assert saw_applied, (
+            'zc_predicted never diverged from commutation_interval while '
+            'armed — the correction is computed but may not be applied, or '
+            'the spool never produced a usable trend. last=%r\n%s' % (
+                last, sitl.log_tail()))
+
+        # --- stale-trend hygiene on desync ---
+        # Need a nonzero trend, then inject a desync and require that the
+        # zero_crosses=0 path also clears zc_trend.
+        pre = _zc_stats(ctl)
+        assert pre['running'] and pre['zero_crosses'] > 50, (
+            'lost closed loop before desync hygiene check: %r\n%s' % (
+                pre, sitl.log_tail()))
+
+        # If trend already settled to 0 at steady speed, kick throttle
+        # briefly or just accept a fault that still zeros crosses + trend.
+        ci_us = max(int(pre['commutation_interval']) // 2, 100)
+        cleared = False
+        for _ in range(8):
+            _zc_fault(ctl, mode=1, duration_us=80 * ci_us)
+            probe_end = time.time() + 0.4
+            while time.time() < probe_end:
+                s = _zc_stats(ctl)
+                if s['zero_crosses'] == 0 and s['zc_trend'] == 0:
+                    cleared = True
+                    break
+                # After a desync, zero_crosses may bounce back quickly; require
+                # that whenever crosses are still low the trend is not a large
+                # leftover from the prior run.
+                if (s['desync_happened'] > pre['desync_happened'] and
+                        s['zero_crosses'] < ZC_TREND_MIN_ZC and
+                        s['zc_trend'] == 0):
+                    cleared = True
+                    break
+            if cleared:
+                break
+
+        assert cleared, (
+            'after desync, zc_trend was not cleared with zero_crosses. '
+            'bemfZcResetTrend must sit next to every zero_crosses = 0 '
+            '(runtime desync path is the usual miss). last=%r pre=%r\n%s' % (
+                _zc_stats(ctl), pre, sitl.log_tail()))
+    finally:
+        tx.value = 0
+        time.sleep(0.3)
+        _zc_fault(ctl, mode=0, duration_us=0)
+        tx.stop()
+        ctl.close()

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -94,6 +94,18 @@
  */
 #define ZC_TREND_MIN_ZC 20
 static int32_t zc_trend;
+/* Last predicted interval used for advance/waitTime (observability + SITL). */
+static uint32_t zc_predicted;
+
+int32_t bemfZcGetTrend(void)
+{
+	return zc_trend;
+}
+
+uint32_t bemfZcGetPredicted(void)
+{
+	return zc_predicted;
+}
 
 RAM_FUNC void PeriodElapsedCallback()
 {
@@ -180,12 +192,15 @@ RAM_FUNC void PeriodElapsedCallback()
 		}
 		predicted = (uint32_t)((int32_t)commutation_interval + corr);
 	}
+	zc_predicted = predicted;
 	if (!eepromBuffer.auto_advance) {
 		advance = (predicted * temp_advance) >> 6; // 60 divde 64 0.9375 degree increments
 	} else {
 		advance = (predicted * auto_advance_level) >> 6; // 60 divde 64 0.9375 degree increments
 	}
-	waitTime = (predicted >> 1) - advance;
+	/* Saturate: predicted can be as low as CI/2 under max negative
+	 * correction, so (predicted/2 - advance) must not wrap uint16. */
+	waitTime = bemfZcWaitTimeFromInterval(predicted, advance);
 	if (!old_routine) {
 		enableCompInterrupts(); // enable comp interrupt
 		if (zero_crosses >= ZC_DEADLINE_MIN_ZC) {
@@ -391,6 +406,7 @@ RAM_FUNC void interruptRoutine()
 void bemfZcResetTrend(void)
 {
 	zc_trend = 0;
+	zc_predicted = 0;
 }
 
 void startMotor()
@@ -401,7 +417,7 @@ void startMotor()
 		zc_blind_steps = 0;
 		zc_miss_bucket = 0;
 		zc_blind_window_count = 0;
-		zc_trend = 0; // no interval history across a stop
+		bemfZcResetTrend(); // no interval history across a stop
 		zc_pre_seen = 1;
 		zc_demag_run = 0;
 		commutate();

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -62,6 +62,39 @@
  */
 #define ZC_DEADLINE_MIN_ZC 100
 
+/*
+ * Acceleration-aware commutation point.
+ *
+ * commutation_interval is a two-pole lag over the last two measured
+ * intervals: the pair is averaged, then blended 50/50 with the previous
+ * estimate. Under constant angular acceleration a lag filter has constant
+ * error, so the estimate trails the true interval by an amount proportional
+ * to the acceleration - and waitTime = CI/2 - advance is computed from that
+ * trailing value, which puts the commutation systematically late through
+ * every spool-up. Late drive raises current, and more current lengthens
+ * demag, which is the same spiral the demag-late detector exists to break
+ * (see interruptRoutine).
+ *
+ * Track the per-interval trend and commutate against the interval the loop
+ * is about to see rather than the one it just averaged. zc_trend is an EMA
+ * (tau = 4 intervals) of thiszctime - lastzctime, so a steady acceleration
+ * produces a steady correction while single-interval jitter is smoothed.
+ *
+ * commutation_interval itself is deliberately NOT changed: it feeds the
+ * stall threshold, the ZC filter schedule, variable PWM, the DShot priority
+ * flip and telemetry, none of which want a predicted value. Only the
+ * advance/waitTime pair moves onto the prediction.
+ *
+ * Bounds: the correction is clamped to +-50% of the current estimate, so a
+ * corrupted trend can never move the commutation point further than a
+ * single missed crossing already does.
+ *
+ * Blind steps do not feed the trend - thiszctime is the deadline's inflated
+ * 1.5x value there, not a measurement.
+ */
+#define ZC_TREND_MIN_ZC 20
+static int32_t zc_trend;
+
 RAM_FUNC void PeriodElapsedCallback()
 {
 	uint8_t blind = 0;
@@ -130,12 +163,29 @@ RAM_FUNC void PeriodElapsedCallback()
 	}
 	commutate();
 	commutation_interval = ((commutation_interval) + ((lastzctime + thiszctime) >> 1)) >> 1;
-	if (!eepromBuffer.auto_advance) {
-		advance = (commutation_interval * temp_advance) >> 6; // 60 divde 64 0.9375 degree increments
-	} else {
-		advance = (commutation_interval * auto_advance_level) >> 6; // 60 divde 64 0.9375 degree increments
+	/* See zc_trend: predict the interval about to be timed, not the lagging
+	 * average of the ones already measured. */
+	uint32_t predicted = commutation_interval;
+	if (!blind) {
+		const int32_t step = (int32_t)thiszctime - (int32_t)lastzctime;
+		zc_trend += (step - zc_trend) >> 2;
 	}
-	waitTime = (commutation_interval >> 1) - advance;
+	if (zero_crosses >= ZC_TREND_MIN_ZC) {
+		const int32_t limit = (int32_t)(commutation_interval >> 1);
+		int32_t corr = zc_trend;
+		if (corr > limit) {
+			corr = limit;
+		} else if (corr < -limit) {
+			corr = -limit;
+		}
+		predicted = (uint32_t)((int32_t)commutation_interval + corr);
+	}
+	if (!eepromBuffer.auto_advance) {
+		advance = (predicted * temp_advance) >> 6; // 60 divde 64 0.9375 degree increments
+	} else {
+		advance = (predicted * auto_advance_level) >> 6; // 60 divde 64 0.9375 degree increments
+	}
+	waitTime = (predicted >> 1) - advance;
 	if (!old_routine) {
 		enableCompInterrupts(); // enable comp interrupt
 		if (zero_crosses >= ZC_DEADLINE_MIN_ZC) {
@@ -338,6 +388,11 @@ RAM_FUNC void interruptRoutine()
 	HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase
 }
 
+void bemfZcResetTrend(void)
+{
+	zc_trend = 0;
+}
+
 void startMotor()
 {
 	if (running == 0) {
@@ -346,6 +401,7 @@ void startMotor()
 		zc_blind_steps = 0;
 		zc_miss_bucket = 0;
 		zc_blind_window_count = 0;
+		zc_trend = 0; // no interval history across a stop
 		zc_pre_seen = 1;
 		zc_demag_run = 0;
 		commutate();

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -156,7 +156,7 @@ void zcfoundroutine()
 	SET_INTERVAL_TIMER_COUNT(0);
 	commutation_interval = (thiszctime + (3 * commutation_interval)) / 4;
 	advance = (temp_advance * commutation_interval) >> 6; //   7.5 degree increments
-	waitTime = commutation_interval / 2 - advance;
+	waitTime = bemfZcWaitTimeFromInterval(commutation_interval, advance);
 	while ((INTERVAL_TIMER_COUNT) < (waitTime)) {
 		if (zero_crosses < 5) {
 			break;

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -4,6 +4,7 @@
 
 #include "commutation.h"
 #include "motor_runtime.h"
+#include "bemf_zc.h"
 #include "main.h"
 #include "common.h"
 #include "comparator.h"
@@ -209,6 +210,9 @@ void zcfoundroutine()
 		zc_deadline_armed = 0;
 		zc_blind_steps = 0;
 		zc_miss_bucket = 0;
+		// Fresh closed loop: the interval trend from a previous run (or
+		// from the poll ramp) is not a measurement of this one.
+		bemfZcResetTrend();
 		// Seed the pre-level flag: the main-loop sampler only runs in
 		// interrupt mode, so the first closed-loop window has no dwell
 		// history yet and must not read as demag-late.

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -130,6 +130,7 @@ void setInput()
 						    escInSineStart()) {
 							forward = 1 - eepromBuffer.dir_reversed;
 							zero_crosses = 0;
+							bemfZcResetTrend();
 							old_routine = 1;
 							maskPhaseInterrupts();
 							brushed_direction_set = 0;
@@ -144,6 +145,7 @@ void setInput()
 						if (((commutation_interval > reverse_speed_threshold) && (duty_cycle < 200)) ||
 						    escInSineStart()) {
 							zero_crosses = 0;
+							bemfZcResetTrend();
 							old_routine = 1;
 							forward = eepromBuffer.dir_reversed;
 							maskPhaseInterrupts();
@@ -207,6 +209,7 @@ void setInput()
 						    escInSineStart()) {
 							forward = 1 - eepromBuffer.dir_reversed;
 							zero_crosses = 0;
+							bemfZcResetTrend();
 							old_routine = 1;
 							maskPhaseInterrupts();
 							brushed_direction_set = 0;
@@ -221,6 +224,7 @@ void setInput()
 						if (((commutation_interval > reverse_speed_threshold) && (duty_cycle < 200)) ||
 						    escInSineStart()) {
 							zero_crosses = 0;
+							bemfZcResetTrend();
 							old_routine = 1;
 							forward = eepromBuffer.dir_reversed;
 							maskPhaseInterrupts();
@@ -362,6 +366,7 @@ void setInput()
 				if (!escIsDriving()) {
 					old_routine = 1;
 					zero_crosses = 0;
+					bemfZcResetTrend();
 					if (eepromBuffer.brake_on_stop) {
 						fullBrake();
 					} else {
@@ -392,6 +397,7 @@ void setInput()
 				if (!escIsDriving()) {
 					old_routine = 1;
 					zero_crosses = 0;
+					bemfZcResetTrend();
 					bad_count = 0;
 					if (eepromBuffer.brake_on_stop > 0) {
 						if (!eepromBuffer.use_sine_start) {

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -14,6 +14,7 @@
 #include "eeprom.h"
 #include "signal.h"
 #include "commutation.h"
+#include "bemf_zc.h"
 #include "targets.h"
 #include "esc_state.h"
 #include "IO.h"
@@ -405,11 +406,13 @@ void faultHandleBemfIntervalStall(void)
 		if (escIsFault()) {
 			/* Episode rail latched: do not re-enter startup. */
 			zero_crosses = 0;
+			bemfZcResetTrend();
 			running = 0;
 			return;
 		}
 		escNoteStallOrDesync(1);
 		zero_crosses = 0;
+		bemfZcResetTrend();
 		if (faultDesyncRestartHoldoffActive()) {
 			/* Coast until holdoff expires; main loop will re-arm. */
 			running = 0;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -11,6 +11,7 @@
 #include "esc_state.h"
 #include "control_loop.h"
 #include "commutation.h"
+#include "bemf_zc.h"
 #include "functions.h"
 #include "peripherals.h"
 #include "phaseouts.h"
@@ -180,6 +181,7 @@ void runtimeProcessDesyncCheck(void)
 				adv_kerpm_hold_ms = ADV_ERPM_HOLD_MS;
 			}
 			zero_crosses = 0;
+			bemfZcResetTrend();
 			desync_happened++;
 			// Same established-run gate as the stall rail (see
 			// faultHandleBemfIntervalStall): interval jumps while the


### PR DESCRIPTION
## Problem

```c
commutation_interval = ((commutation_interval) + ((lastzctime + thiszctime) >> 1)) >> 1;
```

That is a two-pole lag over the last two measured intervals — the pair is averaged, then blended 50/50 with the previous estimate. A lag filter has *constant error under constant input slope*, so the estimate trails the true interval in proportion to angular acceleration, and `waitTime = CI/2 - advance` is computed from that trailing value.

The commutation therefore runs systematically late through every spool-up. Late drive raises current, and more current lengthens demag — the same spiral the demag-late detector exists to break.

## Change

Track the per-interval trend (EMA of `thiszctime - lastzctime`, τ = 4 intervals) and derive `advance`/`waitTime` from the interval the loop is about to see rather than the one it just averaged.

Bounds and scope:

- **`commutation_interval` is unchanged.** It feeds the stall threshold, the ZC filter schedule, variable PWM, the DShot priority flip and telemetry, none of which want a predicted value. Only the `advance`/`waitTime` pair moves onto the prediction.
- The correction is clamped to ±50% of the current estimate, so a corrupted trend cannot move the commutation point further than a single missed crossing already does.
- Blind steps do not feed the trend — `thiszctime` is the deadline's inflated 1.5× value there, not a measurement.
- Armed only from `zero_crosses >= 20`; cleared on stop and on entry to a fresh closed loop.
- The blind-step deadline expression is untouched, so a smaller `waitTime` lengthens the grace slightly — the conservative direction.

## Cost

+104 B flash (93.66% of the F051 budget, gate still passes), +72 B RAM, and roughly ten extra instructions in `PeriodElapsedCallback`. This is the most expensive of the six; on a 93%-full F051 that is worth weighing against the measured benefit.

## Measured

SITL, unloaded model, full throttle, 3 runs each. Metric is the 7k → 13.3k rpm acceleration window (absolute start times vary with start latency, so the window width is the robust figure):

| | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| base | 0.420 | 0.471 | 0.438 | 0.443 s |
| this | 0.409 | 0.408 | 0.432 | 0.416 s |

~6%, consistent in direction but small. The unloaded model is the only one stable enough in SITL to measure this way, and it is also the least favourable case — its inertia is low so the acceleration phase is brief and the lag correction is correspondingly small.

## Needs bench

The heavy props where sustained acceleration makes the lag largest are exactly the ones that are unstable in SITL. Treat the number above as directional only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smx8ZnWjz18sMzFU7j4iVq)_