### PR TITLE
DroneCAN: force the input filter to zero on RawCommand timeout

### DIFF
--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -1211,9 +1211,20 @@ void DroneCAN_update()
 
 	if (canstats.last_raw_command_us != 0 && ts - canstats.last_raw_command_us > 250000ULL) {
 		/*
-          we have stopped getting CAN RawCommand, zero input
+          we have stopped getting CAN RawCommand, zero input.
+
+          The input filter has to be forced to zero as well, not just
+          fed a zero sample: this is the only zero the failsafe gets
+          (the 1kHz re-injection below is disabled once
+          last_raw_command_us is cleared), and one sample through a
+          slow filter leaves nearly all of the previous throttle
+          applied - with INPUT_FILTER_HZ=10 over 99% of it. The motor
+          would keep running at the last commanded throttle for as
+          long as any other accepted DroneCAN transfer kept the main
+          loop's signal watchdog fed.
          */
 		canstats.last_raw_command_us = 0;
+		Filter2P_reset(0);
 		set_input(0);
 	}
 	if (canstats.last_raw_command_us != 0 && ts - last_heartbeat_us > TARGET_PERIOD_US) {

--- a/Src/DroneCAN/filter.c
+++ b/Src/DroneCAN/filter.c
@@ -42,6 +42,18 @@ static void Filter2P_setup(float sample_freq, float cutoff_freq)
 	filter.a2 = (1.0f - 2.0f * cosf(M_PI / 4.0f) * ohm + ohm * ohm) / c;
 }
 
+/*
+  force the filter state to a value, so that the next
+  apply(value, ...) returns it rather than easing towards it. Used by the RawCommand failsafe: a
+  single zero sample pushed through a slow filter leaves almost all of
+  the previous throttle applied
+ */
+void Filter2P_reset(const float value)
+{
+	filter._delay_element_1 = filter._delay_element_2 =
+		value * (1.0f / (1 + filter.a1 + filter.a2));
+}
+
 float Filter2P_apply(const float sample, float cutoff_freq, float sample_freq)
 {
 	if (cutoff_freq <= 0 || sample_freq <= 0) {

--- a/Src/DroneCAN/filter.c
+++ b/Src/DroneCAN/filter.c
@@ -50,8 +50,7 @@ static void Filter2P_setup(float sample_freq, float cutoff_freq)
  */
 void Filter2P_reset(const float value)
 {
-	filter._delay_element_1 = filter._delay_element_2 =
-		value * (1.0f / (1 + filter.a1 + filter.a2));
+	filter._delay_element_1 = filter._delay_element_2 = value * (1.0f / (1 + filter.a1 + filter.a2));
 }
 
 float Filter2P_apply(const float sample, float cutoff_freq, float sample_freq)

--- a/Src/DroneCAN/filter.h
+++ b/Src/DroneCAN/filter.h
@@ -5,3 +5,4 @@
 #pragma once
 
 float Filter2P_apply(const float sample, float cutoff_freq, float sample_rate);
+void Filter2P_reset(const float value);


### PR DESCRIPTION
## Summary

Ports the fix from [am32-firmware/AM32#407](https://github.com/am32-firmware/AM32/pull/407) (tridge):

With `INPUT_FILTER_HZ` set, losing RawCommand did not stop the motor. The 250ms failsafe calls `set_input(0)` exactly once and then clears `last_raw_command_us`, which also disables the 1kHz re-injection — so that single zero is the only one the failsafe ever gets. Passing it through the stateful 2-pole filter barely moves the output: with `INPUT_FILTER_HZ=10` over 99% of the previous throttle survives, and even at the 100Hz maximum 93% does. The separate main loop signal watchdog, which would otherwise stop the motor after 0.5s, is reset by every accepted DroneCAN transfer, so an autopilot that keeps broadcasting ArmingStatus while RawCommand stops holds the ESC at its last commanded throttle indefinitely.

This change:
- Adds `Filter2P_reset()` to force the filter state to a value immediately
- Calls `Filter2P_reset(0)` on RawCommand timeout so failsafe takes effect immediately
- Filtering restarts from zero when RawCommand resumes
- `INPUT_FILTER_HZ=0` is unaffected

## Test plan

- [ ] Build DroneCAN target (e.g. SITL or G431 CAN ESC)
- [ ] With `INPUT_FILTER_HZ=20`, spin motor via RawCommand, then stop RawCommand while ArmingStatus continues — motor should stop promptly (not hold last throttle)
- [ ] With `INPUT_FILTER_HZ=0`, confirm behavior unchanged
- [ ] Resume RawCommand after timeout — throttle filtering starts cleanly from zero

Upstream: https://github.com/am32-firmware/AM32/pull/407