### PR TITLE
feat(g431): ADC zero-cross path for below the comparator's floor

### DIFF
--- a/Inc/bemf_zc.h
+++ b/Inc/bemf_zc.h
@@ -8,6 +8,12 @@
 
 void PeriodElapsedCallback(void);
 void interruptRoutine(void);
+/* Commit an accepted zero crossing (mask the search, timestamp it, schedule
+ * the commutation). Split out of interruptRoutine so a detector other than the
+ * comparator EXTI edge can commit through the same path. zc_grid_comp
+ * back-dates the timestamp by that many INTERVAL_TIMER ticks when the detector
+ * knows the crossing happened before it was registered. */
+void bemfZcAcceptCrossing(uint16_t zc_grid_comp);
 void startMotor(void);
 /* Clear the acceleration trend used for the commutation point (bemf_zc.c).
  * Call next to every zero_crosses = 0 so a desync/coast cannot leave a

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -121,6 +121,58 @@
  * actually in use.
  */
 #	define ZC_SEARCH_BLANK_64THS 32
+/*
+ * ADC zero-cross detection for the floating phase (Mcu/g431/Src/bemf_adc.c).
+ * EXPERIMENTAL, off by default, never bench-run. Enable by defining
+ * USE_ADC_BEMF; below ADC_BEMF_MIN_INTERVAL the ADC path then owns the
+ * crossing search and the comparator EXTI stays masked for that step.
+ *
+ * The point is the low-rpm floor: comparator offset plus the 10 mV minimum
+ * hysteresis step stops producing an edge somewhere around 350-450 rpm on
+ * this article, and no filtering downstream recovers it. The ADC resolves
+ * 0.806 mV/LSB and returns a magnitude, so it both sees further down and can
+ * interpolate the crossing instant between two samples instead of reporting
+ * the grid position.
+ *
+ * !! The four channel numbers below are the one thing in this block that
+ * !! could not be verified from the tree. PA0/PA1 are ADC1_IN1/ADC1_IN2 and
+ * !! ADC2_IN1/ADC2_IN2, but PA4 and PA5 reach ADC2 only, and the exact
+ * !! indices are asserted from the G431 pin table, not confirmed - network
+ * !! policy blocks st.com from this environment. Check them against DS12589
+ * !! Table 13 (or CubeMX) before the first bench run. A wrong index reads a
+ * !! different pin and the path silently never finds a crossing.
+ */
+// #define USE_ADC_BEMF
+#	define ADC_BEMF_PHASE_A_CHANNEL LL_ADC_CHANNEL_13 /* PA5 -> ADC2_IN13 */
+#	define ADC_BEMF_PHASE_B_CHANNEL LL_ADC_CHANNEL_17 /* PA4 -> ADC2_IN17 */
+#	define ADC_BEMF_PHASE_C_CHANNEL LL_ADC_CHANNEL_1  /* PA0 -> ADC2_IN1 */
+#	define ADC_BEMF_COMMON_CHANNEL LL_ADC_CHANNEL_2   /* PA1 -> ADC2_IN2, SENS_COMMON */
+/*
+ * Sample point, in TIM1 ticks after the PWM period starts. Shares
+ * COMP_BLANK_TICKS because it wants the same thing the blank window wants:
+ * to be clear of the dead time and the high-side turn-on transient that ends
+ * it. The pair of conversions then takes 950 ns (2 x 19 ADC cycles at
+ * 40 MHz) = 152 TIM1 ticks, so the on-window has to be at least
+ * 160 + 152 = 312 ticks for the second conversion to complete before
+ * turn-off. At the default 24 kHz (arr 6665) that is 4.7 % duty - just under
+ * the 6 % startup tier where the stuck faults live, with little to spare.
+ */
+#	define ADC_BEMF_TRIGGER_TICKS COMP_BLANK_TICKS
+#	define ADC_BEMF_MIN_DUTY_TICKS (ADC_BEMF_TRIGGER_TICKS + 152)
+/*
+ * Hand off to the comparator above this speed: INTERVAL_TIMER ticks at 2 MHz,
+ * so 700 is a 350 us commutation interval, ~2040 rpm on 14 pole pairs. Above
+ * that the BEMF is comfortably clear of the comparator's floor and the
+ * comparator's continuous-time edge beats a once-per-PWM-period sample.
+ */
+#	define ADC_BEMF_MIN_INTERVAL 700
+/*
+ * Dead band around the crossing, in LSB. 8 LSB is 6.4 mV at the ADC, which
+ * on the 21:1 divider and the 2/3 on-window ratio is ~200 mV of phase BEMF,
+ * about 72 rpm. Samples inside the band are neither a reference nor a
+ * crossing; the interpolation spans them.
+ */
+#	define ADC_BEMF_MIN_LSB 8
 /* USART2 TX on PB3 @ 115200 — matches bootloader USE_DEBUG_UART (AM32-bootloader#60). */
 #	define USE_DEBUG_UART
 #	define USE_SERIAL_TELEMETRY

--- a/Inc/targets.h
+++ b/Inc/targets.h
@@ -127,20 +127,20 @@
  * USE_ADC_BEMF; below ADC_BEMF_MIN_INTERVAL the ADC path then owns the
  * crossing search and the comparator EXTI stays masked for that step.
  *
