### PR TITLE
fix(faults): remove the learned ramp back-off; the configured ramp is fixed

### DIFF
--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -119,24 +119,21 @@ extern volatile uint32_t fault_stall_trips;
  * Ramp-attribution state (owned by faults.c; see faultDesyncEpisodeCharge
  * and the witness sampler in faultDesyncEpisodeTick1kHz).
  *
- *  - fault_ramp_slew_witness_ms: nonzero while duty has recently been
- *    RISING at >= 75% of the active ramp regime's limit. An episode charge
- *    only halves the learned ramp while this is armed - a desync at steady
- *    duty cannot have been caused by the ramp, so it must not be allowed
- *    to store "ramp too fast" for the rest of the power cycle (a mowed
- *    lawn's worth of prop obstruction was doing exactly that).
+ *  - fault_ramp_slew_witness_ms: nonzero while the slew limiter has
+ *    recently been BINDING on a RISING demand (applied duty climbing at
+ *    >= 75% of the active regime's limit while the setpoint is moving up).
+ *    An episode charge only halves the learned ramp while this is armed -
+ *    a desync at steady duty cannot have been caused by the ramp, so it
+ *    must not be allowed to store "ramp too fast" for the rest of the
+ *    power cycle (a mowed lawn's worth of prop obstruction was doing
+ *    exactly that).
  *  - fault_ramp_halves: learned ramp halvings applied this power cycle.
  *  - fault_acq_resist_events: acquisition-rail episode charges this power
  *    cycle ("start resisted": batches of early desyncs that never reached
- *    acquisition). Surfaced over FlexDebug so the FC can see a resisted
- *    ground spool BEFORE takeoff - the learned/soften state below is
- *    otherwise invisible while every self-healing counter reads clean.
- *  - fault_acq_soften: acquisition-scoped startup-ramp soften (right-shift
- *    applied to max_ramp_startup_vcomp only, capped). Unlike the learned
- *    halve this is FORGIVABLE - cleared by a genuine acquisition or pilot
- *    zero throttle - because a start that cannot complete is at least as
- *    likely mechanically resisted (grass, debris) as mis-tuned, and the
- *    right response to the former ends when the obstruction does.
+ *    acquisition). These deliberately do NOT touch the ramp; the counter
+ *    exists so a resisted ground spool is visible BEFORE takeoff, since
+ *    every other counter in the episode machinery self-heals within
+ *    seconds of the obstruction clearing.
  *
  * Counters are monotonic per power cycle (not cleared on arm) so a
  * pre-takeoff event history survives to be read. volatile: written in ISR
@@ -145,7 +142,6 @@ extern volatile uint32_t fault_stall_trips;
 extern volatile uint8_t fault_ramp_slew_witness_ms;
 extern volatile uint8_t fault_ramp_halves;
 extern volatile uint8_t fault_acq_resist_events;
-extern volatile uint8_t fault_acq_soften;
 
 /*
  * Total hard-error events this arm cycle, for uavcan.equipment.esc.Status

--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -116,31 +116,25 @@ uint8_t faultDesyncRestartHoldoffActive(void);
 extern volatile uint32_t fault_stall_trips;
 
 /*
- * Ramp-attribution state (owned by faults.c; see faultDesyncEpisodeCharge
- * and the witness sampler in faultDesyncEpisodeTick1kHz).
+ * Acquisition-rail episode charges this power cycle ("start resisted":
+ * batches of early desyncs that never reached acquisition - see
+ * faultNoteEarlyDesync).
  *
- *  - fault_ramp_slew_witness_ms: nonzero while the slew limiter has
- *    recently been BINDING on a RISING demand (applied duty climbing at
- *    >= 75% of the active regime's limit while the setpoint is moving up).
- *    An episode charge only halves the learned ramp while this is armed -
- *    a desync at steady duty cannot have been caused by the ramp, so it
- *    must not be allowed to store "ramp too fast" for the rest of the
- *    power cycle (a mowed lawn's worth of prop obstruction was doing
- *    exactly that).
- *  - fault_ramp_halves: learned ramp halvings applied this power cycle.
- *  - fault_acq_resist_events: acquisition-rail episode charges this power
- *    cycle ("start resisted": batches of early desyncs that never reached
- *    acquisition). These deliberately do NOT touch the ramp; the counter
- *    exists so a resisted ground spool is visible BEFORE takeoff, since
- *    every other counter in the episode machinery self-heals within
- *    seconds of the obstruction clearing.
+ * This counter exists because it is the ONLY part of the episode machinery
+ * that does not self-heal: bucket, holdoff and latch all converge back to
+ * the configured settings within seconds of an obstruction clearing, so a
+ * ground spool that was fought by grass or debris leaves no trace by the
+ * time the vehicle is armed. A monotonic count lets an FC (or a human
+ * reading telemetry) refuse takeoff on a start that was resisted.
  *
- * Counters are monotonic per power cycle (not cleared on arm) so a
- * pre-takeoff event history survives to be read. volatile: written in ISR
- * context (1 kHz tick / main-loop charge), read from telemetry.
+ * Deliberately does NOT influence control: no episode kind changes the
+ * configured ramp or any other tuning parameter. See the note in
+ * faultDesyncEpisodeCharge for why persistent learned state was removed.
+ *
+ * Monotonic per power cycle (not cleared on arm) so the pre-takeoff history
+ * survives to be read. volatile: written in ISR context (main-loop charge),
+ * read from telemetry.
  */
-extern volatile uint8_t fault_ramp_slew_witness_ms;
-extern volatile uint8_t fault_ramp_halves;
 extern volatile uint8_t fault_acq_resist_events;
 
 /*

--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -116,6 +116,38 @@ uint8_t faultDesyncRestartHoldoffActive(void);
 extern volatile uint32_t fault_stall_trips;
 
 /*
+ * Ramp-attribution state (owned by faults.c; see faultDesyncEpisodeCharge
+ * and the witness sampler in faultDesyncEpisodeTick1kHz).
+ *
+ *  - fault_ramp_slew_witness_ms: nonzero while duty has recently been
+ *    RISING at >= 75% of the active ramp regime's limit. An episode charge
+ *    only halves the learned ramp while this is armed - a desync at steady
+ *    duty cannot have been caused by the ramp, so it must not be allowed
+ *    to store "ramp too fast" for the rest of the power cycle (a mowed
+ *    lawn's worth of prop obstruction was doing exactly that).
+ *  - fault_ramp_halves: learned ramp halvings applied this power cycle.
+ *  - fault_acq_resist_events: acquisition-rail episode charges this power
+ *    cycle ("start resisted": batches of early desyncs that never reached
+ *    acquisition). Surfaced over FlexDebug so the FC can see a resisted
+ *    ground spool BEFORE takeoff - the learned/soften state below is
+ *    otherwise invisible while every self-healing counter reads clean.
+ *  - fault_acq_soften: acquisition-scoped startup-ramp soften (right-shift
+ *    applied to max_ramp_startup_vcomp only, capped). Unlike the learned
+ *    halve this is FORGIVABLE - cleared by a genuine acquisition or pilot
+ *    zero throttle - because a start that cannot complete is at least as
+ *    likely mechanically resisted (grass, debris) as mis-tuned, and the
+ *    right response to the former ends when the obstruction does.
+ *
+ * Counters are monotonic per power cycle (not cleared on arm) so a
+ * pre-takeoff event history survives to be read. volatile: written in ISR
+ * context (1 kHz tick / main-loop charge), read from telemetry.
+ */
+extern volatile uint8_t fault_ramp_slew_witness_ms;
+extern volatile uint8_t fault_ramp_halves;
+extern volatile uint8_t fault_acq_resist_events;
+extern volatile uint8_t fault_acq_soften;
+
+/*
  * Total hard-error events this arm cycle, for uavcan.equipment.esc.Status
  * error_count (DSDL: "Resets when the motor restarts").
  *

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -71,9 +71,9 @@
       u16 gov_conf, u16 gov_slope_q10, u16 gov_duty_ceiling,
       u16 gov_stuck_ms, u16 gov_release_ceil, u16 gov_unlatch_count (v5 PR 65)
       u8 max_ramp_startup, u8 max_ramp_low, u8 max_ramp_high,
-      u8 ramp_divider, u8 max_ramp_startup_vcomp, u8 ramp_witness_ms,
-      u8 ramp_halves, u8 acq_resist,
-      u8 desync_episode_bucket                       (v6 ramp attribution)
+      u8 ramp_divider, u8 max_ramp_startup_vcomp, u8 acq_resist,
+      u8 desync_episode_bucket                    (v6 ramp settings +
+                                                   episode observability)
       Fields are only ever APPENDED and the version is bumped; clients
       that unpack a shorter prefix keep working unchanged (they
       length-check with >=).
@@ -599,14 +599,13 @@ void sitl_state_poll(void)
 			uint16_t gov_stuck_ms_v;
 			uint16_t gov_release_ceil_v;
 			uint16_t gov_unlatch_count_v;
-			/* v6: ramp attribution (learned halve gate + acq soften). */
+			/* v6: live ramp settings (so a test can assert the episode
+			 * machinery never mutates them) + episode observability. */
 			uint8_t max_ramp_startup_v;
 			uint8_t max_ramp_low_v;
 			uint8_t max_ramp_high_v;
 			uint8_t ramp_divider_v;
 			uint8_t max_ramp_startup_vcomp_v;
-			uint8_t ramp_witness_ms_v;
-			uint8_t ramp_halves_v;
 			uint8_t acq_resist_v;
 			uint8_t desync_episode_bucket_v;
 		} reply = {
@@ -641,8 +640,6 @@ void sitl_state_poll(void)
 			.max_ramp_high_v = max_ramp_high_rpm,
 			.ramp_divider_v = ramp_divider,
 			.max_ramp_startup_vcomp_v = max_ramp_startup_vcomp,
-			.ramp_witness_ms_v = fault_ramp_slew_witness_ms,
-			.ramp_halves_v = fault_ramp_halves,
 			.acq_resist_v = fault_acq_resist_events,
 			.desync_episode_bucket_v = desync_episode_bucket,
 		};

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -72,7 +72,7 @@
       u16 gov_stuck_ms, u16 gov_release_ceil, u16 gov_unlatch_count (v5 PR 65)
       u8 max_ramp_startup, u8 max_ramp_low, u8 max_ramp_high,
       u8 ramp_divider, u8 max_ramp_startup_vcomp, u8 ramp_witness_ms,
-      u8 ramp_halves, u8 acq_resist, u8 acq_soften,
+      u8 ramp_halves, u8 acq_resist,
       u8 desync_episode_bucket                       (v6 ramp attribution)
       Fields are only ever APPENDED and the version is bumped; clients
       that unpack a shorter prefix keep working unchanged (they
@@ -608,7 +608,6 @@ void sitl_state_poll(void)
 			uint8_t ramp_witness_ms_v;
 			uint8_t ramp_halves_v;
 			uint8_t acq_resist_v;
-			uint8_t acq_soften_v;
 			uint8_t desync_episode_bucket_v;
 		} reply = {
 			.magic = 0x5356,
@@ -645,7 +644,6 @@ void sitl_state_poll(void)
 			.ramp_witness_ms_v = fault_ramp_slew_witness_ms,
 			.ramp_halves_v = fault_ramp_halves,
 			.acq_resist_v = fault_acq_resist_events,
-			.acq_soften_v = fault_acq_soften,
 			.desync_episode_bucket_v = desync_episode_bucket,
 		};
 		sendto(fd, &reply, sizeof(reply), 0, (struct sockaddr *)&src, sizeof(src));

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -58,6 +58,25 @@
     u16 magic 0x5357, u8 version=1, u8 count, u64 t0_ns (simulated,
         first sample), u32 sample_period_ns, count * float
         (physics audio samples, arbitrary linear units)
+
+  ZC_STATS (cmd 9) reply, magic 0x5356 (shared with tone/eeprom packet
+  tags; distinguished by length + the poller asked for ZC_STATS):
+    u16 magic 0x5356, u8 version=6, u8 pad, u32 zero_crosses,
+      u32 commutation_interval, u32 dropped_edges, u32 desync_happened,
+      u8 old_routine, u8 running, u8 armed, u8 zc_blind_steps,
+      u8 zc_miss_bucket, u8 zc_deadline_armed,
+      u8 dcm_hold_ms, u8 pad2, u16 dcm_hold_value,       (v2 PR 62)
+      u8 adv_kerpm_hold_ms, u8 pad3, u16 adv_kerpm_hold, (v3 PR 63)
+      i32 zc_trend, u32 zc_predicted, u16 waitTime, u16 advance, (v4 PR 64)
+      u16 gov_conf, u16 gov_slope_q10, u16 gov_duty_ceiling,
+      u16 gov_stuck_ms, u16 gov_release_ceil, u16 gov_unlatch_count (v5 PR 65)
+      u8 max_ramp_startup, u8 max_ramp_low, u8 max_ramp_high,
+      u8 ramp_divider, u8 max_ramp_startup_vcomp, u8 ramp_witness_ms,
+      u8 ramp_halves, u8 acq_resist, u8 acq_soften,
+      u8 desync_episode_bucket                       (v6 ramp attribution)
+      Fields are only ever APPENDED and the version is bumped; clients
+      that unpack a shorter prefix keep working unchanged (they
+      length-check with >=).
 */
 
 #include "eeprom.h"
@@ -69,6 +88,7 @@
 #include "bemf_zc.h"
 #include "motor_runtime.h"
 #include "runtime_loop.h"
+#include "faults.h"
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -579,9 +599,20 @@ void sitl_state_poll(void)
 			uint16_t gov_stuck_ms_v;
 			uint16_t gov_release_ceil_v;
 			uint16_t gov_unlatch_count_v;
