### PR TITLE
feat(settings): raise the configurable motor pole-count ceiling to 128

### DIFF
--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -5,6 +5,20 @@
 #ifndef EEPROM_H_
 #	define EEPROM_H_
 
+/*
+ * Configurable magnet pole count (eeprom byte 27, not pole pairs).
+ *
+ * The minimum keeps the pole-pair math (motor_poles / 2) non-zero. The maximum
+ * is what the DroneCAN MOTOR_POLES parameter accepts and what the kv-derived
+ * schedules in settings.c treat as a plausible pole count; it covers the large
+ * high-pole-count outrunners and direct-drive/hub motors that go well past the
+ * 36 poles the configurators historically allowed. It stays below 0xff so an
+ * erased eeprom (0 or 0xff) still reads as out of range and the derived
+ * schedules fall back to their unrestricted / duty-proxy behavior.
+ */
+#	define MOTOR_POLES_MIN 2
+#	define MOTOR_POLES_MAX 128
+
 typedef union EEprom_u {
 	struct {
 		uint8_t reserved_0;	//0

--- a/Mcu/SITL/sitl_gui.py
+++ b/Mcu/SITL/sitl_gui.py
@@ -285,11 +285,12 @@ class ModelBuilderDialog(QDialog):
                   'the spec sheet. Typical: ~2400 (5-inch racer), '
                   '900-1000 (2216/2218 class), 400-700 (heavy lift).')
         self.poles = QSpinBox()
-        self.poles.setRange(2, 64)
+        self.poles.setRange(2, 128)
         self.poles.setValue(14)
         self.poles.setToolTip('Magnet pole count (not stator slots). Almost '
                               'all multirotor outrunners are 14; some large '
-                              'motors are 22 or 28.')
+                              'motors are 22 or 28, and direct-drive / hub '
+                              'motors run well past 36.')
         form.addRow('Poles', self.poles)
         field('resistance', 'Resistance line-to-line (mOhm)', '100',
               tip='Winding resistance line-to-line, milliohms, from the '

--- a/Mcu/SITL/sitl_params.py
+++ b/Mcu/SITL/sitl_params.py
@@ -57,7 +57,7 @@ PARAMS = [
     (24, 'PWM_FREQUENCY', 8, 48, 24, 'PWM carrier, kHz'),
     (25, 'STARTUP_POWER', 50, 150, 100, 'startup duty, percent'),
     (26, 'MOTOR_KV', 0, 255, 55, 'motor Kv, stored as (kv-20)/40'),
-    (27, 'MOTOR_POLES', 2, 64, 14, 'magnet poles (not pole pairs)'),
+    (27, 'MOTOR_POLES', 2, 128, 14, 'magnet poles (not pole pairs)'),
     (28, 'BRAKE_ON_STOP', 0, 1, 0, 'brake when throttle is zero'),
     (29, 'STALL_PROTECTION', 0, 1, 0, 'restart on stall'),
     (30, 'BEEP_VOLUME', 0, 11, 5, 'startup and beacon tone volume'),

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -161,7 +161,7 @@ static const struct parameter {
 	{"REQUIRE_ARMING", T_BOOL, 0, 1, 1, &eepromBuffer.can.require_arming},
 	{"REQUIRE_ZERO_THROTTLE", T_BOOL, 0, 1, 1, &eepromBuffer.can.require_zero_throttle},
 	{"MOTOR_KV", T_UINT16, 20, 10220, 2000, &motor_kv},
-	{"MOTOR_POLES", T_UINT8, 2, 64, 14, &eepromBuffer.motor_poles},
+	{"MOTOR_POLES", T_UINT8, MOTOR_POLES_MIN, MOTOR_POLES_MAX, 14, &eepromBuffer.motor_poles},
 
 	// motor_kv, low_cell_volt_cutoff, STARTUP_TUNE, CURRENT_LIMIT value need to adjust to dronecan gui tool
 	// motor_kv 1k/V

--- a/Src/settings.c
+++ b/Src/settings.c
@@ -215,9 +215,12 @@ void loadEEpromSettings(void)
 		 *
 		 * Out-of-range pole counts (an erased eeprom reads 0 or 0xff)
 		 * leave the envelope at zero, which map() treats as "always at
-		 * the high-rpm limit" - i.e. unrestricted, as before. 2..64 is
-		 * the range the DroneCAN MOTOR_POLES parameter accepts. */
-		if (eepromBuffer.motor_poles >= 2 && eepromBuffer.motor_poles <= 64) {
+		 * the high-rpm limit" - i.e. unrestricted, as before.
+		 * MOTOR_POLES_MIN..MOTOR_POLES_MAX is the range the DroneCAN
+		 * MOTOR_POLES parameter accepts (see eeprom.h). Worst case
+		 * 10220 kv * 128 poles / 544 = 2405 kerpm, well inside the
+		 * uint16 the levels are stored in. */
+		if (eepromBuffer.motor_poles >= MOTOR_POLES_MIN && eepromBuffer.motor_poles <= MOTOR_POLES_MAX) {
 			low_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (100U * 32U);
 			high_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (17U * 32U);
 		} else {
@@ -231,6 +234,7 @@ void loadEEpromSettings(void)
 	 * folding the centivolt scale and the Q12 fraction in gives
 	 *
 	 *   kerpm per centivolt, Q12 = kv * poles * 4096 / 200000
+	 *                            = kv * poles * 256 / 12500
 	 *
 	 * so the hot path is a multiply and a shift with no division. Real free-run
 	 * tops out a few percent below that ideal (IR drop, iron loss), which would
@@ -241,13 +245,21 @@ void loadEEpromSettings(void)
 	 * Computed after motor_kv has taken its final value (the cell-count
 	 * reductions above). Left at 0 - meaning "use the duty proxy" - for a kV
 	 * below the range the throttle limiter already treats as unusable, or a
-	 * pole count outside the 2..64 the DroneCAN MOTOR_POLES parameter accepts
-	 * (an erased eeprom reads 0 or 0xff). Worst case 10220 * 64 * 4096 fits
-	 * uint32 with ~1.6e9 spare before the 15/16 scale-down.
+	 * pole count outside the MOTOR_POLES_MIN..MOTOR_POLES_MAX the DroneCAN
+	 * MOTOR_POLES parameter accepts (an erased eeprom reads 0 or 0xff).
+	 *
+	 * The reduced 256/12500 form above is the one evaluated below rather than
+	 * the equivalent 4096/200000: both are the same rational number (divided
+	 * by 16) so they truncate to the same integer, but the 4096 numerator
+	 * overflows uint32 above ~102 poles, while 256 keeps the intermediate
+	 * inside uint32 for the whole byte range (10220 * 255 * 256 = 6.7e8,
+	 * against 4.29e9). Worst case scale is then 53372, so the 15/16
+	 * scale-down and the uint16 it lands in are both safe, as is the hot
+	 * path's (scale * centivolts) >> 12 on a 12S pack.
 	 */
 	advance_erpm_scale_q12 = 0;
-	if (motor_kv >= 300 && eepromBuffer.motor_poles >= 2 && eepromBuffer.motor_poles <= 64) {
-		uint16_t scale = (uint16_t)(((uint32_t)motor_kv * eepromBuffer.motor_poles * 4096u) / 200000u);
+	if (motor_kv >= 300 && eepromBuffer.motor_poles >= MOTOR_POLES_MIN && eepromBuffer.motor_poles <= MOTOR_POLES_MAX) {
+		uint16_t scale = (uint16_t)(((uint32_t)motor_kv * eepromBuffer.motor_poles * 256u) / 12500u);
 		advance_erpm_scale_q12 = (uint16_t)(scale - (scale >> 4)); /* * 15/16 */
 	}
 

--- a/scripts/esc_capture_gui.py
+++ b/scripts/esc_capture_gui.py
@@ -211,7 +211,7 @@ class MainWindow(QWidget):
         cg.addWidget(self.node_spin, 4, 1)
 
         self.poles_spin = QSpinBox()
-        self.poles_spin.setRange(2, 64)
+        self.poles_spin.setRange(2, 128)
         self.poles_spin.setValue(14)
         cg.addWidget(QLabel('Motor poles'), 5, 0)
         cg.addWidget(self.poles_spin, 5, 1)


### PR DESCRIPTION
## What

Raises the maximum motor pole count a user can configure from **64 to 128** (64 pole pairs), and gives the range names — `MOTOR_POLES_MIN` / `MOTOR_POLES_MAX` in `Inc/eeprom.h` — instead of the open-coded `2..64` that was repeated in three places.

Note on the 36: there is no 36-pole limit anywhere in this firmware. That cap comes from the configurators; the firmware-side ceiling was 64, set by the DroneCAN `MOTOR_POLES` parameter and mirrored by the two kv-derived schedules in `settings.c`. Both still excluded large direct-drive / hub motors, so this raises the firmware ceiling well clear of 36 and of 64. 128 stays below the `0xff` an erased eeprom reads, so out-of-range detection (0 or 0xff → schedules fall back) is unchanged.

## Changes

- `Inc/eeprom.h` — `MOTOR_POLES_MIN` (2) / `MOTOR_POLES_MAX` (128), documented against eeprom byte 27.
- `Src/DroneCAN/DroneCAN.c` — `MOTOR_POLES` parameter uses the macros, so the DroneCAN GUI now offers the full range.
- `Src/settings.c` — both gates use the macros. Above 64 poles the two schedules now compute instead of falling back to their "implausible pole count" behavior:
  - **throttle-restriction envelope**: worst case `10220 kv * 128 poles / 544 = 2405` kerpm, well inside the `uint16` the levels live in.
  - **advance normalization**: `kv * poles * 4096 / 200000` overflows `uint32` above ~102 poles, so the reduced `256 / 12500` form is evaluated instead. Same rational number (both terms divided by 16) and it truncates to the same integer for every accepted kv/pole pair, but the intermediate stays in `uint32` across the whole byte range (`10220 * 255 * 256 = 6.7e8` against `4.29e9`). Worst-case scale becomes 53372, leaving the 15/16 scale-down, the `uint16` it lands in, and the hot path's `(scale * centivolts) >> 12` on a 12S pack all in range.
- `Mcu/SITL/sitl_params.py`, `Mcu/SITL/sitl_gui.py`, `scripts/esc_capture_gui.py` — pole-count ranges that mirrored the old 64 raised to 128.

No behavior change at or below 64 poles: the gates accept exactly what they did before, and the rewritten scale expression is bit-identical over the accepted kv range (checked exhaustively over poles 2..255 against the old form).

## Test

- `make AM32_SITL_CAN` builds clean; `make check_format` reports only the four pre-existing offenders under `Mcu/` (untouched here).
- SITL end-to-end (`AM32_SITL_CAN`, `heavy_13inch` model at 360 kv, DShot300, throttle 900): **46-pole** and **120-pole** configs both arm, start, and hold closed loop — 3545 rpm and 3427 rpm respectively — so the newly enabled envelope and advance normalization do not disturb startup or run.
- The DroneCAN parameter test (`Mcu/SITL/tests/test_params.py`) was not run: `pytest`/`dronecan` are not installed in this container.

Not changed: nothing clamps `motor_poles` itself, so an erased-eeprom `0` would still divide by zero in the sine-startup step delay and the rpm speed-control path. Pre-existing and out of scope here, but worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_015QhBe5oF2wsa5jVstLbEB1)_