- * The point is the low-rpm floor: comparator offset plus the 10 mV minimum
- * hysteresis step stops producing an edge somewhere around 350-450 rpm on
- * this article, and no filtering downstream recovers it. The ADC resolves
- * 0.806 mV/LSB and returns a magnitude, so it both sees further down and can
- * interpolate the crossing instant between two samples instead of reporting
- * the grid position.
+ * The point is the low-rpm floor, and DS13122 Rev 4 Table 73 puts numbers on
+ * it: comparator input offset is -9..+3 mV over temperature and VDDA, and the
+ * smallest hysteresis step - HYST = 1, the one ST's headers call "10MV" - is
+ * 9 mV typical but up to 16 mV. Worst case that is a 25 mV dead zone against
+ * a signal running ~132 mV at 1000 rpm and falling linearly with speed, which
+ * is where the 350-450 rpm floor comes from. No filtering downstream recovers
+ * an edge that was never produced. The ADC resolves 0.806 mV/LSB and returns
+ * a magnitude, so it both sees further down and can interpolate the crossing
+ * instant between two samples instead of reporting the grid position.
  *
- * !! The four channel numbers below are the one thing in this block that
- * !! could not be verified from the tree. PA0/PA1 are ADC1_IN1/ADC1_IN2 and
- * !! ADC2_IN1/ADC2_IN2, but PA4 and PA5 reach ADC2 only, and the exact
- * !! indices are asserted from the G431 pin table, not confirmed - network
- * !! policy blocks st.com from this environment. Check them against DS12589
- * !! Table 13 (or CubeMX) before the first bench run. A wrong index reads a
- * !! different pin and the path silently never finds a crossing.
+ * Channel map confirmed against DS13122 Rev 4 (STM32G491) Table 12: PA0 and
+ * PA1 are IN1/IN2 on both ADCs, PA4 and PA5 reach ADC2 only, as IN17 and
+ * IN13. Note PA4/PA5 also carry DAC1_OUT1/OUT2 - neither DAC output is
+ * enabled on this target, and enabling one would drive the sense node.
  */
 // #define USE_ADC_BEMF
 #	define ADC_BEMF_PHASE_A_CHANNEL LL_ADC_CHANNEL_13 /* PA5 -> ADC2_IN13 */

--- a/Mcu/g431/Inc/bemf_adc.h
+++ b/Mcu/g431/Inc/bemf_adc.h
@@ -1,0 +1,49 @@
+/*
+ * bemf_adc.h - ADC zero-cross detection for the floating phase (STM32G4)
+ *
+ * Alternative low-RPM zero-cross detector for ARK_G431_CAN. See bemf_adc.c
+ * for what it does and why the comparator cannot do it. Compiled only when
+ * the target defines USE_ADC_BEMF; every hook below is a no-op otherwise.
+ */
+#ifndef BEMF_ADC_H_
+#define BEMF_ADC_H_
+
+#include <stdint.h>
+
+#include "targets.h"
+
+#ifdef USE_ADC_BEMF
+
+/* Bring up ADC2's injected group and the TIM1 OC4 trigger that fires it.
+ * Call after ADC_Init()/activateADC() (which own the shared ADC12 common
+ * block) and after MX_TIM1_Init(). */
+void bemfAdcInit(void);
+
+/* Take over the zero-cross search for the step that is about to run, if the
+ * ADC path is the better detector right now. Returns 1 when it has taken
+ * ownership, in which case the caller must leave the comparator EXTI masked.
+ * Called from enableCompInterrupts(). */
+uint8_t bemfAdcArm(void);
+
+/* End the search. Called from maskPhaseInterrupts(), so it runs on every
+ * accepted crossing, blind step and fault path without extra plumbing. */
+void bemfAdcDisarm(void);
+
+/* ISR body, called from ADC1_2_IRQHandler(). */
+void bemfAdcIrqHandler(void);
+
+/* Bench instrumentation: searches the ADC path owned, and crossings it
+ * committed. A gap between them is a search that timed out into a blind
+ * step. */
+uint32_t bemfAdcGetSearches(void);
+uint32_t bemfAdcGetAccepts(void);
+
+#else
+
+#	define bemfAdcInit() ((void)0)
+#	define bemfAdcArm() (0u)
+#	define bemfAdcDisarm() ((void)0)
+
+#endif /* USE_ADC_BEMF */
+
+#endif /* BEMF_ADC_H_ */

--- a/Mcu/g431/Src/bemf_adc.c
+++ b/Mcu/g431/Src/bemf_adc.c
@@ -93,11 +93,26 @@
  */
 #	define ADC_BEMF_MAX_SPAN 32u
 
+/*
+ * Consecutive owned steps that ended without committing a crossing before the
+ * path stands down for the rest of the run. This is the guard against silent
+ * failure - most concretely a wrong ADC channel index, which reads some other
+ * pin and simply never crosses. Without it the loop would blind-step forever
+ * on a path that is never going to work; with it, the damage is bounded to
+ * this many commutations and the comparator takes over exactly as if the
+ * feature were off.
+ */
+#	define ADC_BEMF_MAX_MISSES 8
+
 static uint16_t adc_ref_mag;  /* |differential| at the last pre-crossing sample */
 static uint16_t adc_span;     /* PWM periods since that sample */
 static uint32_t adc_searches; /* steps this path owned */
 static uint32_t adc_accepts;  /* crossings it committed */
 static uint8_t adc_armed;