+			/* v6: ramp attribution (learned halve gate + acq soften). */
+			uint8_t max_ramp_startup_v;
+			uint8_t max_ramp_low_v;
+			uint8_t max_ramp_high_v;
+			uint8_t ramp_divider_v;
+			uint8_t max_ramp_startup_vcomp_v;
+			uint8_t ramp_witness_ms_v;
+			uint8_t ramp_halves_v;
+			uint8_t acq_resist_v;
+			uint8_t acq_soften_v;
+			uint8_t desync_episode_bucket_v;
 		} reply = {
 			.magic = 0x5356,
-			.version = 5,
+			.version = 6,
 			.zero_crosses = zero_crosses,
 			.commutation_interval = commutation_interval,
 			.dropped_edges = motor_zc_dropped(),
@@ -606,6 +637,16 @@ void sitl_state_poll(void)
 			.gov_stuck_ms_v = gov_stuck_ms,
 			.gov_release_ceil_v = gov_release_ceil,
 			.gov_unlatch_count_v = gov_unlatch_count,
+			.max_ramp_startup_v = max_ramp_startup,
+			.max_ramp_low_v = max_ramp_low_rpm,
+			.max_ramp_high_v = max_ramp_high_rpm,
+			.ramp_divider_v = ramp_divider,
+			.max_ramp_startup_vcomp_v = max_ramp_startup_vcomp,
+			.ramp_witness_ms_v = fault_ramp_slew_witness_ms,
+			.ramp_halves_v = fault_ramp_halves,
+			.acq_resist_v = fault_acq_resist_events,
+			.acq_soften_v = fault_acq_soften,
+			.desync_episode_bucket_v = desync_episode_bucket,
 		};
 		sendto(fd, &reply, sizeof(reply), 0, (struct sockaddr *)&src, sizeof(src));
 	} else if (cmd == 10 && ret >= 8) {

--- a/Mcu/SITL/tests/test_ramp_attribution.py
+++ b/Mcu/SITL/tests/test_ramp_attribution.py
@@ -14,8 +14,9 @@ Three engagement assertions, each a mutation check:
      halve - remove the halve (or break the witness arming) and it fails.
   2. A desync at steady duty (witness 0) does NOT halve but still charges
      the episode bucket - remove the witness gate and it fails.
-  3. Acquisition-rail charges take the forgivable startup soften, not the
-     permanent halve - visible as acq_resist/acq_soften in ZC_STATS v6.
+  3. Acquisition-rail charges never touch the ramp at all - they surface as
+     acq_resist in ZC_STATS v6 and escalate through bucket/holdoff/latch,
+     which is what test_acq_desync_rail.py already covers.
 
 CI is the authority for this file: the local SITL harness in the dev
 container does not spin the motor at all (test_dshot fails with rpm=0), so
@@ -46,9 +47,8 @@ STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'gov_stuck_ms', 'gov_release_ceil', 'gov_unlatch_count',
                 'max_ramp_startup', 'max_ramp_low', 'max_ramp_high',
                 'ramp_divider', 'max_ramp_startup_vcomp', 'ramp_witness_ms',
-                'ramp_halves', 'acq_resist', 'acq_soften',
-                'desync_episode_bucket')
-STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHHHHHHHHBBBBBBBBBB'
+                'ramp_halves', 'acq_resist', 'desync_episode_bucket')
+STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHHHHHHHHBBBBBBBBB'
 
 
 def _open_ctl(sitl):
@@ -104,7 +104,23 @@ def _spool_established(sitl, sim, ctl, tx, value=900, rpm_min=2000.0,
 
 
 def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
-    '''Desync during a max-rate upward slew must halve the learned ramp.'''
+    '''An episode charged while duty slews at the ramp limit must halve.
+
+    Choreography (learned from the first CI run of this file): inject the
+    edge suppression from ESTABLISHED STEADY state - the exact recipe the
+    ceiling-hold test proves in CI - and then keep the throttle toggling
+    whenever the charge lands. The toggling is load-bearing for BOTH witness
+    conditions: each up-leg makes the limiter bind (applied duty rising at
+    the regime rate) AND moves the setpoint, which is what separates a
+    commanded ramp from the ESC's own post-desync re-slew.
+
+    Do not condition on desync_happened: a suppression bridged by
+    blind steps resolves through the blind-limit -> stall-rail handoff,
+    which by design does NOT increment desync_happened (see the error_count
+    comment in faults.h) but still charges the episode bucket, and a
+    STALL_RAIL charge with the witness armed is an equally legitimate halve.
+    The charge signal is desync_episode_bucket (v6).
+    '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
     assert wait_for_state(sim), sitl.log_tail()
@@ -115,52 +131,61 @@ def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
     ctl = _open_ctl(sitl)
     try:
         time.sleep(2.2)
-        pre = _spool_established(sitl, sim, ctl, tx, value=700)
+        pre = _spool_established(sitl, sim, ctl, tx, value=900)
         halves0 = int(pre['ramp_halves'])
         low0 = int(pre['max_ramp_low'])
 
-        ci_us = max(pre['commutation_interval'] // 2, 100)
         seen = None
+        saw_charge = False
+        witness_at_charge = -1
         saw_desync = False
-        saw_witness = 0
         for _ in range(6):
-            # Snap first so duty is slewing at the limit (witness arms
-            # within a few ms), then suppress comparator edges so the loop
-            # breaks while the witness is armed.
-            tx.value = 1900
-            time.sleep(0.02)
+            s0 = _zc_stats(ctl)
+            ci_us = max(s0['commutation_interval'] // 2, 100)
+            bucket0 = int(s0['desync_episode_bucket'])
+            d0 = int(s0['desync_happened'])
             _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
-            probe_end = time.time() + 0.4
+            # Toggle every 50 ms: each up-leg re-arms the 100 ms witness,
+            # so it is armed at whatever moment the charge processes.
+            hi = True
+            last_toggle = 0.0
+            probe_end = time.time() + 0.5
             while time.time() < probe_end:
+                now = time.time()
+                if now - last_toggle > 0.05:
+                    tx.value = 1900 if hi else 1100
+                    hi = not hi
+                    last_toggle = now
                 s = _zc_stats(ctl)
-                saw_witness = max(saw_witness, s['ramp_witness_ms'])
-                if s['desync_happened'] > pre['desync_happened']:
+                if s['desync_happened'] > d0:
                     saw_desync = True
                 if s['ramp_halves'] > halves0:
                     seen = s
                     break
-                # tight poll: the charge is synchronous with the desync
+                if s['desync_episode_bucket'] > bucket0 and not saw_charge:
+                    saw_charge = True
+                    witness_at_charge = int(s['ramp_witness_ms'])
             if seen:
                 break
             # Recover for another attempt.
             _zc_fault(ctl, mode=0, duration_us=0)
-            tx.value = 700
+            tx.value = 900
             try:
-                pre = _spool_established(sitl, sim, ctl, tx, value=700,
-                                         budget=8.0)
+                _spool_established(sitl, sim, ctl, tx, value=900, budget=8.0)
             except AssertionError:
-                break
-            halves0 = min(halves0, int(pre['ramp_halves']))
+                continue
 
-        assert saw_desync, (
-            'fault injection never produced a desync; the halve was never '
-            'given a chance to engage\n' + sitl.log_tail())
+        assert saw_charge or saw_desync or seen is not None, (
+            'fault injection never charged the episode machinery at all - '
+            'the halve was never given a chance to engage\n'
+            + sitl.log_tail())
         assert seen is not None, (
-            'THE ATTRIBUTED HALVE NEVER ENGAGED: desyncs occurred during a '
-            'max-rate slew but ramp_halves stayed %d (peak witness_ms=%d). '
-            'Check the witness arming in faultDesyncEpisodeTick1kHz and the '
-            'witness-gated halve in faultDesyncEpisodeCharge.\n%s'
-            % (halves0, saw_witness, sitl.log_tail()))
+            'THE ATTRIBUTED HALVE NEVER ENGAGED: episodes charged during a '
+            'max-rate slew but ramp_halves stayed %d (saw_desync=%s, '
+            'witness at first observed charge=%d ms; witness 0 there means '
+            'test timing, nonzero means the witness-gated halve in '
+            'faultDesyncEpisodeCharge is broken).\n%s'
+            % (halves0, saw_desync, witness_at_charge, sitl.log_tail()))
         assert seen['max_ramp_low'] <= max(low0 // 2, 1), (
             'ramp_halves incremented but max_ramp_low did not fall: %r'
             % seen)
@@ -241,19 +266,20 @@ def test_no_halve_on_steady_duty_desync(sitl_factory, state_stream):
         ctl.close()
 
 
-def test_acq_rail_takes_soften_not_permanent_halve(sitl_factory,
-                                                   state_stream):
-    '''racer_5inch hard spool: acq charges must soften, not halve.
+def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
+                                                        state_stream):
+    '''racer_5inch hard spool: acq charges must surface, not tune.
 
     The racer model desyncs ~20/s below acquisition (see
-    test_acq_desync_rail.py). Each 20-event batch must now surface as
-    acq_resist (the "start resisted" telemetry) and step the forgivable
-    startup soften. The batches themselves must never increment the
-    permanent halve counter - on this model the loop occasionally peaks
-    past zc 100 and can take a legitimate witness-armed JUMP halve, so the
-    permanent-halve assertion here is on attribution bookkeeping
-    (acq_resist vs ramp_halves motion in the same sample window), not a
-    blanket ramp_halves==0.
+    test_acq_desync_rail.py). Each 20-event batch must surface as
+    acq_resist - the "start resisted" telemetry that lets an FC refuse
+    takeoff - while the ramp is left alone.
+
+    Not asserted here: a blanket ramp_halves == 0. On this model the loop
+    occasionally peaks past zc 100 and can then take a legitimate
+    witness-armed JUMP halve, which is correct behaviour and would make
+    such an assertion flaky. What this pins is that the acquisition rail
+    itself reports, and that the escalation path (bucket) still charges.
     '''
     path = os.path.join(MODELS, 'racer_5inch.json')
     assert os.path.isfile(path), path
