### PR TITLE
fix(dshot): EDT current telemetry in 1 A increments

### DIFF
--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -276,7 +276,7 @@ void make_dshot_package(uint16_t com_time)
 			telem_scheduler.temp_count++;
 
 			if (telem_scheduler.current_count >= CURRENT_EDT_RATE_DIVISOR) {
-				extended_frame_to_send = 0b0110 << 8 | (uint8_t)(actual_current / 50);
+				extended_frame_to_send = 0b0110 << 8 | (uint8_t)(actual_current / 100);
 				telem_scheduler.current_count = 0;
 			} else if (telem_scheduler.voltage_count >= VOLTAGE_EDT_RATE_DIVISOR) {
 				extended_frame_to_send = 0b0100 << 8 | (uint8_t)(battery_voltage / 25);


### PR DESCRIPTION
## Summary

- Port upstream [am32-firmware/AM32#403](https://github.com/am32-firmware/AM32/pull/403) (`a19f212`): DShot extended telemetry current uses `/ 100` instead of `/ 50`.
- `actual_current` is in centiamps, so the EDT current field now reports **1 A** increments (was 0.5 A).

## Test plan

- [ ] Confirm EDT current frames on a running ESC read ~2× lower than before for the same load (same physical amps → half the previous encoded value was wrong; now 1 A/LSB).
- [ ] Smoke DShot bi-dir telemetry still interleaves eRPM with temp/voltage/current.