+static uint8_t adc_pending; /* armed a search that has not committed yet */
+static uint8_t adc_misses;
+static uint8_t adc_stood_down;
+static uint8_t adc_discard; /* results to throw away after a restart (ES0523 2.6.7/2.6.8) */
 
 static uint32_t bemfAdcPhaseChannel(void)
 {
@@ -201,8 +216,38 @@ uint8_t bemfAdcArm(void)
 	 *    below that the second conversion straddles turn-off and returns
 	 *    freewheel garbage
 	 */
+	/* A fresh run - startup, or a restart through the stall rail - clears
+	 * the stand-down, so a transient bad patch does not disable the path
+	 * for the life of the boot. */
+	if (zero_crosses < 2) {
+		adc_stood_down = 0;
+		adc_misses = 0;
+		adc_pending = 0;
+	}
+	if (adc_stood_down) {
+		return 0;
+	}
+
 	if (average_interval < ADC_BEMF_MIN_INTERVAL || adjusted_duty_cycle < ADC_BEMF_MIN_DUTY_TICKS) {
 		return 0;
+	}
+
+	/*
+	 * The previous owned step is only known to have failed once the next
+	 * one comes round: adc_pending still set means that search ended in a
+	 * blind step rather than a commit.
+	 */
+	if (adc_pending) {
+		if (adc_misses < ADC_BEMF_MAX_MISSES) {
+			adc_misses++;
+		}
+		if (adc_misses >= ADC_BEMF_MAX_MISSES) {
+			adc_stood_down = 1;
+			adc_pending = 0;
+			return 0;
+		}
+	} else {
+		adc_misses = 0;
 	}
 
 	LL_ADC_INJ_StopConversion(ADC2);
@@ -213,6 +258,8 @@ uint8_t bemfAdcArm(void)
 	adc_ref_mag = 0;
 	adc_span = 0;
 	adc_armed = 1;
+	adc_pending = 1;
+	adc_discard = 1;
 	adc_searches++;
 
 	LL_ADC_ClearFlag_JEOS(ADC2);
@@ -228,6 +275,15 @@ void bemfAdcDisarm(void)
 	}
 	adc_armed = 0;
 	LL_ADC_DisableIT_JEOS(ADC2);
+	/*
+	 * ES0523 2.6.5 puts injected results in the wrong JDRx when JADSTP is
+	 * asserted at end of conversion AND the AHB-to-ADC clock ratio is
+	 * above 10. It does not apply here: AHB is 160 MHz and the ADC runs
+	 * from CKMODE = PCLK/4 = 40 MHz, a ratio of 4. Worth stating, because
+	 * the common disarm path does stop the group from inside the JEOS
+	 * interrupt - precisely the timing the erratum describes - so anyone
+	 * changing the ADC prescaler needs to come back to this.
+	 */
 	LL_ADC_INJ_StopConversion(ADC2);
 }
 
@@ -243,13 +299,32 @@ RAM_FUNC void bemfAdcIrqHandler(void)
 	}
 
 	/*
+	 * ES0523 2.6.7 / 2.6.8: the first conversion after a long idle gap or
+	 * after a stop/resume can be wrong - stale (>1 ms since the previous
+	 * conversion) or, worse, a read of internal channel 0 returning zero.
+	 * Both apply here by construction: the injected group is stopped
+	 * between searches, and at the intervals this path owns the gap is
+	 * routinely over 1 ms (a 350 rpm commutation is ~2 ms on 14 pole
+	 * pairs). A zero would read as a large differential of arbitrary sign,
+	 * which is exactly the kind of thing that becomes a false crossing.
+	 * Throw the first result of every search away. It costs one PWM period
+	 * out of a search window of at least ADC_BEMF_MIN_INTERVAL/2, and the
+	 * post-commutation blank below would usually have discarded it anyway
+	 * - "usually" not being a good enough reason to leave it to chance.
+	 */
+	if (adc_discard != 0) {
+		adc_discard--;
+		return;
+	}
+
+	/*
 	 * Same post-commutation blanking COMP1_2_3_IRQHandler applies to the
 	 * comparator edge: nothing before half the expected interval is a
 	 * crossing, it is the freewheel demag clamp on the phase that was just
 	 * released. Returning before the reference is taken also keeps demag
 	 * readings out of the interpolation.
 	 */
-	if (INTERVAL_TIMER->CNT <= (commutation_interval >> 1)) {
+	if (INTERVAL_TIMER->CNT <= ZC_SEARCH_BLANK(commutation_interval)) {
 		return;
 	}
 
@@ -322,7 +397,14 @@ RAM_FUNC void bemfAdcIrqHandler(void)
 		back = cap;
 	}
 
-	adc_armed = 0;
+	/*
+	 * Do NOT clear adc_armed here. bemfZcAcceptCrossing() masks the search
+	 * through maskPhaseInterrupts(), which is what disarms this path - and
+	 * bemfAdcDisarm() early-returns when adc_armed is already clear, so
+	 * clearing it first would leave the JEOS interrupt enabled and the
+	 * injected group converting for the rest of the step.
+	 */
+	adc_pending = 0;
 	adc_accepts++;
 	bemfZcAcceptCrossing((uint16_t)back);
 }

