### PR TITLE
perf(zc): bound the interval inflation an isolated blind step injects

### DIFF
--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -103,12 +103,45 @@ RAM_FUNC void PeriodElapsedCallback()
 			zc_blind_window_count++; // grind-rate window (faults.c, 1 kHz)
 		}
 		HWCI_PERF_BLIND_STEP();
-		// Take the full elapsed time as the (late) crossing measurement
-		// and commutate now. The inflated interval feeds the average so
+		// Take the elapsed time as the (late) crossing measurement and
+		// commutate now. The inflated interval feeds the average so
 		// timing hunts slower - the safe direction for a decelerating
 		// rotor - and the next accepted crossing resyncs immediately.
+		//
+		// The deadline fires at ~1.5x the believed interval by
+		// construction, so taking the raw elapsed value injects a fixed
+		// +50% sample and inflates the running average ~12.5% on EVERY
+		// miss, regardless of how well the loop was tracking. That is
+		// the right reflex when position is genuinely unknown, but it
+		// also means an isolated dropout in an otherwise healthy loop
+		// costs the same timing excursion as a real deceleration, and
+		// the loop then has to hunt back down.
+		//
+		// Cap the injected inflation at +25% of the current estimate,
+		// halving the excursion an isolated miss costs to ~6.25% of the
+		// average.
+		//
+		// This is a deliberate REDUCTION of a safety margin, not a free
+		// win. A miss still moves the average toward longer intervals,
+		// never shorter, so the sign of the reflex is unchanged - but
+		// the margin against a rotor genuinely decelerating faster than
+		// the estimate tracks is now half what it was, and recovery
+		// from such a deceleration takes more crossings. The trade is
+		// worth making only if the common case (isolated dropout in an
+		// otherwise healthy loop) dominates the rare one on real
+		// hardware, which is a bench question, not a code one.
+		//
+		// The consecutive-miss and miss-rate rails are unchanged: they
+		// count events, not interval growth, so bounding the inflation
+		// does not slow the handoff to the stall rail. A sustained
+		// deceleration that really is outrunning the estimate still
+		// reaches the same place, just over more crossings.
 		maskPhaseInterrupts();
 		uint32_t elapsed = INTERVAL_TIMER_COUNT;
+		const uint32_t elapsed_cap = commutation_interval + (commutation_interval >> 2);
+		if (elapsed > elapsed_cap) {
+			elapsed = elapsed_cap;
+		}
 		if (elapsed > 65535u) {
 			elapsed = 65535u;
 		}


### PR DESCRIPTION
## Problem

The blind-step deadline fires at ~1.5× the believed interval by construction, so recording the raw elapsed value injects a fixed +50% sample and inflates the running average ~12.5% on **every** miss — regardless of how well the loop was tracking.

That is the right reflex when position is genuinely unknown. But it also means an isolated dropout in an otherwise healthy loop costs the same timing excursion as a real deceleration, and the loop then has to hunt back down.

## Change

Cap the recorded interval at +25% of the current estimate, halving the excursion an isolated miss costs to ~6.25%.

## This is a safety-margin reduction

Stating it plainly rather than framing it as a free win. The sign of the reflex is unchanged — a miss still moves the average toward longer intervals, never shorter — but the margin against a rotor decelerating faster than the estimate tracks is now half what it was, and recovering from such a deceleration takes more crossings.

The consecutive-miss and miss-rate rails are unaffected: they count events rather than interval growth, so the handoff to the stall rail happens at the same point.

## Evidence status — weakest of the set, merge last

- No SITL case exercises isolated blind steps in an otherwise healthy loop. In the runs that motivated this work blind stepping never armed at all, because `zero_crosses` stayed under its 100 gate. The suite therefore shows nothing either way beyond "no regression".
- The argument for the trade is that the common case (isolated dropout) dominates the rare one (genuine fast deceleration) on real hardware. That is a bench question, not a code one.
- It composes with #64, which supplies the acceleration term that would let the cap key off a *predicted* interval rather than the lagging average. Merging that first would make this strictly better founded.

I would not merge this one on the strength of the reasoning alone.

## Verification

- `make size-check-ark`: PASS, 25808/27592 (+16 B vs base)
- `make cppcheck`: PASS, no error/warning
- SITL safety+models subset, 3 runs: 1/0/3 failures against a baseline of 1/3/1 — no signal either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smx8ZnWjz18sMzFU7j4iVq)_