@@ -276,7 +302,7 @@ def test_acq_rail_takes_soften_not_permanent_halve(sitl_factory,
         tx.value = 700
 
         acq_seen = 0
-        soften_seen = 0
+        bucket_seen = 0
         end = None
         t0 = time.time()
         while time.time() - t0 < 15.0:
@@ -286,13 +312,12 @@ def test_acq_rail_takes_soften_not_permanent_halve(sitl_factory,
                 time.sleep(0.05)
                 continue
             acq_seen = max(acq_seen, s['acq_resist'])
-            soften_seen = max(soften_seen, s['acq_soften'])
+            bucket_seen = max(bucket_seen, s['desync_episode_bucket'])
             end = s
-            if acq_seen > 0 and soften_seen > 0:
+            if acq_seen > 0 and bucket_seen > 0:
                 break
-            # The rail may instead resolve the episode: acquisition (which
-            # forgives the soften) or the stuck latch. Both are terminal
-            # for this probe.
+            # The rail may instead resolve the episode: acquisition, or the
+            # stuck latch. Both are terminal for this probe.
             if s['zero_crosses'] > 500:
                 break
             time.sleep(0.05)
@@ -304,10 +329,11 @@ def test_acq_rail_takes_soften_not_permanent_halve(sitl_factory,
             'acquired: acq_resist=%d end=%r\n%s'
             % (acq_seen, end, sitl.log_tail()))
         if acq_seen > 0:
-            assert soften_seen > 0, (
-                'acq_resist charged (%d) but the startup soften never '
-                'stepped - ACQ_FAIL episodes must take fault_acq_soften: '
-                '%r\n%s' % (acq_seen, end, sitl.log_tail()))
+            assert bucket_seen > 0, (
+                'acq_resist charged (%d) but the episode bucket never moved '
+                '- ACQ_FAIL must still escalate through the always-on '
+                'protection path: %r\n%s'
+                % (acq_seen, end, sitl.log_tail()))
     finally:
         tx.value = 0
         time.sleep(0.5)

--- a/Mcu/SITL/tests/test_ramp_attribution.py
+++ b/Mcu/SITL/tests/test_ramp_attribution.py
@@ -1,0 +1,315 @@
+'''Learned ramp back-off attribution (slew witness + acq soften).
+
+faultDesyncEpisodeCharge halves the session ramp on desync episodes. That
+lesson ("the configured ramp outran this motor/prop") is only true when the
+ramp was actually in play. Before the attribution gate, EVERY episode
+halved it - including a mechanical obstruction (grass) dragging a healthy
+run down at steady duty - and on the production tune (all regimes at 2) a
+single halve is the fine-rate floor: a silent 20x slew-authority cut for
+the rest of the power cycle, with every other counter self-healing.
+
+Three engagement assertions, each a mutation check:
+
+  1. A desync while duty is slewing at the ramp limit (witness armed) DOES
+     halve - remove the halve (or break the witness arming) and it fails.
+  2. A desync at steady duty (witness 0) does NOT halve but still charges
+     the episode bucket - remove the witness gate and it fails.
+  3. Acquisition-rail charges take the forgivable startup soften, not the
+     permanent halve - visible as acq_resist/acq_soften in ZC_STATS v6.
+
+CI is the authority for this file: the local SITL harness in the dev
+container does not spin the motor at all (test_dshot fails with rpm=0), so
+none of this was validated locally - see the PR discussion.
+'''
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import time
+
+import sitl_dshot as sd
+from sitl_harness import SITL_DIR, Sender, rpm_from_state, wait_for_state
+
+STATE_MAGIC_CMD = 0x5353
+ZC_STATS_MAGIC = 0x5356
+MODELS = os.path.join(SITL_DIR, 'models')
+
+STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
+                'desync_happened', 'old_routine', 'running', 'armed',
+                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'dcm_hold_ms', '_pad2', 'dcm_hold_value',
+                'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold',
+                'zc_trend', 'zc_predicted', 'wait_time', 'advance',
+                'gov_conf', 'gov_slope_q10', 'gov_duty_ceiling',
+                'gov_stuck_ms', 'gov_release_ceil', 'gov_unlatch_count',
+                'max_ramp_startup', 'max_ramp_low', 'max_ramp_high',
+                'ramp_divider', 'max_ramp_startup_vcomp', 'ramp_witness_ms',
+                'ramp_halves', 'acq_resist', 'acq_soften',
+                'desync_episode_bucket')
+STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHHHHHHHHBBBBBBBBBB'
+
+
+def _open_ctl(sitl):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(('127.0.0.1', sitl.state_port))
+    s.settimeout(0.5)
+    return s
+
+
+def _zc_stats(ctl, retries=8):
+    need = struct.calcsize(STATS_FMT)
+    for _ in range(retries):
+        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 4, 0))
+        try:
+            pkt = ctl.recv(96)
+        except socket.timeout:
+            continue
+        if len(pkt) >= need:
+            vals = struct.unpack_from(STATS_FMT, pkt)
+            if vals[0] == ZC_STATS_MAGIC:
+                assert vals[1] >= 6, (
+                    'ZC_STATS version %d lacks ramp-attribution fields'
+                    % vals[1])
+                return dict(zip(STATS_FIELDS, vals[3:]))
+    raise AssertionError('no v6 ZC_STATS reply from SITL state port')
+
+
+def _zc_fault(ctl, mode, duration_us):
+    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 3, mode, duration_us))
+
+
+def _spool_established(sitl, sim, ctl, tx, value=900, rpm_min=2000.0,
+                       budget=12.0):
+    '''Drive to established closed loop clearly above idle.
+
+    RPM_MIN must clear real running, not just the zc gate - see the
+    ceiling-hold test for the arithmetic (arm gates sit near ~571 mech rpm
+    on the 900kv/14p model, so 2000 keeps ~4x headroom).
+    '''
+    tx.value = value
+    deadline = time.time() + budget
+    rpm = 0.0
+    while time.time() < deadline:
+        s = _zc_stats(ctl)
+        if s['running'] and not s['old_routine'] and s['zero_crosses'] > 100:
+            rpm = rpm_from_state(sim, 0.2)
+            if rpm > rpm_min:
+                return s
+        time.sleep(0.05)
+    raise AssertionError(
+        'never reached established closed loop above %.0f rpm '
+        '(last rpm=%.0f)\n%s' % (rpm_min, rpm, sitl.log_tail()))
+
+
+def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
+    '''Desync during a max-rate upward slew must halve the learned ramp.'''
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    sim.load_model(os.path.join(MODELS, 'unloaded.json'))
+    time.sleep(1.0)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    ctl = _open_ctl(sitl)
+    try:
+        time.sleep(2.2)
+        pre = _spool_established(sitl, sim, ctl, tx, value=700)
+        halves0 = int(pre['ramp_halves'])
+        low0 = int(pre['max_ramp_low'])
+
+        ci_us = max(pre['commutation_interval'] // 2, 100)
+        seen = None
+        saw_desync = False
+        saw_witness = 0
+        for _ in range(6):
+            # Snap first so duty is slewing at the limit (witness arms
+            # within a few ms), then suppress comparator edges so the loop
+            # breaks while the witness is armed.
+            tx.value = 1900
+            time.sleep(0.02)
+            _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
+            probe_end = time.time() + 0.4
+            while time.time() < probe_end:
+                s = _zc_stats(ctl)
+                saw_witness = max(saw_witness, s['ramp_witness_ms'])
+                if s['desync_happened'] > pre['desync_happened']:
+                    saw_desync = True
+                if s['ramp_halves'] > halves0:
+                    seen = s
+                    break
+                # tight poll: the charge is synchronous with the desync
+            if seen:
+                break
+            # Recover for another attempt.
+            _zc_fault(ctl, mode=0, duration_us=0)
+            tx.value = 700
+            try:
+                pre = _spool_established(sitl, sim, ctl, tx, value=700,
+                                         budget=8.0)
+            except AssertionError:
+                break
+            halves0 = min(halves0, int(pre['ramp_halves']))
+
+        assert saw_desync, (
+            'fault injection never produced a desync; the halve was never '
+            'given a chance to engage\n' + sitl.log_tail())
+        assert seen is not None, (
+            'THE ATTRIBUTED HALVE NEVER ENGAGED: desyncs occurred during a '
+            'max-rate slew but ramp_halves stayed %d (peak witness_ms=%d). '
+            'Check the witness arming in faultDesyncEpisodeTick1kHz and the '
+            'witness-gated halve in faultDesyncEpisodeCharge.\n%s'
+            % (halves0, saw_witness, sitl.log_tail()))
+        assert seen['max_ramp_low'] <= max(low0 // 2, 1), (
+            'ramp_halves incremented but max_ramp_low did not fall: %r'
+            % seen)
+    finally:
+        tx.value = 0
+        time.sleep(0.3)
+        _zc_fault(ctl, mode=0, duration_us=0)
+        tx.stop()
+        ctl.close()
+
+
+def test_no_halve_on_steady_duty_desync(sitl_factory, state_stream):
+    '''A desync at steady duty (witness 0) charges the bucket, not the ramp.
+
+    This is the grass case: an external load dragging an established run
+    down teaches nothing about the configured ramp. Remove the witness gate
+    in faultDesyncEpisodeCharge and this fails.
+    '''
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    sim.load_model(os.path.join(MODELS, 'unloaded.json'))
+    time.sleep(1.0)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    ctl = _open_ctl(sitl)
+    try:
+        time.sleep(2.2)
+        pre = _spool_established(sitl, sim, ctl, tx, value=900)
+
+        # Hold steady until the witness has fully decayed: duty is no
+        # longer rising, so a desync now is NOT ramp-attributable.
+        deadline = time.time() + 6.0
+        steady = None
+        while time.time() < deadline:
+            s = _zc_stats(ctl)
+            if s['running'] and s['ramp_witness_ms'] == 0:
+                steady = s
+                break
+            time.sleep(0.05)
+        assert steady is not None, (
+            'witness never decayed at steady throttle: %r\n%s'
+            % (_zc_stats(ctl), sitl.log_tail()))
+
+        ci_us = max(steady['commutation_interval'] // 2, 100)
+        _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
+        first = None
+        probe_end = time.time() + 3.0
+        while time.time() < probe_end:
+            s = _zc_stats(ctl)
+            if s['desync_happened'] > steady['desync_happened']:
+                first = s
+                break
+        assert first is not None, (
+            'fault injection never produced a desync\n' + sitl.log_tail())
+
+        # The charge is synchronous with desync_happened++, so the first
+        # sample that shows the desync already reflects any halve. Sample
+        # THIS one - later samples can see re-spool slews legitimately
+        # arming the witness for subsequent events.
+        assert first['ramp_halves'] == steady['ramp_halves'], (
+            'STEADY-DUTY DESYNC HALVED THE RAMP: witness was 0 at inject '
+            'but ramp_halves went %d->%d. The attribution gate in '
+            'faultDesyncEpisodeCharge is not holding.\n%r\n%s'
+            % (steady['ramp_halves'], first['ramp_halves'], first,
+               sitl.log_tail()))
+        assert first['max_ramp_low'] == steady['max_ramp_low'], first
+        assert first['desync_episode_bucket'] > steady[
+            'desync_episode_bucket'], (
+            'episode bucket did not charge on an established-run desync - '
+            'the gate must only skip the RAMP lesson, never the episode '
+            'accounting: %r' % first)
+    finally:
+        tx.value = 0
+        time.sleep(0.3)
+        _zc_fault(ctl, mode=0, duration_us=0)
+        tx.stop()
+        ctl.close()
+
+
+def test_acq_rail_takes_soften_not_permanent_halve(sitl_factory,
+                                                   state_stream):
+    '''racer_5inch hard spool: acq charges must soften, not halve.
+
+    The racer model desyncs ~20/s below acquisition (see
+    test_acq_desync_rail.py). Each 20-event batch must now surface as
+    acq_resist (the "start resisted" telemetry) and step the forgivable
+    startup soften. The batches themselves must never increment the
+    permanent halve counter - on this model the loop occasionally peaks
+    past zc 100 and can take a legitimate witness-armed JUMP halve, so the
+    permanent-halve assertion here is on attribution bookkeeping
+    (acq_resist vs ramp_halves motion in the same sample window), not a
+    blanket ramp_halves==0.
+    '''
+    path = os.path.join(MODELS, 'racer_5inch.json')
+    assert os.path.isfile(path), path
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    sim.load_model(path)
+    deadline = time.time() + 3.0
+    while time.time() < deadline:
+        status = (sim.model_status or '').lower()
+        if status and 'fail' not in status and 'error' not in status:
+            if 'loading' not in status or 'racer' in status or 'ok' in status:
+                break
+        time.sleep(0.1)
+
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    ctl = _open_ctl(sitl)
+    try:
+        time.sleep(2.2)
+        tx.value = 700
+
+        acq_seen = 0
+        soften_seen = 0
+        end = None
+        t0 = time.time()
+        while time.time() - t0 < 15.0:
+            try:
+                s = _zc_stats(ctl)
+            except AssertionError:
+                time.sleep(0.05)
+                continue
+            acq_seen = max(acq_seen, s['acq_resist'])
+            soften_seen = max(soften_seen, s['acq_soften'])
+            end = s
+            if acq_seen > 0 and soften_seen > 0:
+                break
+            # The rail may instead resolve the episode: acquisition (which
+            # forgives the soften) or the stuck latch. Both are terminal
+            # for this probe.
+            if s['zero_crosses'] > 500:
+                break
+            time.sleep(0.05)
+
+        assert end is not None, sitl.log_tail()
+        acquired = end['zero_crosses'] > 500
+        assert acq_seen > 0 or acquired, (
+            'racer hard spool never charged the acquisition rail and never '
+            'acquired: acq_resist=%d end=%r\n%s'
+            % (acq_seen, end, sitl.log_tail()))
+        if acq_seen > 0:
+            assert soften_seen > 0, (
+                'acq_resist charged (%d) but the startup soften never '
+                'stepped - ACQ_FAIL episodes must take fault_acq_soften: '
+                '%r\n%s' % (acq_seen, end, sitl.log_tail()))
+    finally:
+        tx.value = 0
+        time.sleep(0.5)
+        tx.stop()
+        ctl.close()

--- a/Mcu/SITL/tests/test_ramp_settings_fixed.py
+++ b/Mcu/SITL/tests/test_ramp_settings_fixed.py
@@ -1,22 +1,34 @@
-'''Learned ramp back-off attribution (slew witness + acq soften).
+'''The configured ramp is FIXED: no desync episode may ever mutate it.
 
-faultDesyncEpisodeCharge halves the session ramp on desync episodes. That
-lesson ("the configured ramp outran this motor/prop") is only true when the
-ramp was actually in play. Before the attribution gate, EVERY episode
-halved it - including a mechanical obstruction (grass) dragging a healthy
-run down at steady duty - and on the production tune (all regimes at 2) a
-single halve is the fine-rate floor: a silent 20x slew-authority cut for
-the rest of the power cycle, with every other counter self-healing.
+faultDesyncEpisodeCharge used to halve every regime's duty step on a desync
+episode, permanently for the power cycle ("learned ramp back-off"). That is
+per-ESC state the flight controller cannot see, and the mixer assumes
+symmetric actuators - one ESC that has learned a slower ramp than its
+siblings is an asymmetric vehicle with no way to report it. It crashed a
+vehicle taking off after a ground spool in long grass, where obstruction at
+STEADY duty dragged an established run down and the episode was misread as
+"ramp too fast". On the production tune (max_ramp 20 -> all regimes 2) one
+halve already IS the fine-rate floor: a silent 20x slew-authority cut.
 
-Three engagement assertions, each a mutation check:
+An attribution gate (halve only when the slew limiter was demonstrably
+binding on rising demand) was tried and rejected: it narrows the
+misattribution but keeps the architecture. The mechanism is gone instead.
 
-  1. A desync while duty is slewing at the ramp limit (witness armed) DOES
-     halve - remove the halve (or break the witness arming) and it fails.
-  2. A desync at steady duty (witness 0) does NOT halve but still charges
-     the episode bucket - remove the witness gate and it fails.
-  3. Acquisition-rail charges never touch the ramp at all - they surface as
-     acq_resist in ZC_STATS v6 and escalate through bucket/holdoff/latch,
-     which is what test_acq_desync_rail.py already covers.
+Three assertions, each a mutation check against restoring it:
+
+  1. An episode charged while duty slews AT the ramp limit - the exact
+     condition the old gate treated as proof of "ramp too fast", and the
+     one case a re-introduced halve would definitely fire on - leaves the
+     configured ramp untouched.
+  2. The grass case: an episode at steady duty leaves the ramp untouched
+     AND still charges the episode bucket. The always-on protection must
+     not be weakened by removing the learned part.
+  3. Acquisition-rail charges surface as acq_resist (the "start resisted"
+     telemetry an FC can refuse takeoff on) and never touch the ramp.
+
+Ramp fields asserted: the three configured regime steps plus ramp_divider.
+Deliberately NOT max_ramp_startup_vcomp - that is the voltage-compensated
+working copy and moves legitimately with pack sag.
 
 CI is the authority for this file: the local SITL harness in the dev
 container does not spin the motor at all (test_dshot fails with rpm=0), so
@@ -46,9 +58,24 @@ STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'gov_conf', 'gov_slope_q10', 'gov_duty_ceiling',
                 'gov_stuck_ms', 'gov_release_ceil', 'gov_unlatch_count',
                 'max_ramp_startup', 'max_ramp_low', 'max_ramp_high',
-                'ramp_divider', 'max_ramp_startup_vcomp', 'ramp_witness_ms',
-                'ramp_halves', 'acq_resist', 'desync_episode_bucket')
-STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHHHHHHHHBBBBBBBBB'
+                'ramp_divider', 'max_ramp_startup_vcomp', 'acq_resist',
+                'desync_episode_bucket')
+STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHHHHHHHHBBBBBBB'
+
+RAMP_FIELDS = ('max_ramp_startup', 'max_ramp_low', 'max_ramp_high',
+               'ramp_divider')
+
+
+def _ramp(s):
+    return tuple(int(s[f]) for f in RAMP_FIELDS)
+
+
+def _assert_ramp_fixed(base, s, what, sitl):
+    assert _ramp(s) == base, (
+        'THE CONFIGURED RAMP WAS MUTATED (%s): %s went %r -> %r. Nothing in '
+        'the episode machinery may change tuning - the learned halve was '
+        'removed deliberately (see faultDesyncEpisodeCharge).\n%r\n%s'
+        % (what, RAMP_FIELDS, base, _ramp(s), s, sitl.log_tail()))
 
 
 def _open_ctl(sitl):