--- a/Mcu/g431/Src/bemf_adc.c
+++ b/Mcu/g431/Src/bemf_adc.c
@@ -1,0 +1,340 @@
+/*
+ * bemf_adc.c - ADC zero-cross detection for the floating phase (STM32G4)
+ *
+ * WHY
+ * ---
+ * The comparator path has a hard low-RPM floor that no amount of filtering or
+ * blanking moves. G4 comparator input offset is single-digit mV and the
+ * smallest hysteresis step is 10 mV, so once the differential BEMF presented
+ * to the comparator approaches their sum the edge simply stops being
+ * produced. On this article (360 KV, 14 pole pairs, 21:1 sense divider) that
+ * lands around 350-450 rpm, and it is why changeCompInput() has to keep
+ * hysteresis off at crawl - 10 mV was blocking real edges.
+ *
+ * The ADC sees the same node with 0.806 mV per LSB (12 bit, 3V3) and, more
+ * usefully, returns a MAGNITUDE rather than a sign. That buys three things
+ * the comparator cannot give:
+ *
+ *   1. Resolution below the comparator's floor. During the PWM on-window the
+ *      floating phase sits at Vbus/2 + e and SENS_COMMON at Vbus/2 + e/3, so
+ *      the pair differ by (2/3)e, or e/31.5 after the divider. At 350 rpm
+ *      that is ~31 mV = 38 LSB; at 150 rpm still ~16 LSB.
+ *   2. Common-mode rejection in software. Both nodes ride Vbus/2, and
+ *      subtracting them removes bus ripple that the comparator has to reject
+ *      with its own (fixed) input stage.
+ *   3. Sub-period timing. The comparator reports an edge whenever it happens;
+ *      the ADC samples on a grid, which would normally be worse. But two
+ *      samples that straddle the crossing give its position BETWEEN them by
+ *      linear interpolation, so the timestamp is not quantised to the PWM
+ *      period the way the turn-on pile-up in bemf_zc.c is.
+ *
+ * WHAT IT DOES NOT DO
+ * -------------------
+ * It does not sample in the PWM off-window. During freewheel both driven
+ * phases are clamped to ground, the floating node sits at (3/2)e and
+ * SENS_COMMON at e/2 - both near or below 0 V for half of every electrical
+ * revolution, which neither the ADC nor the comparator can resolve. That is
+ * the same reason bemf_zc.c says off-window crossings are invisible and only
+ * register at the next turn-on. Off-window sampling is not a lever on this
+ * hardware topology; the usable window is the PWM on-time, and the ADC path
+ * lives inside it exactly like the comparator does.
+ *
+ * Nor does it use the ADC's hardware oversampler. Averaging N SAR
+ * conversions multiplies the conversion time by N, and the on-window at the
+ * 6 % startup tier is only ~2.5 us wide. Averaging happens across PWM periods
+ * instead, in the sense that the interpolation uses two samples and the
+ * dead-band threshold rejects single-sample noise - and unlike a fixed
+ * oversampling ratio, that is naturally RPM-adaptive, because a slow rotor
+ * simply spends more periods approaching the crossing.
+ *
+ * HOW
+ * ---
+ * ADC2 is untouched by ADC_Init() on this target (ADC1 alone carries temp,
+ * Vbus and current), so the whole instance is available. Its injected group
+ * runs two ranks - floating phase, then SENS_COMMON - triggered from TIM1
+ * TRGO2 driven by OC4REF, which puts the sample pair at a chosen offset
+ * inside the on-window. Injected is the right group: it needs no DMA, it has
+ * its own trigger and result registers, and it would preempt rather than
+ * disturb a regular sequence if ADC2 ever gains one.
+ *
+ * Ownership is decided per step in bemfAdcArm(), called from
+ * enableCompInterrupts(). When the ADC path owns a step the comparator EXTI
+ * stays masked and this file commits the crossing through
+ * bemfZcAcceptCrossing() - the same path interruptRoutine() uses, so blind
+ * stepping, the miss bucket, the demag-late rail and the commutation schedule
+ * all behave identically. A search that finds nothing degrades into the
+ * existing missed-ZC deadline and a blind step; it cannot hang the loop.
+ */
+
+#include "bemf_adc.h"
+
+#ifdef USE_ADC_BEMF
+
+#	include "bemf_zc.h"
+#	include "common.h"
+#	include "main.h"
+#	include "motor_runtime.h"
+
+/*
+ * TIM1 runs at 160 MHz and INTERVAL_TIMER at 2 MHz, so one INTERVAL tick is
+ * 80 TIM1 ticks. Used to convert the interpolated fraction of a PWM period
+ * into the units bemfZcAcceptCrossing() back-dates in.
+ */
+#	define ADC_BEMF_TIM1_PER_INTERVAL_TICK 80u
+
+/*
+ * Cap on how many PWM periods may separate the last clearly-pre-crossing
+ * sample from the one that resolves the crossing. Saturating rather than
+ * discarding the reference matters: at crawl rpm the differential creeps
+ * through the dead band for many periods, and dropping the reference there
+ * would disable detection in exactly the case this path exists for. A
+ * saturated span under-estimates the back-date, which lands the timestamp
+ * slightly late - the safe direction.
+ */
+#	define ADC_BEMF_MAX_SPAN 32u
+
+static uint16_t adc_ref_mag;  /* |differential| at the last pre-crossing sample */
+static uint16_t adc_span;     /* PWM periods since that sample */
+static uint32_t adc_searches; /* steps this path owned */
+static uint32_t adc_accepts;  /* crossings it committed */
+static uint8_t adc_armed;
+
+static uint32_t bemfAdcPhaseChannel(void)
+{
+	if (step == 1 || step == 4) {
+		return ADC_BEMF_PHASE_C_CHANNEL;
+	}
+	if (step == 2 || step == 5) {
+		return ADC_BEMF_PHASE_A_CHANNEL;
+	}
+	return ADC_BEMF_PHASE_B_CHANNEL;
+}
+
+void bemfAdcInit(void)
+{
+	/*
+	 * TIM1 CH4 drives the sample point. PWM2 (inactive while CNT < CCR4)
+	 * makes OC4REF RISE at CNT == CCR4, which is what the ADC triggers on;
+	 * PWM1 would rise at CNT == 0, inside the dead time. CC4E is
+	 * deliberately left disabled - OC4REF is generated regardless, TRGO2
+	 * taps it internally, and TIM1_CH4's pin on this package is PA11,
+	 * which the board uses for FDCAN_RX.
+	 */
+	LL_TIM_OC_SetMode(TIM1, LL_TIM_CHANNEL_CH4, LL_TIM_OCMODE_PWM2);
+	LL_TIM_OC_SetCompareCH4(TIM1, ADC_BEMF_TRIGGER_TICKS);
+	LL_TIM_SetTriggerOutput2(TIM1, LL_TIM_TRGO2_OC4);
+
+	/*
+	 * ADC2 bring-up. The ADC12 common block (clock source and CKMODE =
+	 * PCLK/4 = 40 MHz) is already configured by ADC_Init() for ADC1 and is
+	 * shared, so it must not be re-initialised here.
+	 */
+	if (LL_ADC_IsEnabled(ADC2) == 0) {
+		LL_ADC_DisableDeepPowerDown(ADC2);
+		LL_ADC_EnableInternalRegulator(ADC2);
+		uint32_t wait_loop_index = ((LL_ADC_DELAY_INTERNAL_REGUL_STAB_US * (SystemCoreClock / (100000 * 2))) / 10);
+		while (wait_loop_index != 0) {
+			wait_loop_index--;
+		}
+
+		LL_ADC_StartCalibration(ADC2, LL_ADC_SINGLE_ENDED);
+		while (LL_ADC_IsCalibrationOnGoing(ADC2) != 0) {}
+		wait_loop_index = (LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES * 64) >> 1;
+		while (wait_loop_index != 0) {
+			wait_loop_index--;
+		}
+	}
+
+	LL_ADC_SetResolution(ADC2, LL_ADC_RESOLUTION_12B);
+	LL_ADC_SetDataAlignment(ADC2, LL_ADC_DATA_ALIGN_RIGHT);
+	LL_ADC_SetOverSamplingScope(ADC2, LL_ADC_OVS_DISABLE);
+
+	/*
+	 * Queue disabled so a JSQR write takes effect directly. With the queue
+	 * enabled (reset default) each write pushes a context, which is the
+	 * wrong model for a sequence that is rewritten once per commutation.
+	 * Must be set while JADSTART is clear, i.e. here.
+	 */
+	LL_ADC_INJ_SetQueueMode(ADC2, LL_ADC_INJ_QUEUE_DISABLE);
+	LL_ADC_INJ_SetSequencerDiscont(ADC2, LL_ADC_INJ_SEQ_DISCONT_DISABLE);
+	LL_ADC_INJ_SetSequencerLength(ADC2, LL_ADC_INJ_SEQ_SCAN_ENABLE_2RANKS);
+	LL_ADC_INJ_SetTriggerSource(ADC2, LL_ADC_INJ_TRIG_EXT_TIM1_TRGO2);
+	LL_ADC_INJ_SetTriggerEdge(ADC2, LL_ADC_INJ_TRIG_EXT_RISING);
+
+	/*
+	 * 6.5 ADC cycles at 40 MHz is 162 ns of sampling. The sense node is a
+	 * ~952 ohm source into the ~5 pF sample-and-hold, so the time constant
+	 * is ~10 ns and 162 ns settles well past 12-bit. Total per rank is
+	 * 6.5 + 12.5 = 19 cycles = 475 ns, so the pair completes 950 ns after
+	 * the trigger - the number ADC_BEMF_MIN_DUTY_TICKS is built from.
+	 */
+	static const uint32_t channels[4] = {ADC_BEMF_PHASE_A_CHANNEL, ADC_BEMF_PHASE_B_CHANNEL, ADC_BEMF_PHASE_C_CHANNEL,
+					     ADC_BEMF_COMMON_CHANNEL};
+	for (uint32_t i = 0; i < 4; i++) {
+		LL_ADC_SetChannelSamplingTime(ADC2, channels[i], LL_ADC_SAMPLINGTIME_6CYCLES_5);
+		LL_ADC_SetChannelSingleDiff(ADC2, channels[i], LL_ADC_SINGLE_ENDED);
+	}
+
+	LL_ADC_INJ_SetSequencerRanks(ADC2, LL_ADC_INJ_RANK_1, ADC_BEMF_PHASE_A_CHANNEL);
+	LL_ADC_INJ_SetSequencerRanks(ADC2, LL_ADC_INJ_RANK_2, ADC_BEMF_COMMON_CHANNEL);
+
+	if (LL_ADC_IsEnabled(ADC2) == 0) {
+		LL_ADC_Enable(ADC2);
+		while (LL_ADC_IsActiveFlag_ADRDY(ADC2) == 0) {}
+	}
+
+	/* Same priority class as the comparator EXTI it stands in for. */
+	NVIC_SetPriority(ADC1_2_IRQn, 0);
+	NVIC_EnableIRQ(ADC1_2_IRQn);
+}
+
+uint8_t bemfAdcArm(void)
+{
+	/*
+	 * Ownership, decided fresh at every arm rather than latched at
+	 * commutation, so a throttle or speed change takes effect on the next
+	 * step rather than the one after.
+	 *
+	 *  - slow enough that the comparator is near or past its floor, which
+	 *    is the only reason to pay for this path
+	 *  - enough on-window to fit the sample pair after the trigger offset;
+	 *    below that the second conversion straddles turn-off and returns
+	 *    freewheel garbage
+	 */
+	if (average_interval < ADC_BEMF_MIN_INTERVAL || adjusted_duty_cycle < ADC_BEMF_MIN_DUTY_TICKS) {
+		return 0;
+	}
+
+	LL_ADC_INJ_StopConversion(ADC2);
+	while (LL_ADC_INJ_IsStopConversionOngoing(ADC2) != 0) {}
+
+	LL_ADC_INJ_SetSequencerRanks(ADC2, LL_ADC_INJ_RANK_1, bemfAdcPhaseChannel());
+
+	adc_ref_mag = 0;
+	adc_span = 0;
+	adc_armed = 1;
+	adc_searches++;
+
+	LL_ADC_ClearFlag_JEOS(ADC2);
+	LL_ADC_EnableIT_JEOS(ADC2);
+	LL_ADC_INJ_StartConversion(ADC2);
+	return 1;
+}
+
+void bemfAdcDisarm(void)
+{
+	if (!adc_armed) {
+		return;
+	}
+	adc_armed = 0;
+	LL_ADC_DisableIT_JEOS(ADC2);
+	LL_ADC_INJ_StopConversion(ADC2);
+}
+
+RAM_FUNC void bemfAdcIrqHandler(void)
+{
+	if (LL_ADC_IsActiveFlag_JEOS(ADC2) == 0) {
+		return;
+	}
+	LL_ADC_ClearFlag_JEOS(ADC2);
+
+	if (!adc_armed) {
+		return;
+	}
+
+	/*
+	 * Same post-commutation blanking COMP1_2_3_IRQHandler applies to the
+	 * comparator edge: nothing before half the expected interval is a
+	 * crossing, it is the freewheel demag clamp on the phase that was just
+	 * released. Returning before the reference is taken also keeps demag
+	 * readings out of the interpolation.
+	 */
+	if (INTERVAL_TIMER->CNT <= (commutation_interval >> 1)) {
+		return;
+	}
+
+	/*
+	 * The on-window can collapse under the sample pair mid-search (a
+	 * throttle chop, or the low-rpm ceiling pulling duty down). Drop the
+	 * sample without ageing the reference: duty can recover inside the
+	 * same search, and a freewheel reading would otherwise be interpreted
+	 * as a crossing.
+	 */
+	if (adjusted_duty_cycle < ADC_BEMF_MIN_DUTY_TICKS) {
+		return;
+	}
+
+	const int32_t phase = (int32_t)LL_ADC_INJ_ReadConversionData12(ADC2, LL_ADC_INJ_RANK_1);
+	const int32_t common = (int32_t)LL_ADC_INJ_ReadConversionData12(ADC2, LL_ADC_INJ_RANK_2);
+
+	/*
+	 * Normalise so that positive always means "past the crossing",
+	 * whichever direction this step expects. During the on-window the pair
+	 * differ by (2/3)e, so the raw difference carries the sign of the
+	 * floating phase's BEMF: a rising step crosses from negative to
+	 * positive, a falling step the other way. This matches the comparator,
+	 * whose output is (SENS_COMMON > phase) and so reads high exactly when
+	 * the raw difference is negative.
+	 */
+	int32_t diff = phase - common;
+	if (!rising) {
+		diff = -diff;
+	}
+
+	if (adc_ref_mag != 0 && adc_span < ADC_BEMF_MAX_SPAN) {
+		adc_span++;
+	}
+
+	if (diff <= -(int32_t)ADC_BEMF_MIN_LSB) {
+		/* Unambiguously before the crossing - this is the reference the
+		 * interpolation will run from. */
+		adc_ref_mag = (uint16_t)(-diff);
+		adc_span = 0;
+		return;
+	}
+
+	if (diff < (int32_t)ADC_BEMF_MIN_LSB || adc_ref_mag == 0) {
+		/* Inside the dead band, or nothing to interpolate from yet. */
+		return;
+	}
+
+	/*
+	 * Straddled. The crossing lies between the reference sample and this
+	 * one, at the fraction ref/(ref + now) of the way across, so it
+	 * happened now/(ref + now) of the span ago. Converting the span from
+	 * PWM periods to INTERVAL_TIMER ticks gives the back-date directly.
+	 *
+	 * Worst case magnitudes: 4095 * 32 * 83 fits an unsigned 32-bit
+	 * product with room to spare.
+	 */
+	const uint32_t mag_now = (uint32_t)diff;
+	const uint32_t mag_ref = adc_ref_mag;
+	const uint32_t span = (adc_span != 0) ? adc_span : 1u;
+	const uint32_t period_ticks = (uint32_t)tim1_arr / ADC_BEMF_TIM1_PER_INTERVAL_TICK;
+
+	uint32_t back = (mag_now * span * period_ticks) / (mag_ref + mag_now);
+
+	/* Same backstop the comparator's pile-up estimate uses: a degenerate
+	 * interpolation must not be able to rewrite the timestamp by more than
+	 * a fraction of the interval it is measuring. */
+	const uint32_t cap = commutation_interval >> 2;
+	if (back > cap) {
+		back = cap;
+	}
+
+	adc_armed = 0;
+	adc_accepts++;
+	bemfZcAcceptCrossing((uint16_t)back);
+}
+
+uint32_t bemfAdcGetSearches(void)
+{
+	return adc_searches;
+}
+
+uint32_t bemfAdcGetAccepts(void)
+{
+	return adc_accepts;
+}
+
+#endif /* USE_ADC_BEMF */

