### PR TITLE
ci: publish release and nightly hex assets for the ARK32 configurator

### DIFF
--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -3,6 +3,10 @@ name: CI Build Linux
 # Build all MCU targets and publish .hex assets for the ARK32 configurator
 # and production line (see ARK-Electronics/ARK32#67).
 #
+# Ubuntu-only: release assets and size-gated firmware builds are produced with
+# the Linux xPack toolchain. (Windows host cross-builds currently overflow F051
+# FLASH; native SITL on Windows is covered by the SITL workflow.)
+#
 # - Push/PR on ark-release: build + artifact.
 # - Version tags (vMAJOR.MINOR[-suffix]): GitHub Release with obj/*.hex.
 # - schedule / optional dispatch: rolling `nightly` prerelease (assets replaced).
@@ -31,11 +35,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -43,23 +43,13 @@ jobs:
           submodules: "recursive"
 
       - name: Build CI
-        shell: bash
         run: |
           # Installs + verifies the xPack GCC 15 pin from make/tools.mk.
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            make arm_sdk_install
-            make arm_sdk_check
-            make -j8
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            make arm_sdk_install
-            # Windows make.exe uses cmd; still verify via bash on the runner.
-            bash scripts/check-arm-sdk.sh tools/windows/xpack-arm-none-eabi-gcc-15.2.1-1.1/bin/arm-none-eabi- 15.2.1-1.1
-            tools/windows/make/bin/make
-          fi
+          make arm_sdk_install
+          make arm_sdk_check
+          make -j8
 
       - name: Assert hex naming convention
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -119,7 +109,7 @@ jobs:
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
-          name: AM32-binaries-${{ matrix.os }}
+          name: AM32-binaries
           path: |
             obj/*.hex
           retention-days: 60
@@ -127,7 +117,6 @@ jobs:
 
       - name: Upload version-tag release assets
         if: >
-          matrix.os == 'ubuntu-latest' &&
           github.event_name != 'pull_request' &&
           startsWith(github.ref, 'refs/tags/v') &&
           github.repository == 'ARK-Electronics/ARK32'
@@ -141,7 +130,6 @@ jobs:
 
       - name: Drop previous rolling nightly (if any)
         if: >
-          matrix.os == 'ubuntu-latest' &&
           github.repository == 'ARK-Electronics/ARK32' &&
           (
             github.event_name == 'schedule' ||
@@ -155,7 +143,6 @@ jobs:
 
       - name: Publish rolling nightly prerelease
         if: >
-          matrix.os == 'ubuntu-latest' &&
           github.repository == 'ARK-Electronics/ARK32' &&
           (
             github.event_name == 'schedule' ||

--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -3,18 +3,18 @@ name: CI Build Linux
 # Build all MCU targets and publish .hex assets for the ARK32 configurator
 # and production line (see ARK-Electronics/ARK32#67).
 #
-# - Push/PR on ark-release (and main for compatibility): build + artifact.
+# - Push/PR on ark-release: build + artifact.
 # - Version tags (vMAJOR.MINOR[-suffix]): GitHub Release with obj/*.hex.
 # - schedule / optional dispatch: rolling `nightly` prerelease (assets replaced).
 
 on:
   push:
-    branches: ["main", "ark-release"]
+    branches: ["ark-release"]
     tags:
       # Matches v3.0, v3.0-ark, v3.0-ark-rc1, etc. (glob, not full regex).
       - "v[0-9]*.[0-9]*"
   pull_request:
-    branches: ["main", "ark-release"]
+    branches: ["ark-release"]
   schedule:
     # Rolling nightly at 06:00 UTC on the default branch (ark-release).
     - cron: "0 6 * * *"

--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -1,22 +1,33 @@
 name: CI Build Linux
 
-on: 
+# Build all MCU targets and publish .hex assets for the ARK32 configurator
+# and production line (see ARK-Electronics/ARK32#67).
+#
+# - Push/PR on ark-release (and main for compatibility): build + artifact.
+# - Version tags (vMAJOR.MINOR[-suffix]): GitHub Release with obj/*.hex.
+# - schedule / optional dispatch: rolling `nightly` prerelease (assets replaced).
+
+on:
   push:
-    branches: ["main"]
+    branches: ["main", "ark-release"]
     tags:
-      - 'v[0-9]+.[0-9]+'
+      # Matches v3.0, v3.0-ark, v3.0-ark-rc1, etc. (glob, not full regex).
+      - "v[0-9]*.[0-9]*"
   pull_request:
-    branches: ["main"]
+    branches: ["main", "ark-release"]
+  schedule:
+    # Rolling nightly at 06:00 UTC on the default branch (ark-release).
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
-      file_type:
-        description: 'File type to upload (hex or elf)'
-        required: true
-        default: 'hex'
-        type: choice
-        options:
-          - hex
-          - elf
+      publish_nightly:
+        description: "Publish assets to the rolling nightly prerelease"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -25,10 +36,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Build CI
         shell: bash
@@ -45,6 +57,65 @@ jobs:
             tools/windows/make/bin/make
           fi
 
+      - name: Assert hex naming convention
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          hexes=(obj/*.hex)
+          if [ "${#hexes[@]}" -eq 0 ]; then
+            echo "error: no obj/*.hex produced by the build" >&2
+            exit 1
+          fi
+
+          # Configurator resolves:
+          #   AM32_${escInfo.meta.am32.fileName}_${tagWithoutV_and_rc}.hex
+          # so every artifact must stay AM32_<target>_<version>.hex.
+          bad=0
+          for f in "${hexes[@]}"; do
+            base=$(basename "$f")
+            case "$base" in
+              AM32_*_*.hex)
+                # Reject empty target/version segments (AM32__.hex, AM32_x_.hex).
+                if [[ ! "$base" =~ ^AM32_[A-Za-z0-9][A-Za-z0-9_]*_[0-9]+\.[0-9]+(-[A-Za-z0-9._-]+)?\.hex$ ]]; then
+                  echo "error: hex name does not match AM32_<target>_<MAJOR.MINOR[-tag]>.hex: $base" >&2
+                  bad=1
+                else
+                  echo "ok: $base"
+                fi
+                ;;
+              *)
+                echo "error: hex name does not match AM32_<target>_<version>.hex: $base" >&2
+                bad=1
+                ;;
+            esac
+          done
+
+          # On version tags, filename version must match the tag (configurator
+          # strips a leading 'v' and optional -rcN before lookup).
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            tag_ver="${GITHUB_REF_NAME#v}"
+            # shellcheck disable=SC2001
+            expect_ver=$(printf '%s' "$tag_ver" | sed -E 's/-rc[0-9]+//Ig')
+            echo "tag=${GITHUB_REF_NAME} expect_version_suffix=${expect_ver}"
+            for f in "${hexes[@]}"; do
+              base=$(basename "$f")
+              case "$base" in
+                AM32_*_"${expect_ver}".hex) ;;
+                *)
+                  echo "error: $base is not AM32_<target>_${expect_ver}.hex (tag ${GITHUB_REF_NAME})" >&2
+                  bad=1
+                  ;;
+              esac
+            done
+          fi
+
+          if [ "$bad" -ne 0 ]; then
+            exit 1
+          fi
+          echo "Asserted ${#hexes[@]} hex asset(s)"
+
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
@@ -52,19 +123,60 @@ jobs:
           path: |
             obj/*.hex
           retention-days: 60
+          if-no-files-found: error
 
-      - name: Find and store hex files
-        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
-        run: |
-          hex_files=$(find obj -type f -name "*.${{ inputs.include_hex }}" | tr '\n' ',' | sed 's/,$//')
-          echo "Found hex files: $hex_files"
-          echo "HEX_FILES=$hex_files" >> $GITHUB_ENV
-
-      - name: Upload release assets
-        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
+      - name: Upload version-tag release assets
+        if: >
+          matrix.os == 'ubuntu-latest' &&
+          github.event_name != 'pull_request' &&
+          startsWith(github.ref, 'refs/tags/v') &&
+          github.repository == 'ARK-Electronics/ARK32'
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.HEX_FILES }}
+          files: obj/*.hex
+          fail_on_unmatched_files: true
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              
+
+      - name: Drop previous rolling nightly (if any)
+        if: >
+          matrix.os == 'ubuntu-latest' &&
+          github.repository == 'ARK-Electronics/ARK32' &&
+          (
+            github.event_name == 'schedule' ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish_nightly)
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Rolling prerelease: replace assets and retarget the tag each run.
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+
+      - name: Publish rolling nightly prerelease
+        if: >
+          matrix.os == 'ubuntu-latest' &&
+          github.repository == 'ARK-Electronics/ARK32' &&
+          (
+            github.event_name == 'schedule' ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish_nightly)
+          )
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: Nightly
+          prerelease: true
+          make_latest: false
+          target_commitish: ${{ github.sha }}
+          files: obj/*.hex
+          fail_on_unmatched_files: true
+          body: |
+            Rolling nightly firmware build for the ARK32 configurator and production line.
+
+            - Commit: `${{ github.sha }}`
+            - Ref: `${{ github.ref }}`
+            - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Assets are replaced on each successful nightly run. Prefer version tags (`v*`) for production flashes.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Implements #67 so ARK32 firmware `.hex` files are published as GitHub Release assets the configurator and production line can consume.

### What was broken
- Workflow only triggered on `main`; default branch is `ark-release`
- Tag filter missed `-ark` (and similar) suffixes
- Asset step used `inputs.include_hex` (wrong/empty) → empty release
- Nightlies were Actions artifacts only (auth, zip, 60-day expiry)

### What this does
- **Triggers:** push/PR on `ark-release` and `main`; version tags `v[0-9]*.[0-9]*`; daily cron; optional `workflow_dispatch` with `publish_nightly`
- **Version tags:** `softprops/action-gh-release` attaches `obj/*.hex` with `fail_on_unmatched_files`
- **Naming assert (ubuntu):** every hex matches `AM32_<target>_<MAJOR.MINOR[-tag]>.hex`; on tags the version must match the tag (leading `v` stripped, optional `-rcN` stripped like the configurator)
- **Nightly:** rolling prerelease tag `nightly` (delete+recreate each run, assets replaced, body includes commit SHA)
- **Guardrails:** release/nightly publish only on `ARK-Electronics/ARK32`, ubuntu matrix, non-PR events

## Test plan
- [ ] PR CI Build Linux runs on this branch (ubuntu + windows)
- [ ] After merge: confirm a push to `ark-release` builds and uploads artifacts
- [ ] Manual: `workflow_dispatch` with **publish_nightly=true** → Releases shows prerelease `nightly` with hex assets
- [ ] Manual: tag `v3.0-ark` (when version.h is 3.0-ark) → release assets include `AM32_ARK_4IN1_F051_3.0-ark.hex`
- [ ] Confirm configurator can list/fetch nightly or tagged assets (proxy path)

Closes #67