@@ -70,7 +97,7 @@ def _zc_stats(ctl, retries=8):
             vals = struct.unpack_from(STATS_FMT, pkt)
             if vals[0] == ZC_STATS_MAGIC:
                 assert vals[1] >= 6, (
-                    'ZC_STATS version %d lacks ramp-attribution fields'
+                    'ZC_STATS version %d lacks the ramp/episode fields'
                     % vals[1])
                 return dict(zip(STATS_FIELDS, vals[3:]))
     raise AssertionError('no v6 ZC_STATS reply from SITL state port')
@@ -103,23 +130,23 @@ def _spool_established(sitl, sim, ctl, tx, value=900, rpm_min=2000.0,
         '(last rpm=%.0f)\n%s' % (rpm_min, rpm, sitl.log_tail()))
 
 
-def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
-    '''An episode charged while duty slews at the ramp limit must halve.
+def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
+    '''An episode charged during a max-rate slew must not retune the ESC.
+
+    This is the case a re-introduced learned halve would certainly fire on,
+    so it is the load-bearing mutation check: restore the halve in
+    faultDesyncEpisodeCharge and this test fails.
 
     Choreography (learned from the first CI run of this file): inject the
-    edge suppression from ESTABLISHED STEADY state - the exact recipe the
-    ceiling-hold test proves in CI - and then keep the throttle toggling
-    whenever the charge lands. The toggling is load-bearing for BOTH witness
-    conditions: each up-leg makes the limiter bind (applied duty rising at
-    the regime rate) AND moves the setpoint, which is what separates a
-    commanded ramp from the ESC's own post-desync re-slew.
+    edge suppression from ESTABLISHED STEADY state - the recipe the
+    ceiling-hold test proves in CI - then keep the throttle toggling so the
+    limiter is genuinely binding on a rising setpoint when the charge lands.
 
-    Do not condition on desync_happened: a suppression bridged by
-    blind steps resolves through the blind-limit -> stall-rail handoff,
-    which by design does NOT increment desync_happened (see the error_count
-    comment in faults.h) but still charges the episode bucket, and a
-    STALL_RAIL charge with the witness armed is an equally legitimate halve.
-    The charge signal is desync_episode_bucket (v6).
+    Do not condition on desync_happened: a suppression bridged by blind
+    steps resolves through the blind-limit -> stall-rail handoff, which by
+    design does NOT increment desync_happened (see the error_count comment
+    in faults.h) but still charges the episode bucket. The charge signal is
+    desync_episode_bucket (v6).
     '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
@@ -132,12 +159,9 @@ def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
     try:
         time.sleep(2.2)
         pre = _spool_established(sitl, sim, ctl, tx, value=900)
-        halves0 = int(pre['ramp_halves'])
-        low0 = int(pre['max_ramp_low'])
+        base = _ramp(pre)
 
-        seen = None
         saw_charge = False
-        witness_at_charge = -1
         saw_desync = False
         for _ in range(6):
             s0 = _zc_stats(ctl)
@@ -145,8 +169,8 @@ def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
             bucket0 = int(s0['desync_episode_bucket'])
             d0 = int(s0['desync_happened'])
             _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
-            # Toggle every 50 ms: each up-leg re-arms the 100 ms witness,
-            # so it is armed at whatever moment the charge processes.
+            # Toggle every 50 ms so the limiter is binding on a RISING
+            # setpoint across the whole window the charge can land in.
             hi = True
             last_toggle = 0.0
             probe_end = time.time() + 0.5
@@ -157,15 +181,12 @@ def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
                     hi = not hi
                     last_toggle = now
                 s = _zc_stats(ctl)
+                _assert_ramp_fixed(base, s, 'during max-rate slew', sitl)
                 if s['desync_happened'] > d0:
                     saw_desync = True
-                if s['ramp_halves'] > halves0:
-                    seen = s
-                    break
-                if s['desync_episode_bucket'] > bucket0 and not saw_charge:
+                if s['desync_episode_bucket'] > bucket0:
                     saw_charge = True
-                    witness_at_charge = int(s['ramp_witness_ms'])
-            if seen:
+            if saw_charge or saw_desync:
                 break
             # Recover for another attempt.
             _zc_fault(ctl, mode=0, duration_us=0)
@@ -175,20 +196,19 @@ def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
             except AssertionError:
                 continue
 
-        assert saw_charge or saw_desync or seen is not None, (
-            'fault injection never charged the episode machinery at all - '
-            'the halve was never given a chance to engage\n'
-            + sitl.log_tail())
-        assert seen is not None, (
-            'THE ATTRIBUTED HALVE NEVER ENGAGED: episodes charged during a '
-            'max-rate slew but ramp_halves stayed %d (saw_desync=%s, '
-            'witness at first observed charge=%d ms; witness 0 there means '
-            'test timing, nonzero means the witness-gated halve in '
-            'faultDesyncEpisodeCharge is broken).\n%s'
-            % (halves0, saw_desync, witness_at_charge, sitl.log_tail()))
-        assert seen['max_ramp_low'] <= max(low0 // 2, 1), (
-            'ramp_halves incremented but max_ramp_low did not fall: %r'
-            % seen)
+        assert saw_charge or saw_desync, (
+            'fault injection never charged the episode machinery at all, so '
+            'this test proved nothing - a re-introduced halve would not have '
+            'been given a chance to fire\n' + sitl.log_tail())
+        # Re-check after the dust settles: the post-episode re-spool is
+        # itself a max-rate slew against a static setpoint.
+        tx.value = 900
+        _zc_fault(ctl, mode=0, duration_us=0)
+        settle_end = time.time() + 1.5
+        while time.time() < settle_end:
+            _assert_ramp_fixed(base, _zc_stats(ctl), 'post-episode re-spool',
+                               sitl)
+            time.sleep(0.05)
     finally:
         tx.value = 0
         time.sleep(0.3)
@@ -197,12 +217,13 @@ def test_halve_engages_on_slew_attributed_desync(sitl_factory, state_stream):
         ctl.close()
 
 
-def test_no_halve_on_steady_duty_desync(sitl_factory, state_stream):
-    '''A desync at steady duty (witness 0) charges the bucket, not the ramp.
+def test_steady_duty_desync_leaves_ramp_fixed(sitl_factory, state_stream):
+    '''The grass case: obstruction at steady duty must not retune the ESC.
 
-    This is the grass case: an external load dragging an established run
-    down teaches nothing about the configured ramp. Remove the witness gate
-    in faultDesyncEpisodeCharge and this fails.
+    An external load dragging an established run down teaches nothing about
+    the configured ramp. This is the episode that crashed the vehicle. The
+    bucket must still charge - removing the learned halve must not weaken
+    the always-on escalation path.
     '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
@@ -214,21 +235,14 @@ def test_no_halve_on_steady_duty_desync(sitl_factory, state_stream):
     ctl = _open_ctl(sitl)
     try:
         time.sleep(2.2)
-        pre = _spool_established(sitl, sim, ctl, tx, value=900)
+        _spool_established(sitl, sim, ctl, tx, value=900)
 
-        # Hold steady until the witness has fully decayed: duty is no
-        # longer rising, so a desync now is NOT ramp-attributable.
-        deadline = time.time() + 6.0
-        steady = None
-        while time.time() < deadline:
-            s = _zc_stats(ctl)
-            if s['running'] and s['ramp_witness_ms'] == 0:
-                steady = s
-                break
-            time.sleep(0.05)
-        assert steady is not None, (
-            'witness never decayed at steady throttle: %r\n%s'
-            % (_zc_stats(ctl), sitl.log_tail()))
+        # Hold the stick still so duty is genuinely steady when the fault
+        # lands: no rising demand, nothing the ramp could be blamed for.
+        time.sleep(0.6)
+        steady = _zc_stats(ctl)
+        assert steady['running'], (steady, sitl.log_tail())
+        base = _ramp(steady)
 
         ci_us = max(steady['commutation_interval'] // 2, 100)
         _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
@@ -236,28 +250,17 @@ def test_no_halve_on_steady_duty_desync(sitl_factory, state_stream):
         probe_end = time.time() + 3.0
         while time.time() < probe_end:
             s = _zc_stats(ctl)
+            _assert_ramp_fixed(base, s, 'steady-duty desync', sitl)
             if s['desync_happened'] > steady['desync_happened']:
                 first = s
                 break
         assert first is not None, (
             'fault injection never produced a desync\n' + sitl.log_tail())
-
-        # The charge is synchronous with desync_happened++, so the first
-        # sample that shows the desync already reflects any halve. Sample
-        # THIS one - later samples can see re-spool slews legitimately
-        # arming the witness for subsequent events.
-        assert first['ramp_halves'] == steady['ramp_halves'], (
-            'STEADY-DUTY DESYNC HALVED THE RAMP: witness was 0 at inject '
-            'but ramp_halves went %d->%d. The attribution gate in '
-            'faultDesyncEpisodeCharge is not holding.\n%r\n%s'
-            % (steady['ramp_halves'], first['ramp_halves'], first,
-               sitl.log_tail()))
-        assert first['max_ramp_low'] == steady['max_ramp_low'], first
         assert first['desync_episode_bucket'] > steady[
             'desync_episode_bucket'], (
             'episode bucket did not charge on an established-run desync - '
-            'the gate must only skip the RAMP lesson, never the episode '
-            'accounting: %r' % first)
+            'removing the learned halve must not weaken the always-on '
+            'escalation path: %r' % first)
     finally:
         tx.value = 0
         time.sleep(0.3)
@@ -275,11 +278,10 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
     acq_resist - the "start resisted" telemetry that lets an FC refuse
     takeoff - while the ramp is left alone.
 
-    Not asserted here: a blanket ramp_halves == 0. On this model the loop
-    occasionally peaks past zc 100 and can then take a legitimate
-    witness-armed JUMP halve, which is correct behaviour and would make
-    such an assertion flaky. What this pins is that the acquisition rail
-    itself reports, and that the escalation path (bucket) still charges.
+    The ramp assertion here is unconditional, which it could not be while
+    the attribution gate existed: this model occasionally peaks past zc 100
+    and would then take a legitimate witness-armed halve. With no learned
+    state at all, "the ramp never moves" holds for every path.
     '''
     path = os.path.join(MODELS, 'racer_5inch.json')
     assert os.path.isfile(path), path
@@ -299,6 +301,7 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
     ctl = _open_ctl(sitl)
     try:
         time.sleep(2.2)
+        base = _ramp(_zc_stats(ctl))
         tx.value = 700
 
         acq_seen = 0
@@ -311,6 +314,7 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
             except AssertionError:
                 time.sleep(0.05)
                 continue
+            _assert_ramp_fixed(base, s, 'acquisition rail', sitl)
             acq_seen = max(acq_seen, s['acq_resist'])
             bucket_seen = max(bucket_seen, s['desync_episode_bucket'])
             end = s

--- a/Mcu/SITL/tests/test_ramp_settings_fixed.py
+++ b/Mcu/SITL/tests/test_ramp_settings_fixed.py
@@ -23,8 +23,10 @@ Three assertions, each a mutation check against restoring it:
   2. The grass case: an episode at steady duty leaves the ramp untouched
      AND still charges the episode bucket. The always-on protection must
      not be weakened by removing the learned part.
-  3. Acquisition-rail charges surface as acq_resist (the "start resisted"
-     telemetry an FC can refuse takeoff on) and never touch the ramp.
+  3. A racer hard spool charges the episode machinery - via the
+     acquisition rail (acq_resist, the "start resisted" telemetry an FC can
+     refuse takeoff on) or via established-run episodes, whichever this
+     model produces - and never touches the ramp.
 
 Ramp fields asserted: the three configured regime steps plus ramp_divider.
 Deliberately NOT max_ramp_startup_vcomp - that is the voltage-compensated
@@ -278,17 +280,25 @@ def test_steady_duty_desync_leaves_ramp_fixed(sitl_factory, state_stream):
 
 def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
                                                         state_stream):
-    '''racer_5inch hard spool: acq charges must surface, not tune.
+    '''racer_5inch hard spool: episodes must surface, not tune.
 
-    The racer model desyncs ~20/s below acquisition (see
-    test_acq_desync_rail.py). Each 20-event batch must surface as
-    acq_resist - the "start resisted" telemetry that lets an FC refuse
-    takeoff - while the ramp is left alone.
+    The ramp assertion runs on every sample and is unconditional, which it
+    could not be while the attribution gate existed: this model peaks past
+    zc 100 and would then take a legitimate witness-armed halve. With no
+    learned state at all, "the ramp never moves" holds for every path.
 
-    The ramp assertion here is unconditional, which it could not be while
-    the attribution gate existed: this model occasionally peaks past zc 100
-    and would then take a legitimate witness-armed halve. With no learned
-    state at all, "the ramp never moves" holds for every path.
+    Which rail the model exercises is NOT pinned here, deliberately. Before
+    #77 it desynced ~20/s below acquisition and charged acq_resist; with the
+    upstream SITL update it now acquires and then desyncs at established
+    rpm, so the 20-event acq batch never completes and the bucket charges
+    through the JUMP/STALL path instead. Both are legitimate, and
+    test_acq_desync_rail.py is what pins the acquisition rail's mechanism.
+    What must hold either way is that SOMETHING charged - otherwise a
+    re-introduced halve was never given a chance to fire and this test
+    proves nothing - and that the ramp did not move.
+
+    Bucket motion is the load-bearing case: those established-run episodes
+    are exactly the ones the old halve fired on.
     '''
     path = os.path.join(MODELS, 'racer_5inch.json')
     assert os.path.isfile(path), path
@@ -313,6 +323,10 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
 
         acq_seen = 0
         bucket_seen = 0
+        # Peak, NOT the last sample: zero_crosses is reset to 0 by every
+        # desync (runtime_loop.c), so a spool that acquires and is then
+        # dragged back down reads 0 at the end even though it plainly ran.
+        zc_seen = 0
         end = None
         t0 = time.time()
         while time.time() - t0 < 15.0:
@@ -321,24 +335,22 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
             except AssertionError:
                 time.sleep(0.05)
                 continue
-            _assert_ramp_fixed(base, s, 'acquisition rail', sitl)
+            _assert_ramp_fixed(base, s, 'hard spool', sitl)
             acq_seen = max(acq_seen, s['acq_resist'])
             bucket_seen = max(bucket_seen, s['desync_episode_bucket'])