--- a/Mcu/g431/Src/comparator.c
+++ b/Mcu/g431/Src/comparator.c
@@ -59,12 +59,24 @@ void maskPhaseInterrupts()
 
 void enableCompInterrupts()
 {
-	/* Below the comparator's usable floor the ADC path detects the
-	 * crossing instead; it owns the whole step and the EXTI stays masked,
-	 * so the two detectors can never both commit one. See bemf_adc.c. */
+#ifdef USE_ADC_BEMF
+	/*
+	 * Below the comparator's usable floor the ADC path detects the
+	 * crossing instead (see bemf_adc.c). Mask the EXTI explicitly on
+	 * takeover rather than assume the caller left it masked: every current
+	 * path does, but two live detectors could both commit the same
+	 * crossing, and that is not a bug worth leaving to an invariant held
+	 * somewhere else. Open-coded rather than calling maskPhaseInterrupts(),
+	 * which would disarm the search that was just armed.
+	 */
 	if (bemfAdcArm()) {
+		EXTI->IMR1 &= ~(1 << 21);
+		EXTI->IMR1 &= ~(1 << 22);
+		EXTI->PR1 = LL_EXTI_LINE_22;
+		EXTI->PR1 = LL_EXTI_LINE_21;
 		return;
 	}
+#endif
 	EXTI->IMR1 |= current_EXTI_LINE;
 }
 

--- a/Mcu/g431/Src/comparator.c
+++ b/Mcu/g431/Src/comparator.c
@@ -31,6 +31,7 @@
 
 #include "comparator.h"
 
+#include "bemf_adc.h"
 #include "common.h"
 #include "motor_runtime.h"
 #include "targets.h"
@@ -50,10 +51,20 @@ void maskPhaseInterrupts()
 	EXTI->IMR1 &= ~(1 << 22);
 	EXTI->PR1 = LL_EXTI_LINE_22;
 	EXTI->PR1 = LL_EXTI_LINE_21;
+	/* One place ends the zero-cross search for every caller - accepted
+	 * crossing, blind step, desync, stop - so the ADC detector needs no
+	 * plumbing of its own to stay in step with the comparator one. */
+	bemfAdcDisarm();
 }
 
 void enableCompInterrupts()
 {
+	/* Below the comparator's usable floor the ADC path detects the
+	 * crossing instead; it owns the whole step and the EXTI stays masked,
+	 * so the two detectors can never both commit one. See bemf_adc.c. */
+	if (bemfAdcArm()) {
+		return;
+	}
 	EXTI->IMR1 |= current_EXTI_LINE;
 }
 

--- a/Mcu/g431/Src/peripherals.c
+++ b/Mcu/g431/Src/peripherals.c
@@ -9,6 +9,7 @@
 
 #include "peripherals.h"
 