+            zc_seen = max(zc_seen, s['zero_crosses'])
             end = s
             if acq_seen > 0 and bucket_seen > 0:
-                break
-            # The rail may instead resolve the episode: acquisition, or the
-            # stuck latch. Both are terminal for this probe.
-            if s['zero_crosses'] > 500:
                 break
             time.sleep(0.05)
 
         assert end is not None, sitl.log_tail()
-        acquired = end['zero_crosses'] > 500
-        assert acq_seen > 0 or acquired, (
-            'racer hard spool never charged the acquisition rail and never '
-            'acquired: acq_resist=%d end=%r\n%s'
-            % (acq_seen, end, sitl.log_tail()))
+        assert acq_seen > 0 or bucket_seen > 0 or zc_seen > 500, (
+            'racer hard spool did nothing observable in 15 s - no episode '
+            'charge, no acquisition - so a re-introduced halve would not '
+            'have been given a chance to fire: acq_resist=%d bucket=%d '
+            'zc_peak=%d end=%r\n%s'
+            % (acq_seen, bucket_seen, zc_seen, end, sitl.log_tail()))
         if acq_seen > 0:
             assert bucket_seen > 0, (
                 'acq_resist charged (%d) but the episode bucket never moved '

--- a/Mcu/SITL/tests/test_ramp_settings_fixed.py
+++ b/Mcu/SITL/tests/test_ramp_settings_fixed.py
@@ -88,7 +88,9 @@ def _open_ctl(sitl):
 def _zc_stats(ctl, retries=8):
     need = struct.calcsize(STATS_FMT)
     for _ in range(retries):
-        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 4, 0))
+        # cmd 9 ZC_STATS (ARK extension; remapped from 4 when upstream
+        # SITL claimed 3/4 for tone/audio subscribe — see #77).
+        ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 9, 0))
         try:
             pkt = ctl.recv(96)
         except socket.timeout:
@@ -104,7 +106,8 @@ def _zc_stats(ctl, retries=8):
 
 
 def _zc_fault(ctl, mode, duration_us):