+#include "bemf_adc.h"
 #include "debug_uart.h"
 #include "gate_driver.h"
 #include "serial_telemetry.h"
@@ -691,6 +692,9 @@ void enableCorePeripherals()
 	ADC_Init();
 	enableADC_DMA();
 	activateADC();
+	/* After ADC_Init: the ADC12 common block it configures is shared, and
+	 * the BEMF path takes ADC2 on top of it. */
+	bemfAdcInit();
 #endif
 	LL_COMP_Enable(COMP2);
 	LL_COMP_Enable(COMP1);

--- a/Mcu/g431/Src/stm32g4xx_it.c
+++ b/Mcu/g431/Src/stm32g4xx_it.c
@@ -2,6 +2,7 @@
 #include "stm32g4xx_it.h"
 #include "ADC.h"
 #include "IO.h"
+#include "bemf_adc.h"
 #include "WS2812.h"
 #include "main.h"
 #include "targets.h"
@@ -109,6 +110,13 @@ void COMP1_2_3_IRQHandler(void)
 		LL_EXTI_ClearFlag_0_31(LL_EXTI_LINE_22);
 	}
 }
+
+#ifdef USE_ADC_BEMF
+void ADC1_2_IRQHandler(void)
+{
+	bemfAdcIrqHandler();
+}
+#endif
 
 void TIM6_DAC_IRQHandler(void)
 {

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -354,6 +354,29 @@ RAM_FUNC void interruptRoutine()
 		}
 	}
 #endif
+#if defined(MCU_F051) || defined(MCU_G431)
+	bemfZcAcceptCrossing(zc_grid_comp);
+#else
+	bemfZcAcceptCrossing(0);
+#endif
+}
+
+/*
+ * Commit an accepted zero crossing: stop the search, settle the miss/demag
+ * bookkeeping, timestamp the crossing and schedule the commutation.
+ *
+ * Split out of interruptRoutine() so a detector other than the comparator
+ * EXTI edge can commit a crossing through exactly the same path. zc_grid_comp
+ * back-dates thiszctime by that many INTERVAL_TIMER ticks, for a detector that
+ * knows the crossing physically happened before it was registered - the
+ * comparator's turn-on pile-up estimate, or the ADC path's interpolation
+ * between the samples that straddle the crossing.
+ */
+RAM_FUNC void bemfZcAcceptCrossing(uint16_t zc_grid_comp)
+{
+#if !defined(MCU_F051) && !defined(MCU_G431)
+	(void)zc_grid_comp;
+#endif
 	__disable_irq();
 	maskPhaseInterrupts();
 	zc_deadline_armed = 0; // COM_TIMER now times commutation, not the missed-ZC deadline

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -359,6 +359,20 @@ RAM_FUNC void interruptRoutine()
 #else
 	bemfZcAcceptCrossing(0);
 #endif
+	/*
+	 * Stays here rather than inside bemfZcAcceptCrossing:
+	 * HWCI_PERF_ZC_PHASE_CAPTURE() declares a local at the top of this
+	 * function that COMMIT consumes, so the pair cannot straddle a
+	 * function boundary. Position is unchanged either way - the accept
+	 * path's last act is __enable_irq(), and this still follows it.
+	 *
+	 * It also belongs to the comparator specifically. The histogram bins
+	 * the PWM phase at which an edge arrived, which is a property of an
+	 * asynchronous comparator edge. An ADC-detected crossing is always
+	 * registered at the same point in the period by construction, so it
+	 * has no phase to bin and deliberately does not record one.
+	 */
+	HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase
 }
 
 /*
@@ -438,7 +452,6 @@ RAM_FUNC void bemfZcAcceptCrossing(uint16_t zc_grid_comp)
 	SET_INTERVAL_TIMER_COUNT(0);
 	SET_AND_ENABLE_COM_INT(waitTime + 1); // enable COM_TIMER interrupt
 	__enable_irq();
-	HWCI_PERF_ZC_PHASE_COMMIT(); // accepted edge: bin its PWM phase
 }
 
 void bemfZcResetTrend(void)


### PR DESCRIPTION
Stacks on #79 (base is `feat/embed-g431-can-bootloader`, so the diff is the two ADC commits).

**Experimental, off by default, never bench-run.** With `USE_ADC_BEMF` undefined, `ARK_G431_CAN` is byte-identical to the parent commit.

## Why

The comparator has a floor that nothing downstream can move, and DS13122 Rev 4 Table 73 puts numbers on it: input offset **−9…+3 mV**, and the smallest hysteresis step (`HYST = 1`, the one ST's headers call `10MV`) is **9 mV typ but up to 16 mV**. Worst case that is a 25 mV dead zone against a signal running ~132 mV at 1000 rpm and falling linearly with speed — which is the 350–450 rpm floor, derived rather than estimated. No filtering downstream recovers an edge that was never produced.

The next hysteresis step up is 18 mV typ / 32 mV max, so that knob is out of room too (documented in #79).

The ADC sees the same node at 0.806 mV/LSB and returns a **magnitude** rather than a sign. During the PWM on-window the floating phase sits at `Vbus/2 + e` and SENS_COMMON at `Vbus/2 + e/3`, so the pair differ by `(2/3)e`. Having a magnitude also means the crossing instant can be **interpolated** between the two samples that straddle it, instead of being quantised to the sample that found it — the same quantisation the turn-on pile-up compensation in `bemf_zc.c` exists to undo.

## Two things this deliberately does not do

**It does not sample the PWM off-window.** During freewheel both driven phases are clamped to ground, the floating node sits at `(3/2)e` and SENS_COMMON at `e/2` — both near or below 0 V for half of every electrical revolution. That is why `bemf_zc.c` says off-window crossings are invisible, and it is a property of the sense topology, not of the comparator. "Sample only in the off window" is not a lever here for the ADC either.

**It does not use the hardware oversampler.** Averaging N conversions multiplies conversion time by N, and the on-window at the 6% startup tier is only ~2.5 µs. Averaging happens across PWM periods instead, which is naturally rpm-adaptive: a slow rotor spends more periods approaching the crossing.

## Implementation

ADC2 is untouched by `ADC_Init()` on this target (ADC1 alone carries temp / Vbus / current), so the instance is free. Its injected group runs two ranks — floating phase, then SENS_COMMON — triggered from TIM1 TRGO2 driven by OC4REF. CH4 is put in PWM2 so OC4REF rises at `CNT == CCR4` rather than at `CNT == 0` inside the dead time. `CC4E` stays disabled: OC4REF is generated regardless, and TIM1_CH4's pin here is PA11, which the board uses for FDCAN_RX.

Integration is **two hooks** in the G431 comparator driver, both already the canonical points every caller goes through:

- `enableCompInterrupts()` offers the step to `bemfAdcArm()`, which takes it only when the interval is slow enough to be near the floor and duty leaves room for the sample pair. On takeover it masks the EXTI explicitly, so the two detectors can never both commit one crossing.
- `maskPhaseInterrupts()` disarms.

To share the commit path, the tail of `interruptRoutine()` is split out as `bemfZcAcceptCrossing(zc_grid_comp)` with no behaviour change, so blind stepping, the miss bucket, the demag-late rail and the commutation schedule are identical whichever detector fired. The ADC path passes its interpolated back-date where the comparator passes its pile-up estimate, and repeats the same post-commutation blank (now `ZC_SEARCH_BLANK`, shared with the comparator ISR via #79).

## Failure behaviour

A search that finds nothing falls through to the existing missed-ZC deadline and a blind step. After **8 consecutive owned steps that commit nothing**, the path stands down until the next fresh run and the comparator takes over exactly as if the feature were off. That bounds the cost of any silent failure — most concretely a wrong channel index reading some other pin — to eight commutations instead of blind-stepping forever.

`bemfAdcGetSearches()` / `bemfAdcGetAccepts()` are there for the bench; a gap between them is a search that timed out.

## Datasheet / errata

**Channel map confirmed** against DS13122 Rev 4 (STM32G491) Table 12: PA0/PA1 are IN1/IN2 on both ADCs, PA4 and PA5 reach ADC2 only as **IN17** and **IN13**. Matches the defines. Noted in-tree that PA4/PA5 also carry DAC1_OUT1/OUT2 — neither enabled on this target, and enabling one would drive the sense node.

**ES0523 2.6.7 / 2.6.8** — first conversion after a >1 ms idle gap or a stop/resume can be stale, or can read internal channel 0 and return zero. Both apply here by construction: the group is stopped between searches, and at the intervals this path owns the gap is routinely over 1 ms (a 350 rpm commutation is ~2 ms on 14 pole pairs). A zero reads as a large differential of arbitrary sign — a false crossing waiting to happen. **Handled:** the first result of every search is discarded, costing one PWM period out of a window of at least `ADC_BEMF_MIN_INTERVAL/2`.

**ES0523 2.6.5** — wrong-JDRx on `JADSTP` at end of conversion requires an AHB-to-ADC clock ratio above 10. AHB is 160 MHz, the ADC runs at `PCLK/4` = 40 MHz, ratio 4, so it does not apply. Recorded at the disarm site, which *does* stop the group from inside the JEOS interrupt — exactly the timing the erratum describes — so a future prescaler change has to revisit it.

## Still open before bench

At the default 24 kHz (arr 6665) the sample pair needs ≥312 ticks of on-time, i.e. **4.7% duty**. That is just under the 6% startup tier where the stuck faults live, with little to spare. `ADC_BEMF_TRIGGER_TICKS` and the sampling time are the knobs if it turns out too tight.

## Cost

| | flag off | flag on |
|---|---|---|
| FLASH | 46565 B | 47749 B (+1184, 42.8% of region) |
| RAM | 7768 B | 7784 B (+16) |

The ISR runs once per PWM period only while a search is armed and the ADC owns the step.

## Verification

Verified in the built image: `CCR4 = 160` (TIM1+0x40), `CR2.MMS2 = OC4REF` (0x700000), ADC2 configured, `ADC1_2_IRQHandler` in the vector table.

With `USE_ADC_BEMF` undefined, `ARK_G431_CAN` is byte-identical to the parent commit. `ARK_4IN1_F051` `.text` is unchanged at 17568 B and `bemfZcAcceptCrossing` is absorbed by LTO there — link order shifts, size does not.

`make format`, cppcheck (0 hard findings), `check-codegen-ark` and `check-size-ark` pass with the flag both on and off.

**There is no SITL or HWCI coverage for this path** — G431 peripherals do not exist in either — so bench is the first and only test.