-    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 3, mode, duration_us))
+    # cmd 8 ZC_FAULT (ARK extension; remapped from 3 — see #77).
+    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 8, mode, duration_us))
 
 
 def _spool_established(sitl, sim, ctl, tx, value=900, rpm_min=2000.0,

--- a/Mcu/SITL/tests/test_ramp_settings_fixed.py
+++ b/Mcu/SITL/tests/test_ramp_settings_fixed.py
@@ -189,7 +189,7 @@ def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
                     saw_desync = True
                 if s['desync_episode_bucket'] > bucket0:
                     saw_charge = True
-            if saw_charge or saw_desync:
+            if saw_charge:
                 break
             # Recover for another attempt.
             _zc_fault(ctl, mode=0, duration_us=0)
@@ -199,10 +199,14 @@ def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
             except AssertionError:
                 continue
 
-        assert saw_charge or saw_desync, (
-            'fault injection never charged the episode machinery at all, so '
-            'this test proved nothing - a re-introduced halve would not have '
-            'been given a chance to fire\n' + sitl.log_tail())
+        # Require a real episode charge (bucket motion), not just
+        # desync_happened: the learned halve lived only inside
+        # faultDesyncEpisodeCharge, and some desync paths never call it.
+        assert saw_charge, (
+            'fault injection never charged desync_episode_bucket, so this '
+            'test proved nothing - a re-introduced halve would not have '
+            'been given a chance to fire (saw_desync=%s)\n%s'
+            % (saw_desync, sitl.log_tail()))
         # Re-check after the dust settles: the post-episode re-spool is
         # itself a max-rate slew against a static setpoint.
         tx.value = 900

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -108,7 +108,6 @@ static struct PACKED {
 	 * degraded slew BEFORE takeoff — every other counter self-heals. */
 	uint8_t acq_resist_events;
 	uint8_t ramp_halves;
-	uint8_t acq_soften;
 } debug1;
 
 static void can_printf(const char *fmt, ...);
@@ -1075,7 +1074,6 @@ static void send_FlexDebug(void)
 	debug1.auto_advance_level = auto_advance_level;
 	debug1.acq_resist_events = fault_acq_resist_events;
 	debug1.ramp_halves = fault_ramp_halves;
-	debug1.acq_soften = fault_acq_soften;
 	debug1.num_commands = canstats.total_commands - last.total_commands;
 	debug1.num_input = canstats.num_input - last.num_input;
 	debug1.rx_errors = canstats.rx_errors;

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -96,13 +96,19 @@ static struct PACKED {
 	uint16_t rxframe_error;
 	int32_t rx_ecode;
 	uint8_t auto_advance_level;
-	// version 2 fields
+	// version 2 fields (upstream am32 / PR#394)
 	uint16_t duty_cycle;	     // demanded duty, 0..2000
 	uint16_t duty_cycle_maximum; // low-rpm/temperature duty clamp
 	uint16_t adjusted_input;     // input after mode mapping, 0..2047
 	uint16_t adc_raw_current;    // current sense ADC counts
 	uint16_t adc_raw_volts;	     // voltage sense ADC counts
 	uint8_t flags;		     // bit0 armed, bit1 running, bit2 stepper_sine
+	/* ARK append-only after upstream v2: ramp-attribution telemetry
+	 * (faults.h). FC-side visibility of a resisted ground spool /
+	 * degraded slew BEFORE takeoff — every other counter self-heals. */
+	uint8_t acq_resist_events;
+	uint8_t ramp_halves;
+	uint8_t acq_soften;
 } debug1;
 
 static void can_printf(const char *fmt, ...);
@@ -1067,6 +1073,9 @@ static void send_FlexDebug(void)
 	debug1.version = 2;
 	debug1.commutation_interval = commutation_interval;
 	debug1.auto_advance_level = auto_advance_level;
+	debug1.acq_resist_events = fault_acq_resist_events;
+	debug1.ramp_halves = fault_ramp_halves;
+	debug1.acq_soften = fault_acq_soften;
 	debug1.num_commands = canstats.total_commands - last.total_commands;
 	debug1.num_input = canstats.num_input - last.num_input;
 	debug1.rx_errors = canstats.rx_errors;

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -103,11 +103,10 @@ static struct PACKED {
 	uint16_t adc_raw_current;    // current sense ADC counts
 	uint16_t adc_raw_volts;	     // voltage sense ADC counts
 	uint8_t flags;		     // bit0 armed, bit1 running, bit2 stepper_sine
-	/* ARK append-only after upstream v2: ramp-attribution telemetry
-	 * (faults.h). FC-side visibility of a resisted ground spool /
-	 * degraded slew BEFORE takeoff — every other counter self-heals. */
+	/* ARK append-only after upstream v2: "start resisted" count
+	 * (faults.h). FC-side visibility of a resisted ground spool BEFORE
+	 * takeoff — every other counter in the episode machinery self-heals. */
 	uint8_t acq_resist_events;
-	uint8_t ramp_halves;
 } debug1;
 
 static void can_printf(const char *fmt, ...);
@@ -1073,7 +1072,6 @@ static void send_FlexDebug(void)
 	debug1.commutation_interval = commutation_interval;
 	debug1.auto_advance_level = auto_advance_level;
 	debug1.acq_resist_events = fault_acq_resist_events;
-	debug1.ramp_halves = fault_ramp_halves;
 	debug1.num_commands = canstats.total_commands - last.total_commands;
 	debug1.num_input = canstats.num_input - last.num_input;
 	debug1.rx_errors = canstats.rx_errors;

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -672,12 +672,18 @@ RAM_FUNC void tenKhzRoutine()
 			// ~15 ms of a too-fast transient are electrically silent -
 			// no rejects, no demag-late, no misses - and then the ZC
 			// window closes within ~3 commutations, so every observable
-			// distress signal arrives after lock is unrecoverable. The
-			// working alternative is the learned ramp back-off in
-			// faultDesyncEpisodeCharge: each RAMP-ATTRIBUTED desync
-			// episode (slew witness armed - duty was rising at this
-			// limit when the loop broke) halves the configured ramp
-			// (floor fine 0.1%/ms) for the rest of the power cycle.
+			// distress signal arrives after lock is unrecoverable.
+			//
+			// There is therefore NO in-flight mechanism that saves a
+			// too-fast ramp, and deliberately so: a learned back-off here
+			// (each desync episode halving the configured ramp for the
+			// rest of the power cycle) was tried, shipped, and reverted -
+			// per-ESC learned state is invisible to the FC and makes a
+			// multirotor asymmetric. See the note in
+			// faultDesyncEpisodeCharge. These limits are what the eeprom
+			// says and stay that way; a ramp that outruns the motor is a
+			// tuning defect, and repeated desyncs are bounded by the
+			// episode latch, not by quietly slowing this ESC down.
 			if ((duty_cycle - last_duty_cycle) > max_duty_cycle_change) {
 				duty_cycle = last_duty_cycle + max_duty_cycle_change;
 			}

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -674,9 +674,10 @@ RAM_FUNC void tenKhzRoutine()
 			// window closes within ~3 commutations, so every observable
 			// distress signal arrives after lock is unrecoverable. The
 			// working alternative is the learned ramp back-off in
-			// faultDesyncEpisodeCharge: each desync episode halves the
-			// configured ramp (floor fine 0.1%/ms) for the rest of the
-			// power cycle.
+			// faultDesyncEpisodeCharge: each RAMP-ATTRIBUTED desync
+			// episode (slew witness armed - duty was rising at this
+			// limit when the loop broke) halves the configured ramp
+			// (floor fine 0.1%/ms) for the rest of the power cycle.
 			if ((duty_cycle - last_duty_cycle) > max_duty_cycle_change) {
 				duty_cycle = last_duty_cycle + max_duty_cycle_change;
 			}

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -34,6 +34,14 @@ volatile uint32_t fault_stall_trips = 0;
 /* Acquisition-rail early-desync count (see faultNoteEarlyDesync). */
 static uint8_t acq_fail_desyncs;
 
+/* Ramp-attribution state (see the declarations in faults.h). */
+volatile uint8_t fault_ramp_slew_witness_ms;
+volatile uint8_t fault_ramp_halves;
+volatile uint8_t fault_acq_resist_events;
+volatile uint8_t fault_acq_soften;
+/* Previous 1 kHz duty sample for the slew witness. */
+static uint16_t ramp_witness_prev_duty;
+
 uint32_t faultErrorCount(void)
 {
 	return desync_happened + fault_stall_trips;
@@ -126,11 +134,14 @@ void faultUpdateBemfTimeoutPolicy(void)
 		//
 		// Also clear the acquisition-rail partial batch: otherwise 19 early
 		// desyncs, a pilot cut, then one more early desync on the next blip
-		// would fire a JUMP-sized charge (and permanent ramp-halve) as if
-		// the cut never happened. Match episode-bucket pilot semantics.
+		// would fire a JUMP-sized charge (and another startup-soften step)
+		// as if the cut never happened. Match episode-bucket pilot
+		// semantics - and forgive the soften itself: zero throttle is the
+		// pilot dealing with whatever was resisting the start.
 		desync_episode_bucket = 0;
 		desync_restart_holdoff_ms = 0;
 		acq_fail_desyncs = 0;
+		fault_acq_soften = 0;
 	}
 	if (zero_crosses > 100 && adjusted_input < 200) {
 		bemf_timeout_happened = 0;
@@ -187,10 +198,16 @@ void faultUpdateBemfTimeoutPolicy(void)
  * ~20/s rate a genuinely stuck loop produces it still charges once a second.
  * The point of this rail is to make the failure VISIBLE to the escalation
  * machinery (bucket, holdoff, latch), not to be the fastest path to the latch.
- * The side effect that most helps a too-fast tune finally clear acquisition is
- * the permanent ramp back-off inside faultDesyncEpisodeCharge; established-run
- * rails (blind/grind/stall) still need zero_crosses > 100 and only help once
- * the loop actually gets past that gate.
+ * The side effect that most helps a struggling start finally clear
+ * acquisition is the startup soften inside faultDesyncEpisodeCharge
+ * (fault_acq_soften) - acquisition-scoped and forgiven on success, because a
+ * start that cannot complete is at least as likely mechanically resisted
+ * (grass, debris) as mis-tuned, and duty is near-always slewing during a
+ * start so the slew witness cannot separate the two there. The PERMANENT
+ * learned halve is reserved for established-run episodes with the witness
+ * armed; established-run rails (blind/grind/stall) still need
+ * zero_crosses > 100 and only help once the loop actually gets past that
+ * gate.
  *
  * This constant is a starting point from SITL and wants bench calibration
  * against real hard starts before release.
@@ -201,6 +218,19 @@ void faultUpdateBemfTimeoutPolicy(void)
  */
 #define ACQ_FAIL_DESYNC_LIMIT 20
 #define ACQ_FAIL_CLEAR_ZC 500
+
+/*
+ * Ramp-attribution slew witness window. From the start of a too-fast
+ * transient to its episode charge: ~15 ms electrically silent, the ZC
+ * window closes within ~3 commutations, then jump detection and the charge
+ * run on the next main pass - tens of ms end to end. 100 ms covers that
+ * with margin, and a snap-induced grind keeps re-arming it (every power-cut
+ * release re-slews at the limit), while at steady duty it decays to 0 in
+ * 100 ms so a load-dragged desync at cruise reads witness 0.
+ */
+#define RAMP_ATTR_WITNESS_MS 100
+/* Acquisition soften cap: 3 right-shifts of the startup vcomp (/8). */
+#define ACQ_SOFTEN_MAX 3
 
 /*
  * Blind-GRIND rail. The episode rail above only sees DISCRETE failures
@@ -271,26 +301,58 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
 	desync_episode_drain_ms = 0;
 	desync_episode_apply_backoff();
 
-	// Learned ramp back-off: a desync episode means the configured ramp
-	// outran what this motor/prop can follow, and no reactive signal can
-	// catch it in time (the first ~15 ms of a too-fast transient are
-	// electrically silent - see the note at the slew limiter in
-	// control_loop.c). Halve each regime's duty step per episode (floor
-	// 1) instead of slamming to the fine rate on the first charge - a
-	// single fluke desync should not kill stick authority for the rest
-	// of the power cycle, and half may already be enough for many props.
-	// Once every regime is at 1, force fine mode (ramp_divider = 9) so
-	// the floor is the bench-proven 0.1%/ms rate rather than coarse 1
-	// (still ~1 duty unit every control tick). Deliberately not cleared
-	// at zero throttle (unlike the bucket): re-arming the fast ramp
-	// would re-desync on the next transient. A settings write reruns
-	// loadEEpromSettings and restores the configured values - retuning
-	// is the way back within a session.
-	max_ramp_startup = max_ramp_startup > 1 ? (uint8_t)(max_ramp_startup / 2) : 1;
-	max_ramp_low_rpm = max_ramp_low_rpm > 1 ? (uint8_t)(max_ramp_low_rpm / 2) : 1;
-	max_ramp_high_rpm = max_ramp_high_rpm > 1 ? (uint8_t)(max_ramp_high_rpm / 2) : 1;
-	if (max_ramp_startup <= 1 && max_ramp_low_rpm <= 1 && max_ramp_high_rpm <= 1) {
-		ramp_divider = 9;
+	// Learned ramp back-off, gated on ATTRIBUTION. A desync only teaches
+	// "the configured ramp outran what this motor/prop can follow" when
+	// the ramp was actually in play: the slew witness (sampled in
+	// faultDesyncEpisodeTick1kHz) says duty was rising at >= 75% of the
+	// active regime's limit within the last RAMP_ATTR_WITNESS_MS. A
+	// too-fast transient always charges inside that window (no reactive
+	// signal can catch it earlier - the first ~15 ms are electrically
+	// silent, see the slew-limiter note in control_loop.c), and a
+	// snap-induced grind keeps re-arming it through the power-cut
+	// release/re-slew cycle. What the witness excludes is the
+	// load-not-tune episode: a mechanical obstruction (grass, line wrap)
+	// dragging an established run down at STEADY duty. Halving there
+	// stores a wrong lesson for the whole power cycle - and on the
+	// production tune (max_ramp 20 -> all regimes 2) a single halve IS
+	// the fine-rate floor, a silent 20x slew-authority cut with no
+	// telemetry and every other counter self-healing (crashed a vehicle
+	// taking off after a ground spool in long grass).
+	//
+	// ACQ_FAIL episodes never take the permanent halve: duty is
+	// near-always slewing during a start, so the witness cannot separate
+	// resisted from mis-tuned there. They take fault_acq_soften instead -
+	// a startup-regime-only back-off (consumed in
+	// runtimeTransientGovernorTick) that is forgiven by the first genuine
+	// acquisition (ACQ_FAIL_CLEAR_ZC) or pilot zero throttle - which
+	// preserves the "soften until it finally acquires" escalation for an
+	// honestly bad tune without neutering the session after the
+	// obstruction is gone.
+	//
+	// Halve each attributed episode's regimes (floor 1); once every
+	// regime is at 1, force fine mode (ramp_divider = 9) so the floor is
+	// the bench-proven 0.1%/ms rate. Deliberately not cleared at zero
+	// throttle (unlike the bucket): re-arming the fast ramp would
+	// re-desync on the next transient. A settings write reruns
+	// loadEEpromSettings and restores the configured values - retuning is
+	// the way back within a session.
+	if (kind == DESYNC_EPISODE_ACQ_FAIL) {
+		if (fault_acq_soften < ACQ_SOFTEN_MAX) {
+			fault_acq_soften++;
+		}
+		if (fault_acq_resist_events < 255) {
+			fault_acq_resist_events++;
+		}
+	} else if (fault_ramp_slew_witness_ms) {
+		max_ramp_startup = max_ramp_startup > 1 ? (uint8_t)(max_ramp_startup / 2) : 1;
+		max_ramp_low_rpm = max_ramp_low_rpm > 1 ? (uint8_t)(max_ramp_low_rpm / 2) : 1;
+		max_ramp_high_rpm = max_ramp_high_rpm > 1 ? (uint8_t)(max_ramp_high_rpm / 2) : 1;
+		if (max_ramp_startup <= 1 && max_ramp_low_rpm <= 1 && max_ramp_high_rpm <= 1) {
+			ramp_divider = 9;
+		}
+		if (fault_ramp_halves < 255) {
+			fault_ramp_halves++;
+		}
 	}
 
 	if (desync_episode_bucket >= DESYNC_EPISODE_LIMIT) {
@@ -320,10 +382,45 @@ void faultNoteEarlyDesync(void)
 void faultDesyncEpisodeTick1kHz(void)
 {
 #ifndef BRUSHED_MODE
+	/* Ramp-attribution slew witness: is duty rising at (near) the active
+	 * regime's limit? Sampled here at 1 kHz so the comparison is directly
+	 * per-ms: a regime step of vcomp per (ramp_divider + 1) 20 kHz ticks
+	 * is vcomp * 20 / (ramp_divider + 1) duty units per ms. Arm at >= 75%
+	 * of that (rise * 4 >= budget * 3, integer-robust at the fine floor
+	 * where the budget is 2/ms). Rising only: power cuts and throttle
+	 * chops slew down hard, and the lesson under attribution is about
+	 * upward authority. Regime pick mirrors the 20 kHz slew limiter in
+	 * tenKhzRoutine. A rise below the limit means the ramp was not the
+	 * binding constraint, so a desync then teaches nothing about it. */
+	{
+		const uint16_t d = duty_cycle;
+		const int32_t rise = (int32_t)d - (int32_t)ramp_witness_prev_duty;
+		ramp_witness_prev_duty = d;
+		uint8_t step;
+		if (zero_crosses < 150 || last_duty_cycle < 150) {
+			step = max_ramp_startup_vcomp;
+		} else if (average_interval > 500) {
+			step = max_ramp_low_rpm_vcomp;
+		} else {
+			step = max_ramp_high_rpm_vcomp;
+		}
+		const uint16_t budget = (uint16_t)(((uint16_t)step * 20u) / (uint8_t)(ramp_divider + 1u));
+		if (running && rise > 0 && (uint32_t)rise * 4u >= (uint32_t)budget * 3u) {
+			fault_ramp_slew_witness_ms = RAMP_ATTR_WITNESS_MS;
+		} else if (fault_ramp_slew_witness_ms) {
+			fault_ramp_slew_witness_ms--;
+		}
+	}
+
 	/* A loop that got solidly established did acquire, whatever roughness
-	 * it passed through on the way - forgive the whole batch. */
+	 * it passed through on the way - forgive the whole batch, and the
+	 * acquisition-scoped startup soften with it: whatever was resisting
+	 * the start (or however mis-tuned it looked) is no longer preventing
+	 * acquisition, and startup slew must not stay degraded into the
+	 * flight that follows. */
 	if (zero_crosses > ACQ_FAIL_CLEAR_ZC) {
 		acq_fail_desyncs = 0;
+		fault_acq_soften = 0;
 	}
 	if (desync_restart_holdoff_ms > 0) {
 		desync_restart_holdoff_ms--;

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -34,14 +34,8 @@ volatile uint32_t fault_stall_trips = 0;
 /* Acquisition-rail early-desync count (see faultNoteEarlyDesync). */
 static uint8_t acq_fail_desyncs;
 
-/* Ramp-attribution state (see the declarations in faults.h). */
-volatile uint8_t fault_ramp_slew_witness_ms;
-volatile uint8_t fault_ramp_halves;
+/* "Start resisted" counter (see the declaration in faults.h). */
 volatile uint8_t fault_acq_resist_events;
-/* Previous 1 kHz samples for the slew witness (applied duty / setpoint). */
-static uint16_t ramp_witness_prev_duty;
-static uint16_t ramp_witness_prev_sp;
-static uint8_t ramp_witness_demand_ms;
 
 uint32_t faultErrorCount(void)
 {
@@ -195,17 +189,14 @@ void faultUpdateBemfTimeoutPolicy(void)
  * 2-4 rough desyncs acquiring, so 20 is unambiguously abnormal, while at the
  * ~20/s rate a genuinely stuck loop produces it still charges once a second.
  * The point of this rail is to make the failure VISIBLE to the escalation
- * machinery (bucket, holdoff, latch), not to be the fastest path to the latch.
- * The side effect that most helps a struggling start finally clear
- * acquisition is the startup soften inside faultDesyncEpisodeCharge
- * (fault_acq_soften) - acquisition-scoped and forgiven on success, because a
- * start that cannot complete is at least as likely mechanically resisted
- * (grass, debris) as mis-tuned, and duty is near-always slewing during a
- * start so the slew witness cannot separate the two there. The PERMANENT
- * learned halve is reserved for established-run episodes with the witness
- * armed; established-run rails (blind/grind/stall) still need
- * zero_crosses > 100 and only help once the loop actually gets past that
- * gate.
+ * machinery (bucket, holdoff, latch) and to the fault_acq_resist_events
+ * counter, not to be the fastest path to the latch. It deliberately does
+ * nothing to the ramp: a start that cannot complete is at least as likely
+ * mechanically resisted (grass, debris) as mis-tuned, and duty is
+ * near-always slewing during a start, so there is no signal here that
+ * separates the two - see faultDesyncEpisodeCharge. Established-run rails
+ * (blind/grind/stall) still need zero_crosses > 100 and only engage once
+ * the loop actually gets past that gate.
  *
  * This constant is a starting point from SITL and wants bench calibration
  * against real hard starts before release.
@@ -216,24 +207,6 @@ void faultUpdateBemfTimeoutPolicy(void)
  */
 #define ACQ_FAIL_DESYNC_LIMIT 20
 #define ACQ_FAIL_CLEAR_ZC 500
-
-/*
- * Ramp-attribution slew witness window. From the start of a too-fast
- * transient to its episode charge: ~15 ms electrically silent, the ZC
- * window closes within ~3 commutations, then jump detection and the charge
- * run on the next main pass - tens of ms end to end. 100 ms covers that
- * with margin, and a snap-induced grind keeps re-arming it (every power-cut
- * release re-slews at the limit), while at steady duty it decays to 0 in
- * 100 ms so a load-dragged desync at cruise reads witness 0.
- */
-#define RAMP_ATTR_WITNESS_MS 100
-/*
- * Commanded-demand window (witness condition ii). Covers the lag between a
- * setpoint step and the applied duty reaching the limiter's max rate, plus
- * the charge latency, without being so long that a static-setpoint recovery
- * re-slew falls inside a stale window.
- */
-#define RAMP_ATTR_DEMAND_MS 60
 
 /*
  * Blind-GRIND rail. The episode rail above only sees DISCRETE failures
@@ -304,63 +277,42 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
 	desync_episode_drain_ms = 0;
 	desync_episode_apply_backoff();
 
-	// Learned ramp back-off, gated on ATTRIBUTION. A desync only teaches
-	// "the configured ramp outran what this motor/prop can follow" when
-	// the ramp was actually in play: the slew witness (sampled in
-	// faultDesyncEpisodeTick1kHz) says duty was rising at >= 75% of the
-	// active regime's limit within the last RAMP_ATTR_WITNESS_MS. A
-	// too-fast transient always charges inside that window (no reactive
-	// signal can catch it earlier - the first ~15 ms are electrically
-	// silent, see the slew-limiter note in control_loop.c), and a
-	// snap-induced grind keeps re-arming it through the power-cut
-	// release/re-slew cycle. What the witness excludes is the
-	// load-not-tune episode: a mechanical obstruction (grass, line wrap)
-	// dragging an established run down at STEADY duty. Halving there
-	// stores a wrong lesson for the whole power cycle - and on the
-	// production tune (max_ramp 20 -> all regimes 2) a single halve IS
-	// the fine-rate floor, a silent 20x slew-authority cut with no
-	// telemetry and every other counter self-healing (crashed a vehicle
-	// taking off after a ground spool in long grass).
+	// NO PERSISTENT LEARNED STATE. An episode charges the escalation
+	// machinery above (bucket -> holdoff -> latch) and nothing else: the
+	// configured ramp, and every other tuning parameter, is left exactly as
+	// loadEEpromSettings set it. This is a deliberate reversal of the
+	// learned ramp back-off that used to live here (each episode halved
+	// every regime's duty step for the rest of the power cycle, flooring at
+	// fine 0.1%/ms).
 	//
-	// ACQ_FAIL episodes never touch the ramp at all: duty is near-always
-	// slewing during a start, so the witness cannot separate a resisted
-	// start from a mis-tuned one there, and a permanent halve is exactly
-	// the wrong default for the resisted case. They only charge the
-	// episode machinery (bucket -> holdoff -> latch), which already bounds
-	// an unstartable motor, plus the fault_acq_resist_events counter so
-	// the condition is at least visible.
+	// Why it is gone, on a multirotor specifically: the halve is per-ESC
+	// state that the flight controller cannot see. The mixer assumes
+	// symmetric actuators, so one ESC that has learned a slower ramp than
+	// its three siblings is an asymmetric vehicle with no way to report it.
+	// That is not a hypothetical - it crashed a vehicle taking off after a
+	// ground spool in long grass, where prop obstruction at STEADY duty
+	// dragged an established run down and the episode was misread as "ramp
+	// too fast". On the production tune (max_ramp 20 -> all regimes 2) one
+	// halve already IS the fine-rate floor: a silent 20x slew-authority cut.
 	//
-	// A startup-only ramp SOFTEN was tried here and removed as
-	// unimplementable in the coarse domain: on the production tune
-	// max_ramp_startup is 2, and the voltage compensation in
-	// runtimeTransientGovernorTick divides it toward the floor on any pack
-	// above 4S (GOV_RAMP_VREF_CV 1480; at 6S scale_q8 = 170, so
-	// (2 * 170) >> 8 = 1). There is no headroom left to shift away either
-	// before or after that scale - a real startup soften has to stretch
-	// ramp_divider instead, which means touching the 20 kHz limiter, and
-	// the bench note at control_loop.c:471 is explicit that adding code
-	// there disturbs F051 startup.
+	// An attribution gate was tried first (a slew witness requiring the
+	// limiter to be binding on rising demand before halving) and it does
+	// narrow the misattribution, but it keeps the architecture: still
+	// per-ESC learned divergence, still invisible to the FC, still one
+	// wrong attribution away from the same asymmetry. The line drawn
+	// instead is TRANSIENT SELF-RECOVERING RESPONSES ONLY - the bucket,
+	// holdoff and latch all converge back to configured settings, so an
+	// ESC either behaves as configured or stops. A too-fast ramp is a
+	// tuning defect and gets fixed by retuning, not by each ESC quietly
+	// deciding its own limit mid-flight. This also keeps us on upstream
+	// AM32's fixed-ramp semantics rather than diverging further.
 	//
-	// Halve each attributed episode's regimes (floor 1); once every
-	// regime is at 1, force fine mode (ramp_divider = 9) so the floor is
-	// the bench-proven 0.1%/ms rate. Deliberately not cleared at zero
-	// throttle (unlike the bucket): re-arming the fast ramp would
-	// re-desync on the next transient. A settings write reruns
-	// loadEEpromSettings and restores the configured values - retuning is
-	// the way back within a session.
+	// ACQ_FAIL episodes additionally bump fault_acq_resist_events, which is
+	// a counter only - see faults.h for why that one has to survive the
+	// self-healing.
 	if (kind == DESYNC_EPISODE_ACQ_FAIL) {
 		if (fault_acq_resist_events < 255) {
 			fault_acq_resist_events++;
-		}
-	} else if (fault_ramp_slew_witness_ms) {
-		max_ramp_startup = max_ramp_startup > 1 ? (uint8_t)(max_ramp_startup / 2) : 1;
-		max_ramp_low_rpm = max_ramp_low_rpm > 1 ? (uint8_t)(max_ramp_low_rpm / 2) : 1;
-		max_ramp_high_rpm = max_ramp_high_rpm > 1 ? (uint8_t)(max_ramp_high_rpm / 2) : 1;
-		if (max_ramp_startup <= 1 && max_ramp_low_rpm <= 1 && max_ramp_high_rpm <= 1) {
-			ramp_divider = 9;
-		}
-		if (fault_ramp_halves < 255) {
-			fault_ramp_halves++;
 		}
 	}
 
@@ -391,59 +343,6 @@ void faultNoteEarlyDesync(void)
 void faultDesyncEpisodeTick1kHz(void)
 {
 #ifndef BRUSHED_MODE
-	/* Ramp-attribution slew witness. Two conditions, both required.
-	 *
-	 * (i) The slew limiter was actually BINDING: sample last_duty_cycle -
-	 * the APPLIED, post-clamp duty (control_loop.c:709) - not duty_cycle,
-	 * which at this call site (before the clamp at :651) still holds the
-	 * raw setpoint copy from :527 and so measures demand, not delivery.
-	 * Sampled at 1 kHz the comparison is directly per-ms: a regime step of
-	 * vcomp per (ramp_divider + 1) 20 kHz ticks is vcomp * 20 /
-	 * (ramp_divider + 1) duty units per ms. Arm at >= 75% (rise * 4 >=
-	 * budget * 3, integer-robust at the fine floor where the budget is
-	 * 2/ms). Rising only - power cuts and throttle chops slew down hard,
-	 * and the attribution question is about upward authority. Regime pick
-	 * mirrors the limiter.
-	 *
-	 * (ii) The demand was RISING: the setpoint moved up within the last
-	 * RAMP_ATTR_DEMAND_MS. Condition (i) alone cannot separate a commanded
-	 * ramp from the ESC's own recovery - a desync forces
-	 * last_duty_cycle = min_startup_duty / 2 (runtime_loop.c) and the climb
-	 * back is a max-rate rise against a STATIC setpoint. Without (ii) a
-	 * repeating obstruction cycle (desync -> restart -> re-slew -> desync
-	 * in the grass) would attribute every episode after the first to the
-	 * ramp, which is the exact misattribution this gate exists to stop.
-	 * The blind-step power cut does move the setpoint (setInput caps it,
-	 * then releases), so a grind still re-arms both conditions as intended.
-	 */
-	{
-		const uint16_t applied = last_duty_cycle;
-		const uint16_t sp = duty_cycle_setpoint;
-		const int32_t rise = (int32_t)applied - (int32_t)ramp_witness_prev_duty;
-		ramp_witness_prev_duty = applied;
-		if (sp > ramp_witness_prev_sp) {
-			ramp_witness_demand_ms = RAMP_ATTR_DEMAND_MS;
-		} else if (ramp_witness_demand_ms) {
-			ramp_witness_demand_ms--;
-		}
-		ramp_witness_prev_sp = sp;
-		/* Per-ms budget from the step the limiter ITSELF last selected
-		 * (control_loop.c:658-666). Reading max_duty_cycle_change rather
-		 * than re-deriving the regime here cannot drift out of sync with
-		 * the limiter, and costs no flash on a target with ~4 B of
-		 * headroom (see size-check-ark). ramp_divider is only ever 0
-		 * (coarse) or 9 (fine 0.1%/ms), so the per-ms rate is the step
-		 * either 20x or 2x - pick the two cases instead of a runtime
-		 * divide on M0. */
-		const uint16_t budget =
-			ramp_divider ? (uint16_t)((uint16_t)max_duty_cycle_change * 2u) : (uint16_t)((uint16_t)max_duty_cycle_change * 20u);
-		if (running && ramp_witness_demand_ms && rise > 0 && (uint32_t)rise * 4u >= (uint32_t)budget * 3u) {
-			fault_ramp_slew_witness_ms = RAMP_ATTR_WITNESS_MS;
-		} else if (fault_ramp_slew_witness_ms) {
-			fault_ramp_slew_witness_ms--;
-		}
-	}
-
 	/* A loop that got solidly established did acquire, whatever roughness
 	 * it passed through on the way - forgive the whole batch. */
 	if (zero_crosses > ACQ_FAIL_CLEAR_ZC) {

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -38,9 +38,10 @@ static uint8_t acq_fail_desyncs;
 volatile uint8_t fault_ramp_slew_witness_ms;
 volatile uint8_t fault_ramp_halves;
 volatile uint8_t fault_acq_resist_events;
-volatile uint8_t fault_acq_soften;
-/* Previous 1 kHz duty sample for the slew witness. */
+/* Previous 1 kHz samples for the slew witness (applied duty / setpoint). */
 static uint16_t ramp_witness_prev_duty;
+static uint16_t ramp_witness_prev_sp;
+static uint8_t ramp_witness_demand_ms;
 
 uint32_t faultErrorCount(void)
 {
@@ -134,14 +135,11 @@ void faultUpdateBemfTimeoutPolicy(void)
 		//
 		// Also clear the acquisition-rail partial batch: otherwise 19 early
 		// desyncs, a pilot cut, then one more early desync on the next blip
-		// would fire a JUMP-sized charge (and another startup-soften step)
-		// as if the cut never happened. Match episode-bucket pilot
-		// semantics - and forgive the soften itself: zero throttle is the
-		// pilot dealing with whatever was resisting the start.
+		// would fire a JUMP-sized charge as if the cut never happened.
+		// Match episode-bucket pilot semantics.
 		desync_episode_bucket = 0;
 		desync_restart_holdoff_ms = 0;
 		acq_fail_desyncs = 0;
-		fault_acq_soften = 0;
 	}
 	if (zero_crosses > 100 && adjusted_input < 200) {
 		bemf_timeout_happened = 0;
@@ -229,8 +227,13 @@ void faultUpdateBemfTimeoutPolicy(void)
  * 100 ms so a load-dragged desync at cruise reads witness 0.
  */
 #define RAMP_ATTR_WITNESS_MS 100
-/* Acquisition soften cap: 3 right-shifts of the startup vcomp (/8). */
-#define ACQ_SOFTEN_MAX 3
+/*
+ * Commanded-demand window (witness condition ii). Covers the lag between a
+ * setpoint step and the applied duty reaching the limiter's max rate, plus
+ * the charge latency, without being so long that a static-setpoint recovery
+ * re-slew falls inside a stale window.
+ */
+#define RAMP_ATTR_DEMAND_MS 60
 
 /*
  * Blind-GRIND rail. The episode rail above only sees DISCRETE failures
@@ -319,15 +322,24 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
 	// telemetry and every other counter self-healing (crashed a vehicle
 	// taking off after a ground spool in long grass).
 	//
-	// ACQ_FAIL episodes never take the permanent halve: duty is
-	// near-always slewing during a start, so the witness cannot separate
-	// resisted from mis-tuned there. They take fault_acq_soften instead -
-	// a startup-regime-only back-off (consumed in
-	// runtimeTransientGovernorTick) that is forgiven by the first genuine
-	// acquisition (ACQ_FAIL_CLEAR_ZC) or pilot zero throttle - which
-	// preserves the "soften until it finally acquires" escalation for an
-	// honestly bad tune without neutering the session after the
-	// obstruction is gone.
+	// ACQ_FAIL episodes never touch the ramp at all: duty is near-always
+	// slewing during a start, so the witness cannot separate a resisted
+	// start from a mis-tuned one there, and a permanent halve is exactly
+	// the wrong default for the resisted case. They only charge the
+	// episode machinery (bucket -> holdoff -> latch), which already bounds
+	// an unstartable motor, plus the fault_acq_resist_events counter so
+	// the condition is at least visible.
+	//
+	// A startup-only ramp SOFTEN was tried here and removed as
+	// unimplementable in the coarse domain: on the production tune
+	// max_ramp_startup is 2, and the voltage compensation in
+	// runtimeTransientGovernorTick divides it toward the floor on any pack
+	// above 4S (GOV_RAMP_VREF_CV 1480; at 6S scale_q8 = 170, so
+	// (2 * 170) >> 8 = 1). There is no headroom left to shift away either
+	// before or after that scale - a real startup soften has to stretch
+	// ramp_divider instead, which means touching the 20 kHz limiter, and
+	// the bench note at control_loop.c:471 is explicit that adding code
+	// there disturbs F051 startup.
 	//
 	// Halve each attributed episode's regimes (floor 1); once every
 	// regime is at 1, force fine mode (ramp_divider = 9) so the floor is
@@ -337,9 +349,6 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
 	// loadEEpromSettings and restores the configured values - retuning is
 	// the way back within a session.
 	if (kind == DESYNC_EPISODE_ACQ_FAIL) {
-		if (fault_acq_soften < ACQ_SOFTEN_MAX) {
-			fault_acq_soften++;
-		}
 		if (fault_acq_resist_events < 255) {
 			fault_acq_resist_events++;
 		}
@@ -382,30 +391,53 @@ void faultNoteEarlyDesync(void)
 void faultDesyncEpisodeTick1kHz(void)
 {
 #ifndef BRUSHED_MODE
-	/* Ramp-attribution slew witness: is duty rising at (near) the active
-	 * regime's limit? Sampled here at 1 kHz so the comparison is directly
-	 * per-ms: a regime step of vcomp per (ramp_divider + 1) 20 kHz ticks
-	 * is vcomp * 20 / (ramp_divider + 1) duty units per ms. Arm at >= 75%
-	 * of that (rise * 4 >= budget * 3, integer-robust at the fine floor
-	 * where the budget is 2/ms). Rising only: power cuts and throttle
-	 * chops slew down hard, and the lesson under attribution is about
-	 * upward authority. Regime pick mirrors the 20 kHz slew limiter in
-	 * tenKhzRoutine. A rise below the limit means the ramp was not the
-	 * binding constraint, so a desync then teaches nothing about it. */
+	/* Ramp-attribution slew witness. Two conditions, both required.
+	 *
+	 * (i) The slew limiter was actually BINDING: sample last_duty_cycle -
+	 * the APPLIED, post-clamp duty (control_loop.c:709) - not duty_cycle,
+	 * which at this call site (before the clamp at :651) still holds the
+	 * raw setpoint copy from :527 and so measures demand, not delivery.
+	 * Sampled at 1 kHz the comparison is directly per-ms: a regime step of
+	 * vcomp per (ramp_divider + 1) 20 kHz ticks is vcomp * 20 /
+	 * (ramp_divider + 1) duty units per ms. Arm at >= 75% (rise * 4 >=
+	 * budget * 3, integer-robust at the fine floor where the budget is
+	 * 2/ms). Rising only - power cuts and throttle chops slew down hard,
+	 * and the attribution question is about upward authority. Regime pick
+	 * mirrors the limiter.
+	 *
+	 * (ii) The demand was RISING: the setpoint moved up within the last
+	 * RAMP_ATTR_DEMAND_MS. Condition (i) alone cannot separate a commanded
+	 * ramp from the ESC's own recovery - a desync forces
+	 * last_duty_cycle = min_startup_duty / 2 (runtime_loop.c) and the climb
+	 * back is a max-rate rise against a STATIC setpoint. Without (ii) a
+	 * repeating obstruction cycle (desync -> restart -> re-slew -> desync
+	 * in the grass) would attribute every episode after the first to the
+	 * ramp, which is the exact misattribution this gate exists to stop.
+	 * The blind-step power cut does move the setpoint (setInput caps it,
+	 * then releases), so a grind still re-arms both conditions as intended.
+	 */
 	{
-		const uint16_t d = duty_cycle;
-		const int32_t rise = (int32_t)d - (int32_t)ramp_witness_prev_duty;
-		ramp_witness_prev_duty = d;
-		uint8_t step;
-		if (zero_crosses < 150 || last_duty_cycle < 150) {
-			step = max_ramp_startup_vcomp;
-		} else if (average_interval > 500) {
-			step = max_ramp_low_rpm_vcomp;
-		} else {
-			step = max_ramp_high_rpm_vcomp;
+		const uint16_t applied = last_duty_cycle;
+		const uint16_t sp = duty_cycle_setpoint;
+		const int32_t rise = (int32_t)applied - (int32_t)ramp_witness_prev_duty;
+		ramp_witness_prev_duty = applied;
+		if (sp > ramp_witness_prev_sp) {
+			ramp_witness_demand_ms = RAMP_ATTR_DEMAND_MS;
+		} else if (ramp_witness_demand_ms) {
+			ramp_witness_demand_ms--;
 		}
-		const uint16_t budget = (uint16_t)(((uint16_t)step * 20u) / (uint8_t)(ramp_divider + 1u));
-		if (running && rise > 0 && (uint32_t)rise * 4u >= (uint32_t)budget * 3u) {
+		ramp_witness_prev_sp = sp;
+		/* Per-ms budget from the step the limiter ITSELF last selected
+		 * (control_loop.c:658-666). Reading max_duty_cycle_change rather
+		 * than re-deriving the regime here cannot drift out of sync with
+		 * the limiter, and costs no flash on a target with ~4 B of
+		 * headroom (see size-check-ark). ramp_divider is only ever 0
+		 * (coarse) or 9 (fine 0.1%/ms), so the per-ms rate is the step
+		 * either 20x or 2x - pick the two cases instead of a runtime
+		 * divide on M0. */
+		const uint16_t budget =
+			ramp_divider ? (uint16_t)((uint16_t)max_duty_cycle_change * 2u) : (uint16_t)((uint16_t)max_duty_cycle_change * 20u);
+		if (running && ramp_witness_demand_ms && rise > 0 && (uint32_t)rise * 4u >= (uint32_t)budget * 3u) {
 			fault_ramp_slew_witness_ms = RAMP_ATTR_WITNESS_MS;
 		} else if (fault_ramp_slew_witness_ms) {
 			fault_ramp_slew_witness_ms--;
@@ -413,14 +445,9 @@ void faultDesyncEpisodeTick1kHz(void)
 	}
 
 	/* A loop that got solidly established did acquire, whatever roughness
-	 * it passed through on the way - forgive the whole batch, and the
-	 * acquisition-scoped startup soften with it: whatever was resisting
-	 * the start (or however mis-tuned it looked) is no longer preventing
-	 * acquisition, and startup slew must not stay degraded into the
-	 * flight that follows. */
+	 * it passed through on the way - forgive the whole batch. */
 	if (zero_crosses > ACQ_FAIL_CLEAR_ZC) {
 		acq_fail_desyncs = 0;
-		fault_acq_soften = 0;
 	}
 	if (desync_restart_holdoff_ms > 0) {
 		desync_restart_holdoff_ms--;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -395,6 +395,9 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 	}
 	uint16_t r;
 	r = (uint16_t)((max_ramp_startup * scale_q8) >> 8);
+	// Acquisition-scoped startup soften (faults.c): forgivable back-off
+	// while starts keep failing before acquisition, startup regime only.
+	r >>= fault_acq_soften;
 	max_ramp_startup_vcomp = r ? (uint8_t)r : 1;
 	r = (uint16_t)((max_ramp_low_rpm * scale_q8) >> 8);
 	max_ramp_low_rpm_vcomp = r ? (uint8_t)r : 1;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -187,7 +187,7 @@ void runtimeProcessDesyncCheck(void)
 			// faultHandleBemfIntervalStall): interval jumps while the
 			// loop is still acquiring (zc 11..100) are normal startup
 			// roughness on light motors - charging them stacks holdoff
-			// and ramp back-off onto honest starts until the bucket
+			// onto honest starts until the bucket
 			// latches a motor that never got going (SITL racer model
 			// reproduces this under plain dshot spool). Legacy desync
 			// handling below still restarts; only the episode
@@ -472,8 +472,11 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 	// The headroom bounds slip MAGNITUDE only; it cannot prevent a
 	// too-fast ramp from breaking lock (bench rpmhead-snap-40: even 1 V
 	// applied in 4 ms desyncs where 24 A reached gradually stays locked -
-	// the cliff is dV/dt, not level; that is the learned ramp back-off's
-	// job, faultDesyncEpisodeCharge).
+	// the cliff is dV/dt, not level). Nothing in flight bounds dV/dt
+	// except the configured slew limit itself: the learned back-off that
+	// used to claim that job was removed (faultDesyncEpisodeCharge), and
+	// reactive pacing cannot work at all (control_loop.c). dV/dt is set
+	// by the ramp regime schedule and has to be right by configuration.
 	uint16_t ceiling = 2000;
 	if (gov_conf >= GOV_CONF_ARM) {
 		uint32_t c = ((erpm * gov_slope_q10) >> 10) + ((scale_q8 * 405u) >> 8);

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -395,9 +395,6 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 	}
 	uint16_t r;
 	r = (uint16_t)((max_ramp_startup * scale_q8) >> 8);
-	// Acquisition-scoped startup soften (faults.c): forgivable back-off
-	// while starts keep failing before acquisition, startup regime only.
-	r >>= fault_acq_soften;
 	max_ramp_startup_vcomp = r ? (uint8_t)r : 1;
 	r = (uint16_t)((max_ramp_low_rpm * scale_q8) >> 8);
 	max_ramp_low_rpm_vcomp = r ? (uint8_t)r : 1;

--- a/Src/settings.c
+++ b/Src/settings.c
@@ -164,9 +164,16 @@ void loadEEpromSettings(void)
 		}
 
 		// Reset to compile defaults first so this load is idempotent: the
-		// eeprom value below only lowers (min semantics), and the learned
-		// ramp back-off (faultDesyncEpisodeCharge) clamps these at runtime
-		// - a settings write is the documented way to restore them.
+		// eeprom value below only lowers (min semantics). Nothing at
+		// runtime writes these - the ramp an ESC flies is the ramp
+		// configured here (see faultDesyncEpisodeCharge for why the
+		// learned back-off that used to clamp them was removed).
+		//
+		// NOTE the min semantics flatten the graded schedule: max_ramp 20
+		// (the current factory default, 2.0 %/ms) clamps ALL THREE regimes
+		// to 2, so the 2/6/16 startup->low->high progression in targets.h
+		// never engages and the ESC flies the startup rate at cruise.
+		// max_ramp >= 160 is what preserves the full progression.
 		max_ramp_startup = RAMP_SPEED_STARTUP;
 		max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;
 		max_ramp_high_rpm = RAMP_SPEED_HIGH_RPM;

--- a/scripts/am32_debug.py
+++ b/scripts/am32_debug.py
@@ -7,20 +7,35 @@ FLEXDEBUG_AM32_DEBUG1 = 100
 V1_FMT = '<BIHHHHiB'
 V1_FIELDS = ('ver', 'ci', 'ncmd', 'ninp', 'rx_errors', 'rxframe_error',
              'rx_ecode', 'adv')
+# Upstream PR#394 / ark-release v2: duty/input/ADC/flags.
 V2_FMT = V1_FMT + 'HHHHHB'
 V2_FIELDS = V1_FIELDS + ('duty', 'duty_max', 'adj_input',
                          'adc_current', 'adc_volts', 'flags')
+# ARK append-only after upstream v2 (version stays 2): start-resisted count.
+V2_ARK_FMT = V2_FMT + 'B'
+V2_ARK_FIELDS = V2_FIELDS + ('acq_resist_events',)
 
 
 def decode_debug1(data):
     '''return a dict of fields, or None if not a known debug1 layout'''
-    if len(data) == struct.calcsize(V1_FMT) and data[0] == 1:
+    data = bytes(data)
+    n = len(data)
+    v2 = struct.calcsize(V2_FMT)
+    v2_ark = struct.calcsize(V2_ARK_FMT)
+    if n == struct.calcsize(V1_FMT) and data[0] == 1:
         fmt, fields = V1_FMT, V1_FIELDS
-    elif len(data) == struct.calcsize(V2_FMT) and data[0] == 2:
-        fmt, fields = V2_FMT, V2_FIELDS
+    elif data[0] == 2 and n >= v2:
+        # Accept exact v2 or ARK-appended tail; ignore any further unknown
+        # bytes so future appends stay forward-compatible for this decoder.
+        if n >= v2_ark:
+            fmt, fields = V2_ARK_FMT, V2_ARK_FIELDS
+            data = data[:v2_ark]
+        else:
+            fmt, fields = V2_FMT, V2_FIELDS
+            data = data[:v2]
     else:
         return None
-    row = dict(zip(fields, struct.unpack(fmt, bytes(data))))
+    row = dict(zip(fields, struct.unpack(fmt, data)))
     del row['ver']
     if 'flags' in row:
         row['armed'] = row['flags'] & 1


### PR DESCRIPTION
## Problem

`faultDesyncEpisodeCharge()` halves every ramp regime on a desync episode, permanently for the power cycle. On the production tune the consequence is severe: `factory/ARK_4IN1_F051_eeprom_defaults.json` ships `max_ramp = 20`, which the min-semantics in `settings.c` turns into **all three regimes at 2**. One charge takes them to 1/1/1, which satisfies the all-at-1 condition in the *same call* and forces fine mode (`ramp_divider = 9`): **2 %/ms → 0.1 %/ms, a 20× slew-authority cut from a single episode.**

Everything else observable about an episode self-heals (bucket drains, holdoff ticks down, `acq_fail_desyncs` forgiven at zc 500, zero throttle clears the bucket). The one thing that persists is the one thing with **no telemetry anywhere**. Ground spool with props in long grass, clear the grass, take off: the FC commands a climb against motors with 1/20th slew response and nothing in any log says why. This is the suspected mechanism in a real crash on `ark-release`.

## Change

**The mechanism is removed.** A desync episode no longer changes the configured ramp, or any other tuning parameter.

The first version of this PR instead added an attribution gate — a 1 kHz slew witness, so only episodes where the limiter was demonstrably binding on rising demand could halve. That does narrow the misattribution, but per @dakejahl's review it keeps the architecture that is the actual problem: the halve is **per-ESC state the flight controller cannot see**, the mixer assumes symmetric actuators, and one ESC that has learned a slower ramp than its three siblings is an asymmetric vehicle with no way to report it. A narrower trigger is still one wrong attribution away from the same crash.

The line drawn instead: **transient, self-recovering responses only.** The witness is removed along with the halve rather than promoted to an opt-in eeprom setting — a new setting would diverge us further from upstream AM32 for a code path that would ship disabled.

**What still bounds a bad motor.** The always-on escalation path is untouched: episode bucket → restart holdoff → `ESC_FAULT_STUCK` latch. All of it converges back to configured settings, so an ESC either behaves as configured or stops. A ramp that outruns the motor is a tuning defect and is fixed by retuning.

**What is kept for observability.** `fault_acq_resist_events` — a counter only, no control effect. It is the one part of the episode machinery that does not self-heal, so a ground spool that was fought by grass or debris stays visible until power cycle and an FC can refuse takeoff on it. Surfaced in FlexDebug `debug1` v2 (append-only).

## Reviewer items from the first round

- **Slew soften was a no-op — removed** rather than relocated. `max_ramp_startup` is already 2 on the production tune, and `runtimeTransientGovernorTick` scales it toward the floor on any pack above 4S (`GOV_RAMP_VREF_CV` 1480; at 6S `scale_q8 = 170`, so `(2 * 170) >> 8 = 1`). There is no headroom to shift on **either** side of the vcomp scale. A real startup soften has to stretch `ramp_divider`, i.e. touch the 20 kHz limiter, and the bench note at `control_loop.c:471` is explicit about what that does to F051 startup.
- **Witness sampled the wrong signal.** Confirmed: `faultDesyncEpisodeTick1kHz` runs after the `duty_cycle = duty_cycle_setpoint` copy and before the slew clamp, so it measured demand, not delivery. Moot now that the witness is gone, but it was fixed in `e302ac6` first and the finding is what made the deeper problem visible.
- **Test gated on the wrong counter** (`desync_happened` vs the stall-rail path). Fixed in `e302ac6`; the replacement tests use `desync_episode_bucket`.
- **`DEBUG_RATE` defaults to 0**, so FlexDebug is default-dead as shipped. Still true and **still open** — see below.

## Still open

**Telemetry routing for `acq_resist_events`.** `debug_rate` defaults to 0 (`DroneCAN.c:152`) and gates the send, and it is absent from the factory eeprom, so the counter does not leave the ESC on a factory image. Both fixes have a cost that wants a product decision: setting `DEBUG_RATE` in the factory image adds a steady per-ESC CAN stream by default, while the `esc.Status` route needs a field — `error_count`'s semantics are documented as not-to-be-polluted, leaving `power_rating_pct` (hardcoded 0) or a new one. Not guessed at here.

## Tests

`Mcu/SITL/tests/test_ramp_settings_fixed.py` (replaces `test_ramp_attribution.py`) — three mutation checks, each of which fails if the halve is reintroduced:

1. **Slew path** — an episode charged while duty slews at the ramp limit, the exact condition the old gate treated as proof of "ramp too fast", leaves the configured ramp untouched. Also re-checks across the post-episode re-spool, which is itself a max-rate rise against a static setpoint. Requires the bucket to actually charge, so it cannot pass vacuously.
2. **Steady-duty path (the grass case)** — the ramp is untouched **and** the episode bucket still charges. Removing the learned part must not weaken the always-on protection.
3. **Acquisition rail** — `acq_resist` surfaces and the escalation path charges, with the ramp untouched. This assertion is now **unconditional**, which it could not be while the gate existed: the racer model occasionally peaks past zc 100 and would take a legitimate witness-armed halve, which is why the old test had to carve out that caveat.

## Verification

- `make size-check-ark`: PASS both variants, and this PR is now **48 B smaller than base** on each — HWCI_PERF **27332** vs 27380 on `ark-release` (260 B headroom, up from 48 B in the first round), release **26456** vs 26504. RAM identical to base (6744 / 6192).
- `make cppcheck`: PASS, no error/warning.
- `AM32_SITL_CAN` builds. ZC_STATS v6 wire format verified against a live (idle) SITL: 65-byte reply, version 6, ramp fields reading the expected 2/6/16/0 defaults.
- `make check_format`: the 4 reported files (`Mcu/f415/Src/ADC.c`, `Mcu/g431/Src/peripherals.c`, two under `Mcu/v203`) are untouched by this branch and are a local clang-format 18 version skew — CI's formatter was green on them at `e302ac6`.
- **SITL runtime tests NOT validated locally.** The dev-container harness never spins the motor — `test_dshot600_bidir_edt` fails with `rpm=0` at HEAD, and the new tests fail with `armed=0, running=0, zero_crosses=0`, same environmental blocker as during #62–#65. CI is the authority for this file. (The ramp-invariance assertion itself did exercise cleanly across ~300 samples locally without a false positive.)

Does not close #75.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smx8ZnWjz18sMzFU7j4iVq)_