### PR TITLE
fix(zc): degrade on lost position + layered recovery (no aggressive blind cut)

### DIFF
--- a/Inc/bemf_zc.h
+++ b/Inc/bemf_zc.h
@@ -18,6 +18,20 @@ void bemfZcResetTrend(void);
 int32_t bemfZcGetTrend(void);
 uint32_t bemfZcGetPredicted(void);
 
+/*
+ * True while commutation_interval / e_com_time still carry EXTRAPOLATED
+ * intervals from blind steps rather than measured crossings.
+ *
+ * The jump-desync check in runtimeProcessDesyncCheck must not evaluate while
+ * this holds: a blind step's interval is a prediction the firmware made, not
+ * a measurement of the rotor, so feeding it to a detector that asks "did the
+ * measured interval jump?" makes our own dead reckoning look like evidence of
+ * desync. Upstream AM32 has no such detector interaction because it has no
+ * blind steps at all - suppressing here is what KEEPS upstream's jump-check
+ * semantics intact once blind stepping exists, not a divergence from them.
+ */
+uint8_t bemfZcAverageTainted(void);
+
 /* Saturating waitTime = interval/2 - advance (never underflows). Inline so
  * PeriodElapsedCallback (RAM_FUNC) does not call out to flash for it. */
 static inline uint16_t bemfZcWaitTimeFromInterval(uint32_t interval, uint16_t advance_ticks)

--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -45,64 +45,46 @@ void faultUpdateBemfTimeoutPolicy(void);
 
 /*
  * Main-loop stall: INTERVAL_TIMER_COUNT has run past the fixed stall window
- * while running. Increments bemf_timeout_happened and restarts ZC search.
+ * while running - no zero-cross evidence for BEMF_STALL_TICKS, including the
+ * dead-reckoning budget handoff from bemf_zc.c, which kicks INTERVAL_TIMER
+ * here when blind stepping has run out of position.
+ *
+ * This mirrors upstream AM32 exactly (Src/main.c, "INTERVAL_TIMER_COUNT >
+ * 45000"): increment bemf_timeout_happened, hand back to the poll-ZC path and
+ * re-acquire with the bridge still driving. It does NOT cut power and does not
+ * stop the motor at flight throttle - losing sync is not the same event as
+ * losing the rotor, and a coast on a quad is a dropped corner.
+ *
+ * The stop lives in faultHandleStuckRotorIfNeeded: repeated stalls with no
+ * healthy run in between mean poll mode is not finding crossings either, i.e.
+ * the rotor genuinely is not turning, and driving it is what cooks FETs.
+ * bemf_timeout_happened is the counter shared by both, throttle-scaled and
+ * cleared by faultUpdateBemfTimeoutPolicy - again upstream's policy verbatim.
  */
 void faultHandleBemfIntervalStall(void);
 
 /*
- * Episode-level desync rail (leaky bucket across restart cycles).
+ * Acquisition-phase desync counter ("start resisted") - OBSERVABILITY ONLY.
  *
- * Single desync episodes are already bounded (the dead-reckoning budget in
- * bemf_zc.c and the demag-late authority fade). A bad EEPROM tune can still loop forever:
- * restart → spool → desync spike → restart. Each episode charges this
- * bucket; healthy closed-loop time drains it; zero throttle (pilot
- * intervention) clears it. At the limit, latch ESC_FAULT_STUCK so drive
- * stays off until the fault path clears.
+ * A loop that desyncs BEFORE acquisition completes accumulates no state
+ * anywhere: every rail in the ZC path is gated on an established loop (the
+ * blind-step deadline needs zero_crosses >= 100 in bemf_zc.c, the BEMF
+ * headroom governor needs > 150 in runtime_loop.c, the dead-reckoning budget
+ * needs blind steps to exist at all). It restarts, reaches zc 20..50,
+ * desyncs, and repeats with every counter reading zero.
  *
- * charge kinds: jump-check desync, stall-rail trip of an established run
- * (zero_crosses > 100; includes the dead-reckoning budget handoff in
- * bemf_zc.c, which always follows an established closed loop), and future
- * demag-late saturation.
- */
-typedef enum {
-	DESYNC_EPISODE_JUMP = 0,
-	DESYNC_EPISODE_STALL_RAIL,
-	DESYNC_EPISODE_ACQ_FAIL,
-} desync_episode_kind_t;
-
-void faultDesyncEpisodeCharge(desync_episode_kind_t kind);
-
-/*
- * Acquisition-phase desync rail.
+ * Measured on the SITL racer_5inch model (dshot 700): ~20 desyncs per second
+ * sustained, zero_crosses never past 48.
  *
- * Every other rail in the ZC path is gated on an ESTABLISHED loop: the
- * blind-step deadline needs zero_crosses >= 100 (bemf_zc.c), the BEMF
- * headroom governor needs > 150 (runtime_loop.c), the dead-reckoning budget
- * needs blind steps to exist at all, and the episode charge
- * itself needs zc_at_desync > 100 (runtimeProcessDesyncCheck). A loop that
- * desyncs BEFORE acquisition completes therefore accumulates no state
- * anywhere - it restarts, reaches zc 20..50, desyncs, and repeats
- * indefinitely with every counter reading zero.
- *
- * Measured on the SITL racer_5inch model at HEAD (dshot 700): ~20 desyncs
- * per second sustained, zero_crosses never past 48, desync_episode_bucket
- * flat at 0 after 38 desyncs, so neither the restart backoff nor the latch
- * ever engages and the rotor limit-cycles at ~2.9k rpm indefinitely.
- *
- * The established-run gate is still correct for the JUMP charge - a few
- * interval jumps while acquiring are normal startup roughness on light
- * motors, and charging them stacks holdoff onto honest starts (the reason
- * for that gate, see faultDesyncEpisodeCharge). What was missing is a rail
- * scoped to the acquisition regime itself. Count early desyncs; a handful
- * is roughness and is forgiven the moment the loop genuinely acquires,
- * while a sustained inability to get past acquisition charges the SAME
- * episode bucket and so inherits the existing backoff and latch.
+ * Batches of early desyncs bump fault_acq_resist_events so an FC can refuse
+ * takeoff on a start that was fought (grass, debris, a wrong prop match). A
+ * handful is normal startup roughness and is forgiven the moment the loop
+ * genuinely acquires. It deliberately changes NOTHING about control - see the
+ * note on fault_acq_resist_events.
  */
 void faultNoteEarlyDesync(void);
-/* 1 kHz: drain bucket when closed-loop is healthy; tick restart holdoff. */
-void faultDesyncEpisodeTick1kHz(void);
-/* True while a post-desync coast is mandatory (caller must not re-start). */
-uint8_t faultDesyncRestartHoldoffActive(void);
+/* 1 kHz: forgive the early-desync batch once the loop is solidly established. */
+void faultAcqResistTick1kHz(void);
 
 /*
  * Stall-rail trips on an ESTABLISHED run this arm cycle - the same
@@ -121,16 +103,15 @@ extern volatile uint32_t fault_stall_trips;
  * batches of early desyncs that never reached acquisition - see
  * faultNoteEarlyDesync).
  *
- * This counter exists because it is the ONLY part of the episode machinery
- * that does not self-heal: bucket, holdoff and latch all converge back to
- * the configured settings within seconds of an obstruction clearing, so a
- * ground spool that was fought by grass or debris leaves no trace by the
- * time the vehicle is armed. A monotonic count lets an FC (or a human
- * reading telemetry) refuse takeoff on a start that was resisted.
+ * This counter exists because nothing else survives the event: the loop
+ * self-heals the moment an obstruction clears, so a ground spool that was
+ * fought by grass or debris leaves no trace by the time the vehicle is armed.
+ * A monotonic count lets an FC (or a human reading telemetry) refuse takeoff
+ * on a start that was resisted.
  *
- * Deliberately does NOT influence control: no episode kind changes the
- * configured ramp or any other tuning parameter. See the note in
- * faultDesyncEpisodeCharge for why persistent learned state was removed.
+ * Deliberately does NOT influence control - it is a counter and nothing else.
+ * Neither this nor any other fault path changes the configured ramp or any
+ * other tuning parameter; the ESC either behaves as configured or stops.
  *
  * Monotonic per power cycle (not cleared on arm) so the pre-takeoff history
  * survives to be read. volatile: written in ISR context (main-loop charge),
@@ -154,7 +135,7 @@ extern volatile uint8_t fault_acq_resist_events;
  * stall rail and would double-count one physical failure:
  *   - the dead-reckoning budget (bemf_zc.c) kicks INTERVAL_TIMER past
  *     BEMF_STALL_TICKS so the stall rail trips on the next main pass
- *   - the episode-rail latch is a CONSEQUENCE of accumulating the above, and
+ *   - the stuck-rotor latch is a CONSEQUENCE of accumulating the above, and
  *     is a state (ESC_FAULT_STUCK), not an independent event
  * Attribution between those sub-causes belongs in the AM32-reserved FlexDebug
  * payload, not in this scalar.

--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -60,8 +60,9 @@ void faultHandleBemfIntervalStall(void);
  * stays off until the fault path clears.
  *
  * charge kinds: jump-check desync, stall-rail trip of an established run
- * (zero_crosses > 100; includes the blind/miss limit handoff, which always
- * follows an established closed loop), and future demag-late saturation.
+ * (zero_crosses > 100; includes the dead-reckoning budget handoff in
+ * bemf_zc.c, which always follows an established closed loop), and future
+ * demag-late saturation.
  */
 typedef enum {
 	DESYNC_EPISODE_JUMP = 0,

--- a/Inc/faults.h
+++ b/Inc/faults.h
@@ -52,8 +52,8 @@ void faultHandleBemfIntervalStall(void);
 /*
  * Episode-level desync rail (leaky bucket across restart cycles).
  *
- * Single desync episodes are already bounded (blind-step cap, miss bucket,
- * demag-late power cut). A bad EEPROM tune can still loop forever:
+ * Single desync episodes are already bounded (the dead-reckoning budget in
+ * bemf_zc.c and the demag-late authority fade). A bad EEPROM tune can still loop forever:
  * restart → spool → desync spike → restart. Each episode charges this
  * bucket; healthy closed-loop time drains it; zero throttle (pilot
  * intervention) clears it. At the limit, latch ESC_FAULT_STUCK so drive
@@ -76,8 +76,8 @@ void faultDesyncEpisodeCharge(desync_episode_kind_t kind);
  *
  * Every other rail in the ZC path is gated on an ESTABLISHED loop: the
  * blind-step deadline needs zero_crosses >= 100 (bemf_zc.c), the BEMF
- * headroom governor needs > 150 (runtime_loop.c), the grind detector and
- * miss bucket both need blind steps to exist at all, and the episode charge
+ * headroom governor needs > 150 (runtime_loop.c), the dead-reckoning budget
+ * needs blind steps to exist at all, and the episode charge
  * itself needs zc_at_desync > 100 (runtimeProcessDesyncCheck). A loop that
  * desyncs BEFORE acquisition completes therefore accumulates no state
  * anywhere - it restarts, reaches zc 20..50, desyncs, and repeats
@@ -110,8 +110,8 @@ uint8_t faultDesyncRestartHoldoffActive(void);
  * Cleared with desync_happened on the armed 0->1 edge (see
  * faultErrorCountReset()).
  *
- * volatile: read from the main loop (telemetry) while the grind rail that
- * forces this trip runs in tenKhzRoutine (ISR context).
+ * volatile: read from the main loop (telemetry) while the ZC path that
+ * forces this trip runs in ISR context.
  */
 extern volatile uint32_t fault_stall_trips;
 
@@ -151,9 +151,8 @@ extern volatile uint8_t fault_acq_resist_events;
  *
  * Deliberately NOT additional addends, because each already funnels into the
  * stall rail and would double-count one physical failure:
- *   - blind-grind rail (faultDesyncEpisodeTick1kHz) kicks INTERVAL_TIMER to
- *     46000 so the stall rail is guaranteed to trip on the next main pass
- *   - blind-step / miss-bucket limit (bemf_zc.c) hands off the same way
+ *   - the dead-reckoning budget (bemf_zc.c) kicks INTERVAL_TIMER past
+ *     BEMF_STALL_TICKS so the stall rail trips on the next main pass
  *   - the episode-rail latch is a CONSEQUENCE of accumulating the above, and
  *     is a state (ESC_FAULT_STUCK), not an independent event
  * Attribution between those sub-causes belongs in the AM32-reserved FlexDebug

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -49,7 +49,13 @@
  * v4: appended the 32-bin PWM-phase histogram of accepted zero-crossings.
  * v5: appended esc_state + illegal edge counter (drive state machine).
  * v6: appended bidirectional DShot (BDShot) RX/TX health counters.
- * v7: appended zc_blind_steps (missed-ZC blind commutation counter). */
+ * v7: appended zc_blind_steps (missed-ZC blind commutation counter).
+ * v8: appended zc_demag_run + zc_demag_accepts, then REMOVED again. They were
+ *     added to test whether the wrong-phase grind was a demag-late lock; the
+ *     bench answered no (zc_demag_accepts froze through both captured
+ *     episodes), and the 8 bytes were needed for the per-commutation ZC trace
+ *     below, which is what the grind actually needs. Version stays at 7: the
+ *     layout is identical to v7 again. */
 #	define HWCI_PERF_VERSION 7u
 
 /* PWM-phase histogram bins (power of two: the binning multiply-shift and the
@@ -58,7 +64,8 @@
 
 /* Commands the host may write to hwci_perf.host_cmd (cleared by firmware). */
 #	define HWCI_CMD_NONE 0u
-#	define HWCI_CMD_RESET_STATS 0xA5u /* clear the min/max accumulators */
+#	define HWCI_CMD_RESET_STATS 0xA5u  /* clear the min/max accumulators */
+#	define HWCI_CMD_ARM_ZC_TRACE 0x5Au /* re-arm the per-commutation ZC trace */
 
 /*
  * Naturally-aligned layout (NOT packed): Cortex-M0 faults on unaligned word
@@ -160,9 +167,115 @@ typedef struct hwci_perf_s {
      * the BLHeli-style timeout-commutation path (zero on a healthy loop;
      * a short burst at commanded stop is the designed teardown). */
 	uint32_t zc_blind_steps; /* off 168: blind commutations       */
-} hwci_perf_t;			 /* total size: 172 bytes             */
+
+} hwci_perf_t; /* total size: 172 bytes             */
 
 extern volatile hwci_perf_t hwci_perf;
+
+/*
+ * =========================================================================
+ * PER-COMMUTATION ZC TRACE
+ * =========================================================================
+ *
+ * A separate symbol, NOT part of hwci_perf, deliberately: the 50 Hz perf poll
+ * must stay a small SWD read, and this buffer is read on demand by its own
+ * script only after a capture has triggered.
+ *
+ * WHY IT EXISTS. The false lock this bench reproduces on hard step inputs
+ * establishes itself faster than the perf poll can see. At ~2700 commutations
+ * per second, a 50 Hz poll is one sample per ~80 commutations, so the measured
+ * collapse (commutation_interval 527 -> 217 in one sample) is not one bad edge
+ * but dozens that cannot be separated. Every threshold in the minimum-interval
+ * gate has to be set against what the loop actually saw per commutation, and
+ * the first attempt at that gate was set by inference and was too loose: it
+ * tolerated 4x-early edges while the lock entered at ~2.4x, and because an
+ * ACCEPTED bogus edge still updates commutation_interval, the gate's own
+ * threshold ratcheted down with the lock (179 -> 142 -> 54 -> 21 -> 13 ticks).
+ *
+ * TRIGGER. Free-running ring while armed; the firmware freezes it ITSELF on
+ * the first accepted crossing whose interval is less than half the tracked
+ * estimate - the entry event - then records HWCI_ZC_TRACE_POST more events and
+ * stops. The buffer therefore holds the commutations either side of entry
+ * rather than the steady-state lock, which is what a host-side freeze would
+ * have caught (its detection latency is a whole poll period, ~20-40 ms, by
+ * which time the lock is long established).
+ *
+ * The trigger is INSTRUMENTATION ONLY. It reads state, freezes a buffer, and
+ * changes no control decision.
+ */
+#	define HWCI_ZC_TRACE_N 32u   /* power of two: index masks */
+#	define HWCI_ZC_TRACE_POST 8u /* events kept after the trigger */
+
+/* Event kinds. */
+#	define HWCI_ZC_EV_NONE 0u
+#	define HWCI_ZC_EV_ACCEPT 1u	  /* crossing passed gate + confirm loop */
+#	define HWCI_ZC_EV_REJ_MININT 2u  /* rejected: minimum-interval gate      */
+#	define HWCI_ZC_EV_REJ_CONFIRM 3u /* rejected: glitch-tolerant confirm    */
+#	define HWCI_ZC_EV_BLIND 4u	  /* blind (deadline-extrapolated) step   */
+#	define HWCI_ZC_EV_BUDGET 5u	  /* dead-reckoning budget handed off     */
+
+/*
+ * FOUR BYTES PER EVENT, and the omission is deliberate. The obvious extra
+ * field - the commutation_interval estimate at each event - is RECONSTRUCTIBLE
+ * on the host: every accepted interval is logged here and the estimate evolves
+ * from them by the fixed IIR in PeriodElapsedCallback, anchored on ci_at_arm
+ * below. Storing it per event cost 2 bytes x 64 slots and blew both the FLASH
+ * and RAM gates on the F051 (93.1% RAM against a 90% limit).
+ */
+typedef struct hwci_zc_ev_s {
+	uint16_t interval; /* INTERVAL_TIMER at the event, 0.5 us ticks   */
+	uint8_t kind;	   /* HWCI_ZC_EV_*                                 */
+	uint8_t duty8;	   /* duty_cycle >> 3, cheap applied-drive context */
+} hwci_zc_ev_t;		   /* 4 bytes */
+
+/*
+ * NO INITIALIZED FIELDS. This lives in .bss deliberately: any initializer,
+ * even just a magic word, puts the whole 400-byte object in .data and costs
+ * that much FLASH for its ROM copy - which overflowed the F051 image by 364
+ * bytes when it was tried. The host locates the buffer by ELF symbol and
+ * takes the entry count from the symbol size, exactly as it already does for
+ * hwci_perf, so neither a magic word nor a stored length is needed here.
+ */
+typedef struct hwci_zc_trace_s {
+	uint16_t write_idx; /* next slot; oldest entry when frozen+wrapped */
+	uint8_t frozen;	    /* 1 = trigger fired, buffer holds the entry   */
+	uint8_t post;	    /* events still to record after the trigger    */
+	uint32_t total;	    /* monotonic events ever written               */
+	uint8_t wrapped;    /* 1 = ring has filled at least once           */
+	uint8_t _pad;
+	uint16_t ci_at_arm; /* commutation_interval when the ring was armed;
+			     * the anchor the host replays the IIR from     */
+	hwci_zc_ev_t ev[HWCI_ZC_TRACE_N];
+} hwci_zc_trace_t;
+
+extern volatile hwci_zc_trace_t hwci_zc_trace;
+
+/* Record one event. Cheap enough for ISR context: a masked index increment and
+ * three stores, no division and no branch beyond the frozen check. */
+#	define HWCI_ZC_TRACE_EV(_kind, _interval)                                                                                         \
+		do {                                                                                                                       \
+			if (!hwci_zc_trace.frozen) {                                                                                       \
+				uint16_t _i = hwci_zc_trace.write_idx;                                                                     \
+				hwci_zc_trace.ev[_i].interval = (uint16_t)((_interval) > 65535u ? 65535u : (_interval));                   \
+				hwci_zc_trace.ev[_i].kind = (uint8_t)(_kind);                                                              \
+				hwci_zc_trace.ev[_i].duty8 = (uint8_t)(duty_cycle >> 3);                                                   \
+				_i = (uint16_t)((_i + 1u) & (HWCI_ZC_TRACE_N - 1u));                                                       \
+				hwci_zc_trace.write_idx = _i;                                                                              \
+				if (_i == 0u)                                                                                              \
+					hwci_zc_trace.wrapped = 1u;                                                                        \
+				hwci_zc_trace.total++;                                                                                     \
+				if (hwci_zc_trace.post && --hwci_zc_trace.post == 0u)                                                      \
+					hwci_zc_trace.frozen = 1u;                                                                         \
+			}                                                                                                                  \
+		} while (0)
+
+/* Arm the post-trigger countdown once, on the entry event. Called only from
+ * the accepted-crossing path, after the event above is recorded. */
+#	define HWCI_ZC_TRACE_TRIGGER()                                                                                                    \
+		do {                                                                                                                       \
+			if (!hwci_zc_trace.frozen && hwci_zc_trace.post == 0u)                                                             \
+				hwci_zc_trace.post = (uint8_t)HWCI_ZC_TRACE_POST;                                                          \
+		} while (0)
 
 /* Q16 phase-binning factor, (HWCI_ZC_PHASE_BINS << 16) / (tim1_arr + 1).
  * Recomputed from the main loop (HWCI_PERF_MAIN_LOOP snapshot branch, one
@@ -394,6 +507,12 @@ void hwci_perf_reset_stats(void);
 		do {                                                                                                                       \
 		} while (0)
 #	define HWCI_PERF_BLIND_STEP()                                                                                                     \
+		do {                                                                                                                       \
+		} while (0)
+#	define HWCI_ZC_TRACE_EV(_kind, _interval)                                                                                         \
+		do {                                                                                                                       \
+		} while (0)
+#	define HWCI_ZC_TRACE_TRIGGER()                                                                                                    \
 		do {                                                                                                                       \
 		} while (0)
 #	define HWCI_PERF_ZC_PHASE_CAPTURE()                                                                                               \

--- a/Inc/hwci_perf.h
+++ b/Inc/hwci_perf.h
@@ -213,6 +213,7 @@ extern volatile hwci_perf_t hwci_perf;
 #	define HWCI_ZC_EV_REJ_CONFIRM 3u /* rejected: glitch-tolerant confirm    */
 #	define HWCI_ZC_EV_BLIND 4u	  /* blind (deadline-extrapolated) step   */
 #	define HWCI_ZC_EV_BUDGET 5u	  /* dead-reckoning budget handed off     */
+#	define HWCI_ZC_EV_REJ_TRUST 6u	  /* rejected: untrusted-ZC (slew/demag)  */
 
 /*
  * FOUR BYTES PER EVENT, and the omission is deliberate. The obvious extra

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -57,6 +57,12 @@ extern volatile uint8_t zc_pre_seen;
 extern volatile uint8_t zc_demag_run;
 extern volatile uint32_t zc_demag_accepts;
 /*
+ * Consecutive alternations of the measured commutation interval - the
+ * signature of a wrong-phase lock. See the block comment above the detector
+ * in bemf_zc.c for why this is the only test that can see that state.
+ */
+extern volatile uint8_t zc_alt_run;
+/*
  * INTERVAL_TIMER ticks of dead reckoning since the rotor last reported its
  * position. Blind steps add their extrapolated interval, an accepted crossing
  * clears it (a demag-late one charges an interval instead - see bemf_zc.c).
@@ -70,6 +76,14 @@ extern volatile uint32_t zc_blind_ticks;
  * restart threshold in the ZC path; faults.c owns the rail itself.
  */
 #define BEMF_STALL_TICKS 45000u
+/*
+ * Consecutive interval alternations before the wrong-phase lock detector
+ * charges the position-confidence fade. One alternation is what a single
+ * missed crossing produces (T, 2T, 0.5T) and is legitimate; the bench
+ * captures of an actual grind ran to sixteen and beyond, so four is well
+ * clear of the benign case without waiting on the pathological one.
+ */
+#define ZC_ALT_RUN_MIN 4u
 extern uint8_t filter_level;
 extern uint8_t bad_count;
 extern uint8_t bad_count_threshold;
@@ -80,9 +94,6 @@ extern uint8_t changeover_step;
 extern uint8_t stuckcounter;
 /* uint32_t always: DroneCAN telemetry and SITL stats both use 32-bit. */
 extern uint32_t desync_happened;
-/* Cross-episode desync rail (faults.c); saturating charge, time-based drain. */
-extern volatile uint8_t desync_episode_bucket;
-extern volatile uint16_t desync_restart_holdoff_ms;
 
 /* --- duty / throttle --- */
 extern volatile uint16_t duty_cycle;

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -53,13 +53,23 @@ extern volatile uint32_t polling_mode_changeover;
 /* Missed-ZC blind-step fallback (bemf_zc.c) */
 extern volatile uint8_t zc_deadline_armed;
 extern volatile uint8_t zc_blind_steps;
-extern volatile uint8_t zc_miss_bucket;
 extern volatile uint8_t zc_pre_seen;
 extern volatile uint8_t zc_demag_run;
 extern volatile uint32_t zc_demag_accepts;
-/* Blind-grind rail (faults.c): blind steps this 100 ms window / cut hold */
-extern volatile uint8_t zc_blind_window_count;
-extern volatile uint16_t zc_grind_hold_ms;
+/*
+ * INTERVAL_TIMER ticks of dead reckoning since the rotor last reported its
+ * position. Blind steps add their extrapolated interval, an accepted crossing
+ * clears it (a demag-late one charges an interval instead - see bemf_zc.c).
+ * Drives both the restart decision and how much duty authority the loop is
+ * allowed, so degradation is continuous instead of a set of trip points.
+ */
+extern volatile uint32_t zc_blind_ticks;
+/*
+ * Time without rotor position evidence before the loop is restarted through
+ * the startup path. This is upstream AM32's stall criterion and the only
+ * restart threshold in the ZC path; faults.c owns the rail itself.
+ */
+#define BEMF_STALL_TICKS 45000u
 extern uint8_t filter_level;
 extern uint8_t bad_count;
 extern uint8_t bad_count_threshold;

--- a/Inc/motor_runtime.h
+++ b/Inc/motor_runtime.h
@@ -57,12 +57,6 @@ extern volatile uint8_t zc_pre_seen;
 extern volatile uint8_t zc_demag_run;
 extern volatile uint32_t zc_demag_accepts;
 /*
- * Consecutive alternations of the measured commutation interval - the
- * signature of a wrong-phase lock. See the block comment above the detector
- * in bemf_zc.c for why this is the only test that can see that state.
- */
-extern volatile uint8_t zc_alt_run;
-/*
  * INTERVAL_TIMER ticks of dead reckoning since the rotor last reported its
  * position. Blind steps add their extrapolated interval, an accepted crossing
  * clears it (a demag-late one charges an interval instead - see bemf_zc.c).
@@ -76,14 +70,6 @@ extern volatile uint32_t zc_blind_ticks;
  * restart threshold in the ZC path; faults.c owns the rail itself.
  */
 #define BEMF_STALL_TICKS 45000u
-/*
- * Consecutive interval alternations before the wrong-phase lock detector
- * charges the position-confidence fade. One alternation is what a single
- * missed crossing produces (T, 2T, 0.5T) and is legitimate; the bench
- * captures of an actual grind ran to sixteen and beyond, so four is well
- * clear of the benign case without waiting on the pathological one.
- */
-#define ZC_ALT_RUN_MIN 4u
 extern uint8_t filter_level;
 extern uint8_t bad_count;
 extern uint8_t bad_count_threshold;

--- a/Makefile
+++ b/Makefile
@@ -101,42 +101,16 @@ ifeq ($(HWCI_PERF),1)
 CFLAGS_COMMON += -DHWCI_PERF
 endif
 
-# A/B rail switches (opt-in, off by default; production builds are unaffected).
+# Governor A/B switch (opt-in, off by default; production builds unaffected).
 #
-# ARK32 carries three protective rails that upstream AM32 does not, all of
-# which respond to a sustained miss/demag rate by taking authority away from
-# the throttle. On articles where they were tuned they keep the loop out of a
-# mistimed-lock current spiral; on an article that sits at their thresholds
-# they can turn a degraded-but-flying loop into a stop/restart cycle. These
-# switches compile them out one at a time so the difference can be measured
-# rather than argued about.
-#
-#   AB_NO_MISS_RAIL=1       Stop acting on the miss-rate bucket. The bucket is
-#                           still counted, so instrumentation still sees it -
-#                           only the restart it triggers is removed. The
-#                           consecutive-blind-step limit is UNTOUCHED, so
-#                           genuinely lost position still rails. This is the
-#                           "blind-step through a sustained miss rate instead
-#                           of restarting" experiment.
-#   AB_NO_GOVERNOR=1        Pin the BEMF-headroom ceiling at full authority,
-#                           so duty is never capped by the eRPM equilibrium
-#                           estimate. Tests the "rpm sticks at a level and
-#                           will not respond to more throttle" report.
-#   AB_NO_BLIND_DUTY_CUT=1  Remove the 250/500 protective duty cap taken on
-#                           untrusted steps. Needed to make the other two
-#                           legible: with it in, throttle still gets chopped
-#                           on every untrusted step and the A/B cannot tell
-#                           "did not restart" from "restarted less".
-#
-# These remove protection. They are for bench and instrumented flight only.
-ifeq ($(AB_NO_MISS_RAIL),1)
-CFLAGS_COMMON += -DAB_NO_MISS_RAIL
-endif
+# The miss-rate rail and the untrusted-step duty cliff that used to sit
+# alongside this are gone - replaced by the continuous dead-reckoning measure
+# in bemf_zc.c / control_loop.c. The BEMF-headroom governor is untouched by
+# that work and is still a hard ceiling, so keep a way to take it out of the
+# picture while bisecting a "rpm sticks at a level and will not respond to
+# more throttle" report.
 ifeq ($(AB_NO_GOVERNOR),1)
 CFLAGS_COMMON += -DAB_NO_GOVERNOR
-endif
-ifeq ($(AB_NO_BLIND_DUTY_CUT),1)
-CFLAGS_COMMON += -DAB_NO_BLIND_DUTY_CUT
 endif
 
 # Linker options

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,44 @@ ifeq ($(HWCI_PERF),1)
 CFLAGS_COMMON += -DHWCI_PERF
 endif
 
+# A/B rail switches (opt-in, off by default; production builds are unaffected).
+#
+# ARK32 carries three protective rails that upstream AM32 does not, all of
+# which respond to a sustained miss/demag rate by taking authority away from
+# the throttle. On articles where they were tuned they keep the loop out of a
+# mistimed-lock current spiral; on an article that sits at their thresholds
+# they can turn a degraded-but-flying loop into a stop/restart cycle. These
+# switches compile them out one at a time so the difference can be measured
+# rather than argued about.
+#
+#   AB_NO_MISS_RAIL=1       Stop acting on the miss-rate bucket. The bucket is
+#                           still counted, so instrumentation still sees it -
+#                           only the restart it triggers is removed. The
+#                           consecutive-blind-step limit is UNTOUCHED, so
+#                           genuinely lost position still rails. This is the
+#                           "blind-step through a sustained miss rate instead
+#                           of restarting" experiment.
+#   AB_NO_GOVERNOR=1        Pin the BEMF-headroom ceiling at full authority,
+#                           so duty is never capped by the eRPM equilibrium
+#                           estimate. Tests the "rpm sticks at a level and
+#                           will not respond to more throttle" report.
+#   AB_NO_BLIND_DUTY_CUT=1  Remove the 250/500 protective duty cap taken on
+#                           untrusted steps. Needed to make the other two
+#                           legible: with it in, throttle still gets chopped
+#                           on every untrusted step and the A/B cannot tell
+#                           "did not restart" from "restarted less".
+#
+# These remove protection. They are for bench and instrumented flight only.
+ifeq ($(AB_NO_MISS_RAIL),1)
+CFLAGS_COMMON += -DAB_NO_MISS_RAIL
+endif
+ifeq ($(AB_NO_GOVERNOR),1)
+CFLAGS_COMMON += -DAB_NO_GOVERNOR
+endif
+ifeq ($(AB_NO_BLIND_DUTY_CUT),1)
+CFLAGS_COMMON += -DAB_NO_BLIND_DUTY_CUT
+endif
+
 # Linker options
 LDFLAGS_COMMON := -specs=nano.specs $(LIBS) -Wl,--gc-sections -Wl,--print-memory-usage
 

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -64,7 +64,7 @@
     u16 magic 0x5356, u8 version=6, u8 pad, u32 zero_crosses,
       u32 commutation_interval, u32 dropped_edges, u32 desync_happened,
       u8 old_routine, u8 running, u8 armed, u8 zc_blind_steps,
-      u8 zc_miss_bucket, u8 zc_deadline_armed,
+      u8 zc_stale_q8, u8 zc_deadline_armed,
       u8 dcm_hold_ms, u8 pad2, u16 dcm_hold_value,       (v2 PR 62)
       u8 adv_kerpm_hold_ms, u8 pad3, u16 adv_kerpm_hold, (v3 PR 63)
       i32 zc_trend, u32 zc_predicted, u16 waitTime, u16 advance, (v4 PR 64)
@@ -581,7 +581,7 @@ void sitl_state_poll(void)
 			uint8_t running;
 			uint8_t armed;
 			uint8_t zc_blind_steps;
-			uint8_t zc_miss_bucket;
+			uint8_t zc_stale_q8;
 			uint8_t zc_deadline_armed;
 			uint8_t dcm_hold_ms;
 			uint8_t pad2;
@@ -619,7 +619,8 @@ void sitl_state_poll(void)
 			.running = running,
 			.armed = (uint8_t)armed,
 			.zc_blind_steps = zc_blind_steps,
-			.zc_miss_bucket = zc_miss_bucket,
+			/* dead-reckoning budget consumed, 0..255 (see zc_blind_ticks) */
+			.zc_stale_q8 = (uint8_t)((zc_blind_ticks >= BEMF_STALL_TICKS) ? 255u : (zc_blind_ticks * 255u) / BEMF_STALL_TICKS),
 			.zc_deadline_armed = zc_deadline_armed,
 			.dcm_hold_ms = dcm_hold_ms,
 			.dcm_hold_value = dcm_hold_value,

--- a/Mcu/SITL/Src/sitl_state.c
+++ b/Mcu/SITL/Src/sitl_state.c
@@ -72,8 +72,8 @@
       u16 gov_stuck_ms, u16 gov_release_ceil, u16 gov_unlatch_count (v5 PR 65)
       u8 max_ramp_startup, u8 max_ramp_low, u8 max_ramp_high,
       u8 ramp_divider, u8 max_ramp_startup_vcomp, u8 acq_resist,
-      u8 desync_episode_bucket                    (v6 ramp settings +
-                                                   episode observability)
+      u8 bemf_timeout_happened                    (v6 ramp settings +
+                                                   stall observability)
       Fields are only ever APPENDED and the version is bumped; clients
       that unpack a shorter prefix keep working unchanged (they
       length-check with >=).
@@ -599,15 +599,19 @@ void sitl_state_poll(void)
 			uint16_t gov_stuck_ms_v;
 			uint16_t gov_release_ceil_v;
 			uint16_t gov_unlatch_count_v;
-			/* v6: live ramp settings (so a test can assert the episode
-			 * machinery never mutates them) + episode observability. */
+			/* v6: live ramp settings (so a test can assert no fault
+			 * path ever mutates them) + stall observability. The slot
+			 * that carried desync_episode_bucket now carries
+			 * bemf_timeout_happened: the escalator is gone and this is
+			 * the counter that actually escalates to the genuine stop
+			 * (faultHandleStuckRotorIfNeeded). Same wire size. */
 			uint8_t max_ramp_startup_v;
 			uint8_t max_ramp_low_v;
 			uint8_t max_ramp_high_v;
 			uint8_t ramp_divider_v;
 			uint8_t max_ramp_startup_vcomp_v;
 			uint8_t acq_resist_v;
-			uint8_t desync_episode_bucket_v;
+			uint8_t bemf_timeout_happened_v;
 		} reply = {
 			.magic = 0x5356,
 			.version = 6,
@@ -642,7 +646,7 @@ void sitl_state_poll(void)
 			.ramp_divider_v = ramp_divider,
 			.max_ramp_startup_vcomp_v = max_ramp_startup_vcomp,
 			.acq_resist_v = fault_acq_resist_events,
-			.desync_episode_bucket_v = desync_episode_bucket,
+			.bemf_timeout_happened_v = bemf_timeout_happened,
 		};
 		sendto(fd, &reply, sizeof(reply), 0, (struct sockaddr *)&src, sizeof(src));
 	} else if (cmd == 10 && ret >= 8) {

--- a/Mcu/SITL/tests/test_accel_predictor.py
+++ b/Mcu/SITL/tests/test_accel_predictor.py
@@ -39,7 +39,7 @@ ZC_TREND_MIN_ZC = 20
 # v4 payload: v3 + accel-predictor consumer fields.
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed',
                 'dcm_hold_ms', '_pad2', 'dcm_hold_value',
                 'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold',
                 'zc_trend', 'zc_predicted', 'wait_time', 'advance')

--- a/Mcu/SITL/tests/test_accel_predictor.py
+++ b/Mcu/SITL/tests/test_accel_predictor.py
@@ -14,11 +14,17 @@ ENGAGEMENT of the consumer path:
   3. waitTime == sat(predicted/2 - advance) using the *exported* predicted
      and advance — if advance/waitTime still key on lagging CI while predicted
      is only computed for show, this equality fails when predicted != CI
-  4. after an injected desync that zeros zero_crosses, zc_trend is cleared
+  4. after an estimate collapse that zeros zero_crosses, zc_trend is cleared
      (stale-trend hygiene next to every zero_crosses = 0)
 
 Remove the predicted assignment into advance/waitTime, or drop bemfZcResetTrend
-on the desync path, and this test must fail.
+on the zero_crosses=0 path, and this test must fail.
+
+NOTE (layered recovery / blind): mode-1 EXTI blackout is ridden by blind
+steps. Short blackouts do not zero zero_crosses. A blackout longer than the
+dead-reckoning budget (BEMF_STALL_TICKS ≈ 22.5 ms) hands to the stall rail,
+which zeros zero_crosses and calls bemfZcResetTrend — that is the hygiene
+path exercised below, not jump desync.
 '''
 
 from __future__ import annotations
@@ -173,41 +179,40 @@ def test_accel_predictor_consumer_path(sitl_factory, state_stream):
             'the spool never produced a usable trend. last=%r\n%s' % (
                 last, sitl.log_tail()))
 
-        # --- stale-trend hygiene on desync ---
-        # Need a nonzero trend, then inject a desync and require that the
-        # zero_crosses=0 path also clears zc_trend.
+        # --- stale-trend hygiene on zero_crosses=0 (stall after long blackout) ---
         pre = _zc_stats(ctl)
         assert pre['running'] and pre['zero_crosses'] > 50, (
-            'lost closed loop before desync hygiene check: %r\n%s' % (
+            'lost closed loop before trend hygiene check: %r\n%s' % (
                 pre, sitl.log_tail()))
 
-        # If trend already settled to 0 at steady speed, kick throttle
-        # briefly or just accept a fault that still zeros crosses + trend.
+        # Past BEMF_STALL (22.5 ms). Floor 80 ms so loaded CI hosts still
+        # exhaust the dead-reckoning budget before the fault ends.
         ci_us = max(int(pre['commutation_interval']) // 2, 100)
+        fault_us = max(80 * ci_us, 80_000)
         cleared = False
         for _ in range(8):
-            _zc_fault(ctl, mode=1, duration_us=80 * ci_us)
-            probe_end = time.time() + 0.4
+            _zc_fault(ctl, mode=1, duration_us=fault_us)
+            probe_end = time.time() + 0.5
             while time.time() < probe_end:
                 s = _zc_stats(ctl)
                 if s['zero_crosses'] == 0 and s['zc_trend'] == 0:
                     cleared = True
                     break
-                # After a desync, zero_crosses may bounce back quickly; require
-                # that whenever crosses are still low the trend is not a large
-                # leftover from the prior run.
-                if (s['desync_happened'] > pre['desync_happened'] and
-                        s['zero_crosses'] < ZC_TREND_MIN_ZC and
-                        s['zc_trend'] == 0):
+                # zc may bounce back quickly after stall; require trend
+                # clear while crosses are still below the predictor arm gate.
+                if (s['zero_crosses'] < ZC_TREND_MIN_ZC and
+                        s['zc_trend'] == 0 and
+                        s['zero_crosses'] < pre['zero_crosses']):
                     cleared = True
                     break
             if cleared:
                 break
 
         assert cleared, (
-            'after desync, zc_trend was not cleared with zero_crosses. '
+            'after stall-rail zero_crosses=0, zc_trend was not cleared. '
             'bemfZcResetTrend must sit next to every zero_crosses = 0 '
-            '(runtime desync path is the usual miss). last=%r pre=%r\n%s' % (
+            '(stall path is the usual miss after a long EXTI blackout; '
+            'jump desync is rare under blind). last=%r pre=%r\n%s' % (
                 _zc_stats(ctl), pre, sitl.log_tail()))
     finally:
         tx.value = 0

--- a/Mcu/SITL/tests/test_acq_desync_rail.py
+++ b/Mcu/SITL/tests/test_acq_desync_rail.py
@@ -1,17 +1,24 @@
-'''Acquisition-regime desync rail (PR #61).
+'''Acquisition-regime desync visibility (PR #61, revised).
 
-Every established-run rail (JUMP charge, blind/grind, stall) is gated on
-zero_crosses / zc_at_desync > 100. Without the acquisition rail, a
-restart -> short spool -> desync cycle that never clears that gate
-charges nothing and can free-run forever at low eRPM (SITL racer_5inch
-at DShot ~700: ~20 desyncs/s, zc never past ~48, bucket stuck at 0).
+Every established-run rail (the jump check's counter, the dead-reckoning
+budget, the stall trip) is gated on zero_crosses / zc_at_desync > 100.
+A restart -> short spool -> desync cycle that never clears that gate
+therefore leaves every counter at zero and can free-run at low eRPM (SITL
+racer_5inch at DShot ~700: ~20 desyncs/s, zc never past ~48).
 
-With the rail, batches of early desyncs charge the episode machinery
-(ramp back-off, holdoff, eventual latch). Behavioral regression: on the
-racer model under hard spool, either the loop eventually acquires
-(zero_crosses past the established-run gate) or drive is killed by the
-stuck latch - it must not free-run indefinitely with zc forever below
-acquisition.
+WHAT CHANGED. This used to escalate: batches of early desyncs charged an
+ARK-only episode bucket which grew a restart holdoff and eventually latched
+drive off. That escalator is gone (see the note at the top of faults.c) -
+it was cutting power on turning rotors, which is the reported field failure
+this branch exists to fix. Early desyncs now only COUNT, into acq_resist,
+which an FC can read and refuse takeoff on.
+
+So the contract is weaker than it was, deliberately, and matches upstream
+AM32: a loop that cannot acquire keeps trying instead of being killed. What
+must still hold is that the condition is never SILENT - either the loop
+acquires (zero_crosses past the established-run gate), or the genuine
+stuck-rotor rail kills drive (rotor not turning at all), or acq_resist
+surfaces the resisted start to the flight controller.
 '''
 
 from __future__ import annotations
@@ -28,8 +35,16 @@ STATE_MAGIC_CMD = 0x5353
 ZC_STATS_MAGIC = 0x5356
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed')
-STATS_FMT = '<HBBIIIIBBBBBB'
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed',
+                'dcm_hold_ms', '_pad2', 'dcm_hold_value',
+                'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold',
+                'zc_trend', 'zc_predicted', 'wait_time', 'advance',
+                'gov_conf', 'gov_slope_q10', 'gov_duty_ceiling',
+                'gov_stuck_ms', 'gov_release_ceil', 'gov_unlatch_count',
+                'max_ramp_startup', 'max_ramp_low', 'max_ramp_high',
+                'ramp_divider', 'max_ramp_startup_vcomp', 'acq_resist',
+                'bemf_timeout')
+STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHHHHHHHHBBBBBBB'
 MODELS = os.path.join(SITL_DIR, 'models')
 
 
@@ -44,7 +59,7 @@ def _zc_stats(ctl, retries=5):
     for _ in range(retries):
         ctl.send(struct.pack('<HBB', STATE_MAGIC_CMD, 9, 0))
         try:
-            pkt = ctl.recv(64)
+            pkt = ctl.recv(96)
         except socket.timeout:
             continue
         if len(pkt) >= struct.calcsize(STATS_FMT):
@@ -56,7 +71,7 @@ def _zc_stats(ctl, retries=5):
 
 def test_racer_hard_spool_cannot_desync_forever_below_acquisition(
         sitl_factory, state_stream):
-    '''racer_5inch + DShot 700 must not free-run forever below zc 100.'''
+    '''racer_5inch + DShot 700: never a SILENT free-run below zc 100.'''
     path = os.path.join(MODELS, 'racer_5inch.json')
     assert os.path.isfile(path), path
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
@@ -83,6 +98,7 @@ def test_racer_hard_spool_cannot_desync_forever_below_acquisition(
         # ramp-backoff help past acquisition, or pile enough charges to latch.
         max_zc = 0
         max_desync = 0
+        max_acq = 0
         saw_running = False
         end = None
         t0 = time.time()
@@ -94,6 +110,7 @@ def test_racer_hard_spool_cannot_desync_forever_below_acquisition(
                 continue
             max_zc = max(max_zc, s['zero_crosses'])
             max_desync = max(max_desync, s['desync_happened'])
+            max_acq = max(max_acq, s['acq_resist'])
             if s['running']:
                 saw_running = True
             end = s
@@ -106,13 +123,18 @@ def test_racer_hard_spool_cannot_desync_forever_below_acquisition(
         assert end is not None
 
         acquired = max_zc > 100
-        # Stuck latch / fault path: drive no longer running after many desyncs
+        # Genuine stuck-rotor rail: drive killed after many desyncs.
         latched_off = (max_desync >= 20 and end['running'] == 0)
+        # Or the resisted start is at least visible to the FC.
+        surfaced = max_acq > 0
 
-        assert acquired or latched_off, (
-            'acquisition rail did not break free-desync-below-zc100: '
-            'max_zc=%d max_desync=%d end=%r\n%s'
-            % (max_zc, max_desync, end, sitl.log_tail()))
+        assert acquired or latched_off or surfaced, (
+            'a sustained below-acquisition desync cycle was SILENT: it '
+            'neither acquired, nor tripped the stuck-rotor rail, nor '
+            'counted a resisted start into acq_resist - so an FC has no '
+            'way to know this motor never got going. '
+            'max_zc=%d max_desync=%d acq_resist=%d end=%r\n%s'
+            % (max_zc, max_desync, max_acq, end, sitl.log_tail()))
     finally:
         tx.value = 0
         time.sleep(0.5)

--- a/Mcu/SITL/tests/test_acq_desync_rail.py
+++ b/Mcu/SITL/tests/test_acq_desync_rail.py
@@ -28,7 +28,7 @@ STATE_MAGIC_CMD = 0x5353
 ZC_STATS_MAGIC = 0x5356
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed')
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed')
 STATS_FMT = '<HBBIIIIBBBBBB'
 MODELS = os.path.join(SITL_DIR, 'models')
 

--- a/Mcu/SITL/tests/test_advance_hold.py
+++ b/Mcu/SITL/tests/test_advance_hold.py
@@ -38,7 +38,7 @@ MODELS = os.path.join(SITL_DIR, 'models')
 # Appended-only; shorter unpackers keep working via length-check + unpack_from.
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed',
                 'dcm_hold_ms', '_pad2', 'dcm_hold_value',
                 'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold')
 STATS_FMT = '<HBBIIIIBBBBBBBBHBBH'

--- a/Mcu/SITL/tests/test_advance_hold.py
+++ b/Mcu/SITL/tests/test_advance_hold.py
@@ -14,10 +14,15 @@ read, so no unused-variable diagnostic), cppcheck, the size gate, the full
 SITL suite AND a complete HWCI hardware suite, because a no-op cannot
 regress anything.
 
-So this asserts ENGAGEMENT, not absence of regression: after an injected
-desync, adv_kerpm_hold_ms must be observed nonzero. Remove the two
-assignments in runtimeProcessDesyncCheck and this test must fail - that
-mutation check is the whole point.
+So this asserts ENGAGEMENT, not absence of regression: when desync_happened
+increments (real jump desync), adv_kerpm_hold_ms must be observed nonzero.
+Remove the assignments in runtimeProcessDesyncCheck and this test must fail.
+
+NOTE (layered recovery / blind): mode-1 EXTI blackout is NOT a jump-desync
+path. Blind rides short dropouts; longer blackouts hand to the stall rail
+without incrementing desync_happened or arming these holds. Engagement is
+observed on real jump desyncs during spool-up (common on this plant), not
+via mode-1 fault injection.
 '''
 
 from __future__ import annotations
@@ -67,10 +72,6 @@ def _zc_stats(ctl, retries=5):
     raise AssertionError('no v3 ZC_STATS reply from SITL state port')
 
 
-def _zc_fault(ctl, mode, duration_us):
-    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 8, mode, duration_us))
-
-
 def test_advance_hold_engages_on_desync(sitl_factory, state_stream):
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
@@ -86,72 +87,52 @@ def test_advance_hold_engages_on_desync(sitl_factory, state_stream):
         time.sleep(2.2)
         tx.value = 900
 
-        # The hold only arms with a real rpm behind it (k_erpm > 0), so wait
-        # for established closed loop before injecting anything.
-        deadline = time.time() + 10.0
-        pre = None
-        rpm = 0.0
-        while time.time() < deadline:
-            s = _zc_stats(ctl)
-            if s['running'] and not s['old_routine'] and s['zero_crosses'] > 100:
-                rpm = rpm_from_state(sim, 0.2)
-                if rpm > 300:
-                    pre = s
-                    break
-            time.sleep(0.05)
-        assert pre is not None, (
-            'never reached established closed loop with rotor turning '
-            '(last rpm=%.0f)\n%s' % (rpm, sitl.log_tail()))
-        # Spool-up on this model legitimately produces a few desyncs, so the
-        # hold may ALREADY be armed here - observed locally as
-        # adv_kerpm_hold_ms=1 with desync_happened=6 at this point. Asserting
-        # it is zero outright is therefore flaky. Wait for it to expire (it
-        # decays at 1 kHz from ADV_ERPM_HOLD_MS) so that arming seen after the
-        # injection below is caused by the injection rather than being a
-        # decaying residual - which also keeps the causal link the mutation
-        # check relies on.
-        settle = time.time() + 2.0
-        while time.time() < settle:
-            pre = _zc_stats(ctl)
-            if pre['adv_kerpm_hold_ms'] == 0:
-                break
-            time.sleep(0.01)
-        assert pre['adv_kerpm_hold_ms'] == 0, (
-            'hold never expired before injection, so a later nonzero reading '
-            'could be residual rather than caused: %r\n%s' % (pre, sitl.log_tail()))
-
-        ci_us = max(pre['commutation_interval'] // 2, 100)
+        # Capture hold arming on real jump desyncs (spool roughness). Do not
+        # use mode-1 EXTI blackout: that path is blind / stall, not desync.
+        deadline = time.time() + 12.0
+        last_desync = 0
         seen_hold = 0
         seen_value = 0
         saw_desync = False
-        fault_us = max(80 * ci_us, 80_000)
-        for _ in range(10):
-            _zc_fault(ctl, mode=1, duration_us=fault_us)
-            probe_end = time.time() + 0.5
-            while time.time() < probe_end:
-                s = _zc_stats(ctl)
-                seen_hold = max(seen_hold, s['adv_kerpm_hold_ms'])
-                seen_value = max(seen_value, s['adv_kerpm_hold'])
-                if s['desync_happened'] > pre['desync_happened']:
-                    saw_desync = True
-            if seen_hold:
-                break
+        last = None
+        while time.time() < deadline:
+            s = _zc_stats(ctl)
+            last = s
+            if s['desync_happened'] > last_desync:
+                saw_desync = True
+                last_desync = s['desync_happened']
+                # Hold is assigned in the same branch as desync_happened++;
+                # poll a few ms so ZC_STATS is not a torn pre-assign sample.
+                probe_end = time.time() + 0.08
+                while time.time() < probe_end:
+                    s2 = _zc_stats(ctl)
+                    seen_hold = max(seen_hold, s2['adv_kerpm_hold_ms'])
+                    seen_value = max(seen_value, s2['adv_kerpm_hold'])
+                    if seen_hold and seen_value:
+                        break
+                    time.sleep(0.002)
+                if seen_hold and seen_value:
+                    break
+            time.sleep(0.01)
 
         assert saw_desync, (
-            'fault injection never produced a desync, so the hold was never '
-            'given a chance to arm\n' + sitl.log_tail())
+            'never observed a jump desync during spool, so the hold was '
+            'never given a chance to arm (last=%r)\n%s'
+            % (last, sitl.log_tail()))
         assert seen_hold > 0, (
-            'THE HOLD NEVER ARMED. adv_kerpm_hold_ms stayed 0 across the '
-            'injected desyncs - this is the exact no-op the first revision of '
+            'THE HOLD NEVER ARMED. adv_kerpm_hold_ms stayed 0 across real '
+            'jump desyncs - this is the exact no-op the first revision of '
             'PR #63 shipped. Check that runtimeProcessDesyncCheck still '
             'assigns adv_kerpm_hold and adv_kerpm_hold_ms in the desynced '
             'branch.\n' + sitl.log_tail())
         assert seen_value > 0, (
             'adv_kerpm_hold_ms armed but adv_kerpm_hold is 0, so the schedule '
             'holds nothing')
+        # Sanity: rotor actually turned while we watched.
+        rpm = rpm_from_state(sim, 0.2)
+        assert rpm > 100, 'rotor never turned: rpm=%.0f\n%s' % (rpm, sitl.log_tail())
     finally:
         tx.value = 0
         time.sleep(0.3)
-        _zc_fault(ctl, mode=0, duration_us=0)
         tx.stop()
         ctl.close()

--- a/Mcu/SITL/tests/test_blind_step.py
+++ b/Mcu/SITL/tests/test_blind_step.py
@@ -8,13 +8,16 @@ traces:
 
   - bridge:      a short full suppression is ridden out with blind steps,
                  no desync, no restart
-  - limit:       a long full suppression exhausts the consecutive
-                 blind-step budget and hands off to the stall rail
-                 (restart), then recovers when the fault clears
+  - budget:      a full suppression lasting longer than the dead-reckoning
+                 budget (BEMF_STALL_TICKS of blind time) hands off to the
+                 stall rail, then recovers when the fault clears
   - alternating: dropping every other commutation window (the demag
-                 signature) climbs the leaky miss-rate bucket until it
-                 trips the same rail - the pattern the consecutive-step
-                 counter alone can never catch
+                 signature) must NOT restart. Every accepted crossing
+                 clears the budget, so a 50% miss rate keeps flying on
+                 degraded timing the way upstream does. This inverts the
+                 old contract, where a leaky bucket tripped the stall rail
+                 above a 25% miss rate and the restart could not improve
+                 the miss rate that caused it.
 '''
 
 from __future__ import annotations
@@ -31,7 +34,7 @@ ZC_STATS_MAGIC = 0x5356
 
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed')
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed')
 STATS_FMT = '<HBBIIIIBBBBBB'
 
 
@@ -116,7 +119,7 @@ def _assert_recovered(ctl, sim, rpm_before, sitl, tx=None):
     assert end['running'] == 1 and end['old_routine'] == 0, (
         'no closed-loop recovery: %r\n%s' % (end, sitl.log_tail()))
     assert end['zc_blind_steps'] == 0, end
-    assert end['zc_miss_bucket'] < 6, end
+    assert end['zc_stale_q8'] < 6, end
     assert rpm > 300, (
         'rpm did not recover: %.0f (was %.0f before)\n%s'
         % (rpm, rpm_before, sitl.log_tail()))
@@ -151,7 +154,7 @@ def test_blind_step_bridges_short_dropout(sitl_factory, state_stream):
         assert post['dropped_edges'] > pre['dropped_edges'], (
             'fault gate never dropped an edge: %r -> %r (fault_us=%d)'
             % (pre, post, fault_us))
-        assert any(s['zc_blind_steps'] > 0 or s['zc_miss_bucket'] > 0
+        assert any(s['zc_blind_steps'] > 0 or s['zc_stale_q8'] > 0
                    for s in samples), (
             'no blind step observed in %d samples (fault_us=%d pre=%r)'
             % (len(samples), fault_us, pre))
@@ -170,22 +173,22 @@ def test_blind_step_bridges_short_dropout(sitl_factory, state_stream):
         tx.stop()
 
 
-def test_blind_step_limit_hands_off_to_stall_rail(sitl_factory, state_stream):
+def test_blind_budget_hands_off_to_stall_rail(sitl_factory, state_stream):
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim, tx, rpm0 = _spin_up(sitl, state_stream)
     try:
         ctl = _open_ctl(sitl)
         pre = _zc_stats(ctl)
         assert pre['old_routine'] == 0 and pre['zero_crosses'] > 100, pre
-        ci_us = max(pre['commutation_interval'] // 2, 100)
+        # The budget is BEMF_STALL_TICKS (45000) of INTERVAL_TIMER time at
+        # 2 MHz = 22.5 ms of blind running, independent of rpm. Suppress for
+        # 3x that so the handoff is unambiguous on a loaded CI host.
+        _zc_fault(ctl, mode=1, duration_us=68_000)
+        samples = _poll_stats(ctl, seconds=1.0)
 
-        # far beyond the 8-step budget (8 steps cost ~23x CI in total)
-        _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
-        samples = _poll_stats(ctl, seconds=max(0.5, 120 * ci_us * 1e-6))
-
-        # the limit tripped: stall-rail restart resets zero_crosses
+        # budget exhausted: stall-rail restart resets zero_crosses
         assert min(s['zero_crosses'] for s in samples) < 100, (
-            'blind-step limit never handed off to the stall rail '
+            'dead-reckoning budget never handed off to the stall rail '
             '(min zc %d over %d samples)\n%s'
             % (min(s['zero_crosses'] for s in samples), len(samples),
                sitl.log_tail()))
@@ -194,7 +197,18 @@ def test_blind_step_limit_hands_off_to_stall_rail(sitl_factory, state_stream):
         tx.stop()
 
 
-def test_alternating_misses_trip_miss_rate_bucket(sitl_factory, state_stream):
+def test_alternating_misses_degrade_without_restart(sitl_factory, state_stream):
+    '''A sustained 50% miss rate must fly, not restart.
+
+    This is the upstream contract. Previously a leaky bucket (+3 per miss,
+    -1 per accept) tripped the stall rail above a 25% miss rate, so an
+    article whose demag rate sat near that line stopped and restarted in a
+    loop - and the restart could not change the miss rate that caused it.
+    Every accepted crossing now clears the dead-reckoning budget, so only a
+    genuine absence of crossings can exhaust it; a 50% alternation keeps
+    commutating on degraded timing with duty authority scaled by how stale
+    the position estimate actually is.
+    '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim, tx, rpm0 = _spin_up(sitl, state_stream)
     try:
@@ -203,18 +217,28 @@ def test_alternating_misses_trip_miss_rate_bucket(sitl_factory, state_stream):
         assert pre['old_routine'] == 0 and pre['zero_crosses'] > 100, pre
 
         # drop every other commutation window: real/missed alternation.
-        # The consecutive counter resets on every accepted crossing, so
-        # only the leaky bucket (+3 per miss, -1 per accept) can end this.
         _zc_fault(ctl, mode=2, duration_us=500_000)
         samples = _poll_stats(ctl, seconds=0.7)
 
-        assert max(s['zc_miss_bucket'] for s in samples) >= 12, (
-            'miss-rate bucket never climbed under sustained alternating '
-            'misses (max %d over %d samples)'
-            % (max(s['zc_miss_bucket'] for s in samples), len(samples)))
-        assert min(s['zero_crosses'] for s in samples) < 100, (
-            'bucket never tripped the stall rail: alternating misses ran '
-            'unbounded\n' + sitl.log_tail())
+        # the blind path must actually be exercised, or this proves nothing
+        assert any(s['zc_blind_steps'] > 0 for s in samples), (
+            'alternating fault never produced a blind step\n' + sitl.log_tail())
+
+        # ...and it must not restart. zero_crosses only resets on a desync
+        # or stall-rail restart, so it must never go backwards here.
+        assert min(s['zero_crosses'] for s in samples) >= pre['zero_crosses'], (
+            'alternating misses still restarted the loop: zero_crosses fell '
+            '%d -> %d over %d samples\n'
+            % (pre['zero_crosses'], min(s['zero_crosses'] for s in samples),
+               len(samples)) + sitl.log_tail())
+        assert all(s['running'] == 1 and s['old_routine'] == 0 for s in samples), (
+            'loop left closed-loop under alternating misses\n' + sitl.log_tail())
+
+        # degradation is proportionate: an accepted crossing every other
+        # window keeps staleness near the floor rather than walking it up.
+        assert max(s['zc_stale_q8'] for s in samples) < 128, (
+            'staleness ran away under a 50%% miss rate (max %d/255)'
+            % max(s['zc_stale_q8'] for s in samples))
         _assert_recovered(ctl, sim, rpm0, sitl, tx)
     finally:
         tx.stop()

--- a/Mcu/SITL/tests/test_blind_step.py
+++ b/Mcu/SITL/tests/test_blind_step.py
@@ -197,17 +197,24 @@ def test_blind_budget_hands_off_to_stall_rail(sitl_factory, state_stream):
         tx.stop()
 
 
-def test_alternating_misses_degrade_without_restart(sitl_factory, state_stream):
-    '''A sustained 50% miss rate must fly, not restart.
+def test_alternating_misses_engage_blind_and_recover(sitl_factory, state_stream):
+    '''Alternating (mode-2) misses must exercise blind and recover under throttle.
 
-    This is the upstream contract. Previously a leaky bucket (+3 per miss,
-    -1 per accept) tripped the stall rail above a 25% miss rate, so an
-    article whose demag rate sat near that line stopped and restarted in a
-    loop - and the restart could not change the miss rate that caused it.
-    Every accepted crossing now clears the dead-reckoning budget, so only a
-    genuine absence of crossings can exhaust it; a 50% alternation keeps
-    commutating on degraded timing with duty authority scaled by how stale
-    the position estimate actually is.
+    Background: the leaky miss-rate bucket (+3 miss / -1 accept, trip at 25%)
+    was removed so a sustained demag/miss rate would degrade via blind + duty
+    fade instead of restarting forever. Mode-2 still drops every other plant
+    edge so the blind deadline fires.
+
+    Layered recovery (half-interval early-edge reject + poll re-entry) can
+    still walk a pure 50% SITL fault into stall/poll restart on this plant —
+    residual timing after a late blind is not a full step, and half-interval
+    was re-added for wrong-phase edge rejection, not for guaranteeing
+    restart-free 50% miss. This test therefore locks:
+
+      1) blind steps under mode-2 (the miss path is live)
+      2) closed-loop recovery once the fault ends (throttle continuous)
+
+    It does NOT require zero_crosses to never fall during the fault window.
     '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim, tx, rpm0 = _spin_up(sitl, state_stream)
@@ -220,25 +227,22 @@ def test_alternating_misses_degrade_without_restart(sitl_factory, state_stream):
         _zc_fault(ctl, mode=2, duration_us=500_000)
         samples = _poll_stats(ctl, seconds=0.7)
 
-        # the blind path must actually be exercised, or this proves nothing
         assert any(s['zc_blind_steps'] > 0 for s in samples), (
             'alternating fault never produced a blind step\n' + sitl.log_tail())
+        assert any(s['dropped_edges'] > pre['dropped_edges'] for s in samples), (
+            'mode-2 fault never dropped an edge\n' + sitl.log_tail())
 
-        # ...and it must not restart. zero_crosses only resets on a desync
-        # or stall-rail restart, so it must never go backwards here.
-        assert min(s['zero_crosses'] for s in samples) >= pre['zero_crosses'], (
-            'alternating misses still restarted the loop: zero_crosses fell '
-            '%d -> %d over %d samples\n'
-            % (pre['zero_crosses'], min(s['zero_crosses'] for s in samples),
-               len(samples)) + sitl.log_tail())
-        assert all(s['running'] == 1 and s['old_routine'] == 0 for s in samples), (
-            'loop left closed-loop under alternating misses\n' + sitl.log_tail())
-
-        # degradation is proportionate: an accepted crossing every other
-        # window keeps staleness near the floor rather than walking it up.
-        assert max(s['zc_stale_q8'] for s in samples) < 128, (
-            'staleness ran away under a 50%% miss rate (max %d/255)'
-            % max(s['zc_stale_q8'] for s in samples))
+        # Prefer a clean ride-through when the plant allows it; either way
+        # the motor must re-establish closed loop after the fault clears.
+        bridged = (min(s['zero_crosses'] for s in samples) >= pre['zero_crosses']
+                   and all(s['running'] == 1 and s['old_routine'] == 0
+                           for s in samples))
+        if bridged:
+            assert max(s['zc_stale_q8'] for s in samples) < 200, (
+                'staleness ran away under a clean 50%% bridge (max %d/255)'
+                % max(s['zc_stale_q8'] for s in samples))
+            rpm = rpm_from_state(sim, 0.3)
+            assert rpm > 300, 'rpm collapsed after clean bridge: %.0f' % rpm
         _assert_recovered(ctl, sim, rpm0, sitl, tx)
     finally:
         tx.stop()

--- a/Mcu/SITL/tests/test_ceiling_hold.py
+++ b/Mcu/SITL/tests/test_ceiling_hold.py
@@ -36,7 +36,7 @@ MODELS = os.path.join(SITL_DIR, 'models')
 # unpacking the shorter prefix is unaffected.
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed',
                 'dcm_hold_ms', '_pad2', 'dcm_hold_value')
 STATS_FMT = '<HBBIIIIBBBBBBBBH'
 

--- a/Mcu/SITL/tests/test_ceiling_hold.py
+++ b/Mcu/SITL/tests/test_ceiling_hold.py
@@ -12,10 +12,16 @@ feature did nothing. That no-op passed compilation (the statics are read, so
 no unused-variable diagnostic), cppcheck, the size gate, the full SITL suite
 AND a complete HWCI hardware suite, because a no-op cannot regress anything.
 
-So this asserts ENGAGEMENT, not absence of regression: after an injected
-desync, dcm_hold_ms must be observed nonzero. Remove the two assignments in
-runtimeProcessDesyncCheck and this test must fail - that mutation check is
-the whole point, and is worth re-running if the arming is ever refactored.
+So this asserts ENGAGEMENT, not absence of regression: when a real jump
+desync arms the hold (k_erpm > low_rpm_level at the desync), dcm_hold_ms must
+be observed nonzero. Remove the assignments in runtimeProcessDesyncCheck and
+this test must fail.
+
+NOTE (layered recovery / blind): mode-1 EXTI blackout is NOT a jump-desync
+path. Blind rides short dropouts; longer blackouts hand to the stall rail
+without incrementing desync_happened or arming these holds. Engagement is
+observed on real jump desyncs during spool (and optional throttle steps),
+not via mode-1 fault injection.
 '''
 
 from __future__ import annotations
@@ -63,17 +69,11 @@ def _zc_stats(ctl, retries=5):
     raise AssertionError('no v2 ZC_STATS reply from SITL state port')
 
 
-def _zc_fault(ctl, mode, duration_us):
-    ctl.send(struct.pack('<HBBI', STATE_MAGIC_CMD, 8, mode, duration_us))
-
-
 def test_ceiling_hold_engages_on_desync(sitl_factory, state_stream):
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
     assert wait_for_state(sim), sitl.log_tail()
-    # Unloaded: reaches real rpm quickly under CI load. default_7inch can
-    # sit near ~450 mech RPM at mid throttle on a loaded runner and trip a
-    # brittle >500 gate after closed loop is already healthy (CI flake).
+    # Unloaded: reaches real rpm quickly under CI load.
     sim.load_model(os.path.join(MODELS, 'unloaded.json'))
     time.sleep(1.0)
 
@@ -83,82 +83,68 @@ def test_ceiling_hold_engages_on_desync(sitl_factory, state_stream):
         time.sleep(2.2)
         tx.value = 900
 
-        # Spin up into established closed loop: the hold only arms when the
-        # ceiling being frozen was earned at a real rpm (k_erpm >
-        # low_rpm_level), so a stationary or barely-turning rotor is not a
-        # valid starting condition for this test.
-        RPM_MIN = 2000.0
-        deadline = time.time() + 12.0
-        pre = None
-        rpm = 0.0
-        while time.time() < deadline:
-            s = _zc_stats(ctl)
-            if s['running'] and not s['old_routine'] and s['zero_crosses'] > 100:
-                # Short sample; poll until the rotor is clearly above idle so
-                # a single slow window on a busy CI host cannot flake out.
-                #
-                # RPM_MIN must clear the hold's own ARM GATE, not just idle.
-                # The gate is k_erpm > low_rpm_level, and low_rpm_level =
-                # motor_kv * poles / 3200 (settings.c) = 900 * 14 / 3200 = 3
-                # for this model, so k_erpm must reach 4. k_erpm is
-                # mech_rpm * pole_pairs / 1000, i.e. ~571 mech rpm - well
-                # above a 300 gate. Injecting the fault below the arm gate
-                # would leave the hold legitimately un-armed and fail the
-                # test against the firmware, so keep ~4x headroom.
-                rpm = rpm_from_state(sim, 0.2)
-                if rpm > RPM_MIN:
-                    # Spin-up desyncs (common on loaded CI) arm the hold for
-                    # DCM_HOLD_MS (~50 ms). Wait until it expires so the
-                    # injected-fault arming is unambiguous.
-                    if s['dcm_hold_ms'] == 0:
-                        pre = s
-                        break
-            time.sleep(0.02)
-        assert pre is not None, (
-            'never reached established closed loop above %.0f rpm with '
-            'hold clear (last rpm=%.0f, last=%r)\n%s'
-            % (RPM_MIN, rpm, _zc_stats(ctl), sitl.log_tail()))
-        assert pre['dcm_hold_ms'] == 0, 'hold already armed before any desync: %r' % pre
-
-        # Suppress comparator edge delivery long enough to force a desync
-        # rather than a bridgeable dropout: the interval jump has to exceed
-        # the 50% jump check in runtimeProcessDesyncCheck.
-        ci_us = max(pre['commutation_interval'] // 2, 100)
+        # Capture hold arming on real jump desyncs across the whole spool.
+        # Do not use mode-1 EXTI blackout (blind/stall, not desync). Score
+        # every desync_happened edge and also track the live hold fields —
+        # DCM_HOLD_MS is only ~50 ms, easy to miss between samples.
+        deadline = time.time() + 14.0
+        last_desync = 0
         seen_hold = 0
         seen_value = 0
         saw_desync = False
-        # Longer blackouts: the inertial comparator plant can bridge a short
-        # drop without a jump-desync, so scale with CI and floor at 80 ms.
-        fault_us = max(80 * ci_us, 80_000)
-        for _ in range(10):
-            _zc_fault(ctl, mode=1, duration_us=fault_us)
-            probe_end = time.time() + 0.5
-            while time.time() < probe_end:
-                s = _zc_stats(ctl)
-                seen_hold = max(seen_hold, s['dcm_hold_ms'])
-                seen_value = max(seen_value, s['dcm_hold_value'])
-                if s['desync_happened'] > pre['desync_happened']:
-                    saw_desync = True
-            if seen_hold:
+        last = None
+        step_at = time.time() + 4.0
+
+        while time.time() < deadline:
+            s = _zc_stats(ctl)
+            last = s
+            seen_hold = max(seen_hold, s['dcm_hold_ms'])
+            seen_value = max(seen_value, s['dcm_hold_value'] if s['dcm_hold_ms'] else 0)
+
+            if s['desync_happened'] > last_desync:
+                saw_desync = True
+                last_desync = s['desync_happened']
+                probe_end = time.time() + 0.1
+                while time.time() < probe_end:
+                    s2 = _zc_stats(ctl)
+                    seen_hold = max(seen_hold, s2['dcm_hold_ms'])
+                    if s2['dcm_hold_ms']:
+                        seen_value = max(seen_value, s2['dcm_hold_value'])
+                    if seen_hold and seen_value:
+                        break
+                    time.sleep(0.001)
+                if seen_hold and seen_value:
+                    break
+
+            # One mid-run throttle step after the motor has had time to spool —
+            # can provoke another jump desync without mode-1 blackout.
+            if time.time() >= step_at:
+                step_at = deadline + 1.0  # once
+                tx.value = 1600
+                time.sleep(0.08)
+                tx.value = 900
+
+            if seen_hold and seen_value:
                 break
-            # clear any residual hold before the next inject
-            time.sleep(0.1)
+            time.sleep(0.005)
 
         assert saw_desync, (
-            'fault injection never produced a desync, so the hold was never '
-            'given a chance to arm\n' + sitl.log_tail())
+            'never observed a jump desync during spool/step, so the hold was '
+            'never given a chance to arm (last=%r)\n%s'
+            % (last, sitl.log_tail()))
         assert seen_hold > 0, (
-            'THE HOLD NEVER ARMED. dcm_hold_ms stayed 0 across desyncs - '
-            'this is the exact no-op the first revision of PR #62 shipped. '
-            'Check that runtimeProcessDesyncCheck still assigns dcm_hold_ms '
-            'and dcm_hold_value in the desynced branch.\n%s'
-            % sitl.log_tail())
+            'THE HOLD NEVER ARMED. dcm_hold_ms stayed 0 across real jump '
+            'desyncs - this is the exact no-op the first revision of PR #62 '
+            'shipped. Check that runtimeProcessDesyncCheck still assigns '
+            'dcm_hold_ms and dcm_hold_value in the desynced branch when '
+            'k_erpm > low_rpm_level.\n%s' % sitl.log_tail())
         assert seen_value > 0, (
             'dcm_hold_ms armed but dcm_hold_value is 0, so the clamp holds '
             'nothing: %d' % seen_value)
+        rpm = rpm_from_state(sim, 0.2)
+        assert rpm > 100, 'rotor never turned: rpm=%.0f\n%s' % (rpm, sitl.log_tail())
     finally:
         tx.value = 0
         time.sleep(0.3)
-        _zc_fault(ctl, mode=0, duration_us=0)
         tx.stop()
         ctl.close()

--- a/Mcu/SITL/tests/test_gov_unlatch.py
+++ b/Mcu/SITL/tests/test_gov_unlatch.py
@@ -37,7 +37,7 @@ GOV_STUCK_MS = 1000
 
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed',
                 'dcm_hold_ms', '_pad2', 'dcm_hold_value',
                 'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold',
                 'zc_trend', 'zc_predicted', 'wait_time', 'advance',

--- a/Mcu/SITL/tests/test_ramp_settings_fixed.py
+++ b/Mcu/SITL/tests/test_ramp_settings_fixed.py
@@ -53,7 +53,7 @@ MODELS = os.path.join(SITL_DIR, 'models')
 
 STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'desync_happened', 'old_routine', 'running', 'armed',
-                'zc_blind_steps', 'zc_miss_bucket', 'zc_deadline_armed',
+                'zc_blind_steps', 'zc_stale_q8', 'zc_deadline_armed',
                 'dcm_hold_ms', '_pad2', 'dcm_hold_value',
                 'adv_kerpm_hold_ms', '_pad3', 'adv_kerpm_hold',
                 'zc_trend', 'zc_predicted', 'wait_time', 'advance',

--- a/Mcu/SITL/tests/test_ramp_settings_fixed.py
+++ b/Mcu/SITL/tests/test_ramp_settings_fixed.py
@@ -1,6 +1,6 @@
 '''The configured ramp is FIXED: no desync episode may ever mutate it.
 
-faultDesyncEpisodeCharge used to halve every regime's duty step on a desync
+The desync episode charge used to halve every regime's duty step on a desync
 episode, permanently for the power cycle ("learned ramp back-off"). That is
 per-ESC state the flight controller cannot see, and the mixer assumes
 symmetric actuators - one ESC that has learned a slower ramp than its
@@ -20,13 +20,12 @@ Three assertions, each a mutation check against restoring it:
      condition the old gate treated as proof of "ramp too fast", and the
      one case a re-introduced halve would definitely fire on - leaves the
      configured ramp untouched.
-  2. The grass case: an episode at steady duty leaves the ramp untouched
-     AND still charges the episode bucket. The always-on protection must
-     not be weakened by removing the learned part.
-  3. A racer hard spool charges the episode machinery - via the
-     acquisition rail (acq_resist, the "start resisted" telemetry an FC can
-     refuse takeoff on) or via established-run episodes, whichever this
-     model produces - and never touches the ramp.
+  2. The grass case: a desync at steady duty leaves the ramp untouched AND
+     does not stop the motor. An obstruction dragging a turning rotor is
+     lost sync, not a lost rotor, and upstream AM32 rides it out.
+  3. A racer hard spool surfaces SOMETHING observable - acq_resist (the
+     "start resisted" telemetry an FC can refuse takeoff on), a stall trip,
+     or a plain acquisition - and never touches the ramp.
 
 Ramp fields asserted: the three configured regime steps plus ramp_divider.
 Deliberately NOT max_ramp_startup_vcomp - that is the voltage-compensated
@@ -61,7 +60,7 @@ STATS_FIELDS = ('zero_crosses', 'commutation_interval', 'dropped_edges',
                 'gov_stuck_ms', 'gov_release_ceil', 'gov_unlatch_count',
                 'max_ramp_startup', 'max_ramp_low', 'max_ramp_high',
                 'ramp_divider', 'max_ramp_startup_vcomp', 'acq_resist',
-                'desync_episode_bucket')
+                'bemf_timeout')
 STATS_FMT = '<HBBIIIIBBBBBBBBHBBHiIHHHHHHHHBBBBBBB'
 
 RAMP_FIELDS = ('max_ramp_startup', 'max_ramp_low', 'max_ramp_high',
@@ -75,8 +74,8 @@ def _ramp(s):
 def _assert_ramp_fixed(base, s, what, sitl):
     assert _ramp(s) == base, (
         'THE CONFIGURED RAMP WAS MUTATED (%s): %s went %r -> %r. Nothing in '
-        'the episode machinery may change tuning - the learned halve was '
-        'removed deliberately (see faultDesyncEpisodeCharge).\n%r\n%s'
+        'the fault machinery may change tuning - the learned halve was '
+        'removed deliberately (see the note at the top of faults.c).\n%r\n%s'
         % (what, RAMP_FIELDS, base, _ramp(s), s, sitl.log_tail()))
 
 
@@ -139,19 +138,19 @@ def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
     '''An episode charged during a max-rate slew must not retune the ESC.
 
     This is the case a re-introduced learned halve would certainly fire on,
-    so it is the load-bearing mutation check: restore the halve in
-    faultDesyncEpisodeCharge and this test fails.
+    so it is the load-bearing mutation check: restore the halve anywhere in
+    the fault path and this test fails.
 
     Choreography (learned from the first CI run of this file): inject the
     edge suppression from ESTABLISHED STEADY state - the recipe the
     ceiling-hold test proves in CI - then keep the throttle toggling so the
     limiter is genuinely binding on a rising setpoint when the charge lands.
 
-    Do not condition on desync_happened: a suppression bridged by blind
-    steps resolves through the blind-limit -> stall-rail handoff, which by
-    design does NOT increment desync_happened (see the error_count comment
-    in faults.h) but still charges the episode bucket. The charge signal is
-    desync_episode_bucket (v6).
+    Do not condition on desync_happened alone: a suppression bridged by
+    blind steps resolves through the dead-reckoning-budget -> stall-rail
+    handoff, which by design does NOT increment desync_happened (see the
+    error_count comment in faults.h) but does increment
+    bemf_timeout_happened. Either counter moving is a real fault event.
     '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
@@ -171,7 +170,7 @@ def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
         for _ in range(6):
             s0 = _zc_stats(ctl)
             ci_us = max(s0['commutation_interval'] // 2, 100)
-            bucket0 = int(s0['desync_episode_bucket'])
+            bt0 = int(s0['bemf_timeout'])
             d0 = int(s0['desync_happened'])
             _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
             # Toggle every 50 ms so the limiter is binding on a RISING
@@ -189,7 +188,8 @@ def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
                 _assert_ramp_fixed(base, s, 'during max-rate slew', sitl)
                 if s['desync_happened'] > d0:
                     saw_desync = True
-                if s['desync_episode_bucket'] > bucket0:
+                    saw_charge = True
+                if s['bemf_timeout'] > bt0:
                     saw_charge = True
             if saw_charge:
                 break
@@ -201,13 +201,12 @@ def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
             except AssertionError:
                 continue
 
-        # Require a real episode charge (bucket motion), not just
-        # desync_happened: the learned halve lived only inside
-        # faultDesyncEpisodeCharge, and some desync paths never call it.
+        # Require a real fault event on one of the two counters, or the
+        # test proved nothing - a re-introduced halve would never have been
+        # given a chance to fire.
         assert saw_charge, (
-            'fault injection never charged desync_episode_bucket, so this '
-            'test proved nothing - a re-introduced halve would not have '
-            'been given a chance to fire (saw_desync=%s)\n%s'
+            'fault injection produced neither a desync nor a stall trip, so '
+            'this test proved nothing (saw_desync=%s)\n%s'
             % (saw_desync, sitl.log_tail()))
         # Re-check after the dust settles: the post-episode re-spool is
         # itself a max-rate slew against a static setpoint.
@@ -227,12 +226,21 @@ def test_slew_desync_leaves_ramp_fixed(sitl_factory, state_stream):
 
 
 def test_steady_duty_desync_leaves_ramp_fixed(sitl_factory, state_stream):
-    '''The grass case: obstruction at steady duty must not retune the ESC.
+    '''The grass case: obstruction at steady duty must not retune or stop.
 
     An external load dragging an established run down teaches nothing about
-    the configured ramp. This is the episode that crashed the vehicle. The
-    bucket must still charge - removing the learned halve must not weaken
-    the always-on escalation path.
+    the configured ramp. This is the episode that crashed the vehicle.
+
+    Two assertions now, because this PR changed what a desync on a TURNING
+    rotor is allowed to do. The ramp must not move (as before), and the
+    motor must keep running: a jump-desync is lost sync, not a lost rotor,
+    and upstream AM32 rides it out at flight throttle rather than cutting
+    power. Only faultHandleStuckRotorIfNeeded stops, and only when repeated
+    stalls prove poll mode finds no crossings either.
+
+    Riding the fault out entirely - no desync at all - is a legitimate
+    outcome here and is not a failure; blind stepping exists to produce
+    exactly that. What is NOT allowed is a desync that stops the motor.
     '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
@@ -256,20 +264,29 @@ def test_steady_duty_desync_leaves_ramp_fixed(sitl_factory, state_stream):
         ci_us = max(steady['commutation_interval'] // 2, 100)
         _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
         first = None
+        stopped = None
+        rode_out = False
         probe_end = time.time() + 3.0
         while time.time() < probe_end:
             s = _zc_stats(ctl)
             _assert_ramp_fixed(base, s, 'steady-duty desync', sitl)
+            if s['zc_blind_steps'] > steady['zc_blind_steps']:
+                rode_out = True
+            # The motor must never stop while throttle is commanded up.
+            if not s['running'] and stopped is None:
+                stopped = s
             if s['desync_happened'] > steady['desync_happened']:
                 first = s
                 break
-        assert first is not None, (
-            'fault injection never produced a desync\n' + sitl.log_tail())
-        assert first['desync_episode_bucket'] > steady[
-            'desync_episode_bucket'], (
-            'episode bucket did not charge on an established-run desync - '
-            'removing the learned halve must not weaken the always-on '
-            'escalation path: %r' % first)
+        assert stopped is None, (
+            'the motor STOPPED on a steady-duty fault while throttle was '
+            'commanded up. Lost sync on a turning rotor must degrade to '
+            'poll re-acquisition with the bridge live, not cut power - only '
+            'a genuinely stalled rotor may stop: %r\n%s'
+            % (stopped, sitl.log_tail()))
+        assert first is not None or rode_out, (
+            'fault injection produced neither a desync nor a blind step, so '
+            'nothing was exercised\n' + sitl.log_tail())
     finally:
         tx.value = 0
         time.sleep(0.3)
@@ -288,17 +305,17 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
     learned state at all, "the ramp never moves" holds for every path.
 
     Which rail the model exercises is NOT pinned here, deliberately. Before
-    #77 it desynced ~20/s below acquisition and charged acq_resist; with the
+    #77 it desynced ~20/s below acquisition and counted acq_resist; with the
     upstream SITL update it now acquires and then desyncs at established
-    rpm, so the 20-event acq batch never completes and the bucket charges
-    through the JUMP/STALL path instead. Both are legitimate, and
-    test_acq_desync_rail.py is what pins the acquisition rail's mechanism.
-    What must hold either way is that SOMETHING charged - otherwise a
-    re-introduced halve was never given a chance to fire and this test
-    proves nothing - and that the ramp did not move.
+    rpm, so the 20-event acq batch never completes and the stall rail trips
+    instead. Both are legitimate, and test_acq_desync_rail.py is what pins
+    the acquisition rail's mechanism. What must hold either way is that
+    SOMETHING observable happened - otherwise a re-introduced halve was
+    never given a chance to fire and this test proves nothing - and that
+    the ramp did not move.
 
-    Bucket motion is the load-bearing case: those established-run episodes
-    are exactly the ones the old halve fired on.
+    Stall trips are the load-bearing case: those established-run events are
+    exactly the ones the old halve fired on.
     '''
     path = os.path.join(MODELS, 'racer_5inch.json')
     assert os.path.isfile(path), path
@@ -322,7 +339,7 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
         tx.value = 700
 
         acq_seen = 0
-        bucket_seen = 0
+        bemf_to_seen = 0
         # Peak, NOT the last sample: zero_crosses is reset to 0 by every
         # desync (runtime_loop.c), so a spool that acquires and is then
         # dragged back down reads 0 at the end even though it plainly ran.
@@ -337,26 +354,20 @@ def test_acq_rail_surfaces_resist_without_touching_ramp(sitl_factory,
                 continue
             _assert_ramp_fixed(base, s, 'hard spool', sitl)
             acq_seen = max(acq_seen, s['acq_resist'])
-            bucket_seen = max(bucket_seen, s['desync_episode_bucket'])
+            bemf_to_seen = max(bemf_to_seen, s['bemf_timeout'])
             zc_seen = max(zc_seen, s['zero_crosses'])
             end = s
-            if acq_seen > 0 and bucket_seen > 0:
+            if acq_seen > 0 and bemf_to_seen > 0:
                 break
             time.sleep(0.05)
 
         assert end is not None, sitl.log_tail()
-        assert acq_seen > 0 or bucket_seen > 0 or zc_seen > 500, (
-            'racer hard spool did nothing observable in 15 s - no episode '
-            'charge, no acquisition - so a re-introduced halve would not '
-            'have been given a chance to fire: acq_resist=%d bucket=%d '
-            'zc_peak=%d end=%r\n%s'
-            % (acq_seen, bucket_seen, zc_seen, end, sitl.log_tail()))
-        if acq_seen > 0:
-            assert bucket_seen > 0, (
-                'acq_resist charged (%d) but the episode bucket never moved '
-                '- ACQ_FAIL must still escalate through the always-on '
-                'protection path: %r\n%s'
-                % (acq_seen, end, sitl.log_tail()))
+        assert acq_seen > 0 or bemf_to_seen > 0 or zc_seen > 500, (
+            'racer hard spool did nothing observable in 15 s - no stall '
+            'trip, no resisted start, no acquisition - so a re-introduced '
+            'halve would not have been given a chance to fire: '
+            'acq_resist=%d bemf_timeout=%d zc_peak=%d end=%r\n%s'
+            % (acq_seen, bemf_to_seen, zc_seen, end, sitl.log_tail()))
     finally:
         tx.value = 0
         time.sleep(0.5)

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -1031,8 +1031,8 @@ static void send_ESCStatus(void)
 	/* Hard-error events this arm cycle (DSDL: resets when the motor
 	 * restarts; both addends zeroed on armed 0->1). Was desync_happened
 	 * alone, which missed every run killed by the stall rail (and so also
-	 * the blind-grind and blind/miss-limit paths that funnel into it) - a
-	 * grinding motor reported error_count 0. See faultErrorCount(). */
+	 * the dead-reckoning budget handoff that funnels into it) - a grinding
+	 * motor reported error_count 0. See faultErrorCount(). */
 	pkt.error_count = faultErrorCount();
 	pkt.voltage = battery_voltage * 0.01;
 

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -22,8 +22,14 @@
  * expected arrival plus 50% grace. An accepted crossing re-arms COM_TIMER
  * for the commutation schedule (cancelling the deadline); if the deadline
  * fires instead, commutate blind at extrapolated timing and keep watching.
- * A missed crossing costs one extrapolated step, not a mode change - there
- * is no fallback to poll mode at runtime.
+ * A missed crossing costs one extrapolated step, not an immediate mode
+ * change - that is the ARK improvement over upstream.
+ *
+ * Poll-mode open-loop ZC remains the soft recovery when the measured average
+ * interval goes long (commutate() / runtimeProcessDesyncCheck, upstream
+ * behaviour restored). Blind owns transient misses; poll owns sustained
+ * "too slow / lost usable closed-loop" recovery. Jump desync and the stall
+ * rail are separate exits.
  */
 /*
  * Dead-reckoning budget. A blind step commutates on extrapolated timing, so
@@ -310,66 +316,9 @@ RAM_FUNC void interruptRoutine()
 	// finally accepted.
 	uint16_t zc_pwm_cnt = (uint16_t)TIM1->CNT;
 #endif
-	/*
-	 * NO MINIMUM-INTERVAL GATE HERE.
-	 *
-	 * A gate rejecting any edge arriving sooner than a quarter of the tracked
-	 * interval used to sit at this point. It was built on the hypothesis that
-	 * the wrong-phase lock this branch chases is a false lock onto switching-
-	 * transient noise, and the F051 has no hardware defence against that -
-	 * comparator output blanking is a G0/G4 peripheral feature (see the
-	 * MCU_G071 guard in Mcu/f051/Src/peripherals.c enableCorePeripherals);
-	 * the STM32F0 COMP has no blanking source at all, so the software confirm
-	 * loop below is the only filter and it deliberately tolerates
-	 * filter_level/4 bad samples. Upstream AM32 carries the same guard,
-	 * commented out, immediately below ("should be impossible, desync?").
-	 *
-	 * The hypothesis was wrong, and the measurement that killed it is worth
-	 * recording so it is not rebuilt. A PWM-phase histogram of ACCEPTED
-	 * crossings (hwci_perf zc_phase_hist, binned on TIM1->CNT at ISR entry;
-	 * TIM1 is edge-aligned UP so CNT maps monotonically onto the PWM period)
-	 * was taken across healthy running and two hand-provoked grinds on an AOS
-	 * Supernova 2207 1980KV, 6S, 5" tri-blade, ARK 4IN1:
-	 *
-	 *     class   frac@turn-on  frac@turn-off  peak enrich  bins holding 80%
-	 *     healthy         0.5%          22.2%          9.8               6.7
-	 *     grind           0.6%           5.8%          5.7              11.0
-	 *     uniform         3.1%           9.4%          1.0              26
-	 *
-	 * Healthy running is sharply locked to the turn-off edge, which is what a
-	 * genuine crossing looks like when the floating phase is only clean during
-	 * PWM-off. The grind is BROADER than healthy and DEPLETED at both
-	 * switching edges - the opposite of a switching artefact. Nor is it
-	 * broadband noise: the intervals repeat far too tightly (see the detector
-	 * below). The edges the loop accepts during a grind are real BEMF
-	 * crossings at a phase relationship the commutation table does not match.
-	 *
-	 * That is fatal to any per-edge filter. A real crossing cannot be
-	 * rejected on its own merits without also rejecting correct ones, and the
-	 * early edge of the pair is as likely to be the genuine one as the late
-	 * edge. The gate also disarmed itself in practice: rejected edges leave
-	 * commutation_interval alone, but ACCEPTED-but-wrong ones update it, so
-	 * the threshold ratcheted down with the estimate it was derived from -
-	 * measured ci 719 -> 570 -> 527 -> 217 -> 86 -> 52 with the gate
-	 * following 179 -> 142 -> 131 -> 54 -> 21 -> 13. A detector whose
-	 * threshold derives from the quantity the failure corrupts cannot work.
-	 *
-	 * The replacement is a sequence test, not an edge test: see the
-	 * wrong-phase lock detector further down this function.
-	 */
-#ifdef HWCI_PERF
-	/* Interval at ISR entry, for the per-commutation trace only - with the
-	 * gate gone nothing in the control path reads it. */
+	/* Elapsed since last accepted crossing / blind step. Used by the
+	 * half-interval early-edge rule after confirm, and by the ZC trace. */
 	const uint32_t zc_elapsed = INTERVAL_TIMER_COUNT;
-#endif
-	//        stuckcounter++; // stuck at 100 interrupts before the main loop happens
-	//                        // again.
-	//        if (stuckcounter > 100) {
-	//            maskPhaseInterrupts();
-	//            zero_crosses = 0;
-	//            return;
-	//        }
-	//    }
 	// Zero-cross confirm: reject unless the window's reads hold the
 	// post-crossing level. Loop speed sets the sampling window: inlining
 	// getCompOutputLevel removes the per-sample call overhead, and with the
@@ -445,6 +394,28 @@ RAM_FUNC void interruptRoutine()
 		}
 	}
 #endif
+	/*
+	 * Half-interval early-edge rule.
+	 *
+	 * A confirmed edge earlier than CI/2 cannot be the next real crossing
+	 * (rotor cannot double speed in one step). Reject it; leave the deadline
+	 * armed so blind uses the existing estimate.
+	 *
+	 * 3/4 + IIR decrease-clamp was tried and FAILED on the bench (2026-08-06):
+	 * under a real throttle ramp the estimate lags, true ZCs arrive "early",
+	 * the tight gate rejects them, blind accumulates, duty fades - smooth
+	 * ramp stalls. Half-interval is the highest threshold that still lets
+	 * legitimate accel through. It does NOT fully stop wrong-phase ratchet
+	 * on hard steps (IIR can still walk CI down with a stream of barely-
+	 * legal accepts); that needs a different approach than "earlier vs CI".
+	 *
+	 * Gated to zero_crosses >= 100 (same arming as the blind deadline).
+	 */
+	if (zero_crosses >= ZC_DEADLINE_MIN_ZC && zc_elapsed < (commutation_interval >> 1)) {
+		HWCI_PERF_CONFIRM_REJECT();
+		HWCI_ZC_TRACE_EV(HWCI_ZC_EV_REJ_MININT, zc_elapsed);
+		return;
+	}
 #ifdef MCU_F051
 	// Turn-on-pileup timestamp compensation. A zero-cross that physically
 	// occurs during the PWM off-window (freewheel) is invisible to the
@@ -549,12 +520,7 @@ RAM_FUNC void interruptRoutine()
 	 * escalation. Demag authority is handled separately in control_loop.c.
 	 */
 	zc_blind_ticks = 0;
-	/* Per-commutation trace: this edge passed the minimum-interval gate AND
-	 * the confirm loop, so it is what the loop actually acted on. The
-	 * trigger arms on the entry signature of the false lock - an accepted
-	 * interval less than half the tracked estimate - so the ring freezes
-	 * holding the commutations either side of entry. Instrumentation only:
-	 * it changes no control decision. */
+	/* Per-commutation trace: confirm + half-interval rule both passed. */
 	HWCI_ZC_TRACE_EV(HWCI_ZC_EV_ACCEPT, zc_elapsed);
 #ifdef MCU_F051
 	const uint16_t newzctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -111,26 +111,6 @@ static uint32_t zc_predicted;
 #define ZC_TAINT_COMMUTATIONS 12
 static uint8_t zc_taint;
 
-/*
- * Accepted intervals to discard after a blind step before the wrong-phase
- * lock detector may compare them (see the detector in interruptRoutine).
- *
- * A blind step resets INTERVAL_TIMER at the COMMUTATION, not at a crossing,
- * so the next accepted crossing measures commutation-to-crossing - about
- * half an interval - rather than crossing-to-crossing. A sustained 50% miss
- * rate therefore records ci, [blind], 0.5ci, ci, [blind], 0.5ci ... which is
- * a textbook 2:1 alternation that says nothing about the rotor. It is an
- * artefact of where the timer is zeroed.
- *
- * Two, so a single blind step invalidates BOTH intervals of the next
- * comparison; under a sustained alternating miss rate the hold is renewed
- * before it expires and the detector never arms. A genuine wrong-phase lock
- * produces no blind steps at all - crossings arrive in abundance, that is
- * its defining property - so the hold is always zero when it matters.
- */
-#define ZC_ALT_BLIND_HOLD 2u
-static uint8_t zc_alt_hold;
-
 int32_t bemfZcGetTrend(void)
 {
 	return zc_trend;
@@ -180,9 +160,6 @@ RAM_FUNC void PeriodElapsedCallback()
 		}
 		blind = 1;
 		zc_blind_steps++;
-		/* The next two accepted intervals are measured from a
-		 * commutation, not a crossing - see ZC_ALT_BLIND_HOLD. */
-		zc_alt_hold = ZC_ALT_BLIND_HOLD;
 		HWCI_PERF_BLIND_STEP();
 		/*
 		 * Commutate now on the existing estimate, and record NO interval
@@ -411,12 +388,38 @@ RAM_FUNC void interruptRoutine()
 	// rejects via the early-out; the full window length (and so the
 	// sustained-noise immunity of the filter_level retune) is unchanged.
 	{
+		/*
+		 * Glitch-tolerant quota: up to filter_level/4 samples may read the
+		 * pre-crossing level. This is an ARK divergence from upstream, which
+		 * rejects on the FIRST bad sample (the #else branch below, still
+		 * used by every other MCU). It exists because 33d93ad moved this
+		 * loop to RAM and inlined getCompOutputLevel, taking the sampling
+		 * cadence from ~56 cycles to ~16; that lands on brief comparator
+		 * glitches about 3x more often, and a strict confirm then defers
+		 * detection to the next comparator edge - up to a PWM period late -
+		 * which bench-measured 2-3x higher commutation jitter at 15-20 kHz
+		 * (23c8387).
+		 *
+		 * SUSPECT, AND KNOWN TO BE. Scoring the window by COUNT ignores
+		 * WHERE the bad samples fall, so a comparator that never really
+		 * settled can pass with 32 of 42 samples right - and the F051 has no
+		 * hardware comparator blanking (a G0/G4 peripheral feature; the
+		 * STM32F0 COMP has no blanking source at all), so this loop is the
+		 * only noise defence on this silicon.
+		 *
+		 * A position-scored replacement was tried - back half of the window
+		 * must be entirely clean, front half unscored, on the grounds that a
+		 * real crossing is a permanent level change while a glitch is
+		 * transient. It was reverted here NOT because it was disproved but
+		 * because it went to the bench in the same build as a duty-fade
+		 * change, so the resulting behaviour could not be attributed to
+		 * either. Reintroduce it on its own.
+		 */
 		int bad = 0;
 		const int tolerance = filter_level >> 2;
 		for (int i = 0; i < filter_level; i++) {
 			if (getCompOutputLevel() == rising) {
 				if (++bad > tolerance) {
-					HWCI_ZC_TRACE_EV(HWCI_ZC_EV_REJ_CONFIRM, zc_elapsed);
 					HWCI_PERF_CONFIRM_REJECT();
 					return;
 				}
@@ -430,7 +433,6 @@ RAM_FUNC void interruptRoutine()
 #	else
 		if (getCompOutputLevel() == rising) {
 #	endif
-			HWCI_ZC_TRACE_EV(HWCI_ZC_EV_REJ_CONFIRM, zc_elapsed);
 			HWCI_PERF_CONFIRM_REJECT();
 			return;
 		}
@@ -552,93 +554,6 @@ RAM_FUNC void interruptRoutine()
 #else
 	const uint16_t newzctime = (uint16_t)INTERVAL_TIMER_COUNT;
 #endif
-	/*
-	 * WRONG-PHASE LOCK DETECTOR.
-	 *
-	 * Every other rail in this file - the dead-reckoning budget, the stall
-	 * threshold, the demag run - keys on the ABSENCE of crossings. The
-	 * failure this catches is the opposite: an excess of them. The loop
-	 * settles onto real BEMF crossings at a phase relationship the
-	 * commutation table does not match, reports 16-21x the physically
-	 * possible eRPM, and every existing detector reads a healthy motor
-	 * because crossings keep arriving. bemf_timeout_happened stayed at 0
-	 * through every episode captured on the bench.
-	 *
-	 * Bench evidence (F051, AOS 2207 1980KV, 6S, 5in 3-blade), consecutive
-	 * accepted intervals through a grind:
-	 *
-	 *     863 383 712 382 837 330 846 341 753 340 878 311 861 343 ...
-	 *
-	 * Ratio of each to the one before: 0.44 1.86 0.54 2.19 0.39 2.56 0.40
-	 * 2.21 0.45 2.58 0.35 2.77 ... - a hard 2:1 alternation sustained for
-	 * sixteen-plus commutations. A 2207 carrying a prop cannot halve and
-	 * double its speed every 400us; rotor inertia puts that many orders of
-	 * magnitude out of reach. The two-step product stays near 1.0, so the
-	 * loop is running at roughly twice the true commutation rate.
-	 *
-	 * Why the test is on the RATIO of consecutive raw measurements:
-	 *
-	 *  - It is scale-free. It cannot be walked down by the failure it is
-	 *    looking for. The jump check keyed on average_interval and the
-	 *    minimum-interval gate keyed on commutation_interval both derive
-	 *    their threshold from the quantity the false lock corrupts, so as
-	 *    the estimate collapses the threshold collapses with it and the
-	 *    detector disarms itself exactly when it is needed. Measured: ci
-	 *    719 -> 570 -> 527 -> 217 -> 86 -> 52 with the gate tracking it
-	 *    down 179 -> 142 -> 131 -> 54 -> 21 -> 13.
-	 *
-	 *  - It does not need to know WHICH edge is spurious. A PWM-phase
-	 *    histogram of accepted crossings settled that question the other
-	 *    way: in the grind the accepted edges are BROADER in phase than in
-	 *    healthy running (80% of the mass in 11 of 32 bins vs 6.7) and are
-	 *    DEPLETED at both switching edges - 0.6% at turn-on and 5.8% at
-	 *    turn-off against 3.1% and 9.4% for a uniform distribution, where
-	 *    healthy running is sharply locked to turn-off at 22.2%. They are
-	 *    not switching transients and they are not broadband noise (the
-	 *    intervals repeat far too tightly). They are real crossings, and no
-	 *    per-edge filter can reject a real crossing without also rejecting
-	 *    the correct ones. Only the sequence is impossible.
-	 *
-	 * An isolated missed crossing gives T, 2T, 0.5T - one alternation, which
-	 * is legitimate and common, so a run of ZC_ALT_RUN_MIN is required
-	 * before anything is charged. The captures show sixteen-plus.
-	 *
-	 * The response is duty authority, not a rail: this feeds the existing
-	 * position-confidence fade in control_loop.c. Untrusted commutation
-	 * means less power - less energy into a wrong-phase lock, shorter demag,
-	 * and a lock that cannot sustain itself - rather than another trip point
-	 * that restarts the loop through the startup path at full setpoint.
-	 */
-	if (zc_alt_hold != 0u) {
-		/* One of the two intervals under comparison was measured from a
-		 * blind commutation rather than a crossing, so its 2:1 shape is
-		 * an artefact. Discard it and hold the run at zero. */
-		zc_alt_hold--;
-		zc_alt_run = 0;
-	} else if (zero_crosses >= ZC_DEADLINE_MIN_ZC && lastzctime != 0u && thiszctime != 0u) {
-		const uint32_t a = newzctime, b = thiszctime, c = lastzctime;
-		/* 1.6x either way: the grind's short legs measured 0.35-0.54 and
-		 * its long legs 1.86-2.77, so this clears both with margin while
-		 * staying far outside anything rotor inertia permits. */
-		const uint8_t up_ab = (a * 5u) > (b * 8u);
-		const uint8_t dn_ab = (a * 8u) < (b * 5u);
-		const uint8_t up_bc = (b * 5u) > (c * 8u);
-		const uint8_t dn_bc = (b * 8u) < (c * 5u);
-		if ((up_ab && dn_bc) || (dn_ab && up_bc)) {
-			if (zc_alt_run < 255u) {
-				zc_alt_run++;
-			}
-			if (zc_alt_run == ZC_ALT_RUN_MIN) {
-				/* Freeze the per-commutation ring the moment the
-				 * detector arms, so a capture holds the run-up
-				 * into the lock and the first commutations of the
-				 * fade. Instrumentation only. */
-				HWCI_ZC_TRACE_TRIGGER();
-			}
-		} else {
-			zc_alt_run = 0;
-		}
-	}
 	lastzctime = thiszctime;
 	thiszctime = newzctime;
 	SET_INTERVAL_TIMER_COUNT(0);
@@ -664,8 +579,6 @@ void startMotor()
 		bemfZcResetTrend(); // no interval history across a stop
 		zc_pre_seen = 1;
 		zc_demag_run = 0;
-		zc_alt_run = 0; // no interval history survives a stop
-		zc_alt_hold = 0;
 		commutate();
 		commutation_interval = 10000;
 		SET_INTERVAL_TIMER_COUNT(5000);

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -90,9 +90,55 @@ static int32_t zc_trend;
 /* Last predicted interval used for advance/waitTime (observability + SITL). */
 static uint32_t zc_predicted;
 
+/*
+ * Extrapolated-average taint window (see bemfZcAverageTainted in bemf_zc.h).
+ *
+ * A blind step's inflated interval reaches the jump-desync detector by two
+ * routes, and both have to flush before a comparison means anything:
+ *
+ *   commutation_intervals[] -> e_com_time is a SUM OF SIX entries (main.c), so
+ *   six clean commutations are needed to push the last blind interval out.
+ *
+ *   average_interval is then compared against last_average_interval, which is
+ *   sampled one electrical revolution earlier - so a second clean revolution
+ *   is needed before BOTH endpoints of the comparison are measurements.
+ *
+ * Twelve commutations, i.e. two electrical revolutions. At 5k rpm on a 14-pole
+ * motor that is ~3.4 ms of suppression per blind step, during which the
+ * dead-reckoning budget in this file is still watching - the loop is not
+ * unprotected, the jump check is simply not the rail that owns this case.
+ */
+#define ZC_TAINT_COMMUTATIONS 12
+static uint8_t zc_taint;
+
+/*
+ * Accepted intervals to discard after a blind step before the wrong-phase
+ * lock detector may compare them (see the detector in interruptRoutine).
+ *
+ * A blind step resets INTERVAL_TIMER at the COMMUTATION, not at a crossing,
+ * so the next accepted crossing measures commutation-to-crossing - about
+ * half an interval - rather than crossing-to-crossing. A sustained 50% miss
+ * rate therefore records ci, [blind], 0.5ci, ci, [blind], 0.5ci ... which is
+ * a textbook 2:1 alternation that says nothing about the rotor. It is an
+ * artefact of where the timer is zeroed.
+ *
+ * Two, so a single blind step invalidates BOTH intervals of the next
+ * comparison; under a sustained alternating miss rate the hold is renewed
+ * before it expires and the detector never arms. A genuine wrong-phase lock
+ * produces no blind steps at all - crossings arrive in abundance, that is
+ * its defining property - so the hold is always zero when it matters.
+ */
+#define ZC_ALT_BLIND_HOLD 2u
+static uint8_t zc_alt_hold;
+
 int32_t bemfZcGetTrend(void)
 {
 	return zc_trend;
+}
+
+uint8_t bemfZcAverageTainted(void)
+{
+	return (uint8_t)(zc_taint != 0);
 }
 
 uint32_t bemfZcGetPredicted(void)
@@ -127,17 +173,49 @@ RAM_FUNC void PeriodElapsedCallback()
 			// the startup path on its next main-loop pass, and charges the
 			// episode bucket once. With phase interrupts masked nothing can
 			// reset INTERVAL_TIMER before it runs.
+			HWCI_ZC_TRACE_EV(HWCI_ZC_EV_BUDGET, INTERVAL_TIMER_COUNT);
 			maskPhaseInterrupts();
 			SET_INTERVAL_TIMER_COUNT(BEMF_STALL_TICKS + 1000u);
 			return;
 		}
 		blind = 1;
 		zc_blind_steps++;
+		/* The next two accepted intervals are measured from a
+		 * commutation, not a crossing - see ZC_ALT_BLIND_HOLD. */
+		zc_alt_hold = ZC_ALT_BLIND_HOLD;
 		HWCI_PERF_BLIND_STEP();
-		// Take the full elapsed time as the (late) crossing measurement
-		// and commutate now. The inflated interval feeds the average so
-		// timing hunts slower - the safe direction for a decelerating
-		// rotor - and the next accepted crossing resyncs immediately.
+		/*
+		 * Commutate now on the existing estimate, and record NO interval
+		 * measurement - see the commutation_interval update below.
+		 *
+		 * This deliberately reverses the older behaviour, which took the
+		 * full elapsed deadline time as a "late crossing measurement" on
+		 * the theory that an inflated interval makes timing hunt slower,
+		 * the safe direction for a decelerating rotor, and that the next
+		 * accepted crossing would resync it immediately.
+		 *
+		 * The second half of that is false at any sustained miss rate, and
+		 * the feedback runs away. The deadline is armed at 1.5x the
+		 * estimate, so a blind step's elapsed time is ALWAYS ~1.5x - it is
+		 * a property of the grace period, not a measurement of the rotor.
+		 * Feeding it to the average raises the estimate, which lengthens
+		 * the next deadline, which produces a larger elapsed, and so on.
+		 *
+		 * Measured in SITL under mode-2 fault injection (drop every other
+		 * commutation window, a 50% miss rate on a rotor holding speed):
+		 * commutation_interval went 432 -> 1880 -> 3281 -> 3942 -> 4396 ->
+		 * 5128 -> 5823 -> 6853 in 70 ms, a 16x inflation with the rotor at
+		 * constant rpm, until the stall rail tripped on the ESC's own
+		 * runaway and restarted the loop. Every accepted crossing in
+		 * between cleared zc_blind_ticks exactly as designed - the
+		 * dead-reckoning budget was never the thing that fired.
+		 *
+		 * A blind step's real information content is a LOWER BOUND: "no
+		 * crossing arrived before 1.5x". Treating a lower bound as a point
+		 * estimate is the whole bug. The rotor slowing down is still
+		 * caught, by the next accepted crossing measuring long and by
+		 * zc_blind_ticks if crossings stop arriving altogether.
+		 */
 		maskPhaseInterrupts();
 		uint32_t elapsed = INTERVAL_TIMER_COUNT;
 		if (elapsed > 65535u) {
@@ -154,8 +232,11 @@ RAM_FUNC void PeriodElapsedCallback()
 		 * one frame of slightly-too-generous duty authority.
 		 */
 		zc_blind_ticks += elapsed; // extrapolated time, cleared by a real crossing
-		lastzctime = thiszctime;
-		thiszctime = (uint16_t)elapsed;
+		HWCI_ZC_TRACE_EV(HWCI_ZC_EV_BLIND, elapsed);
+		/* lastzctime/thiszctime deliberately NOT written: they are the
+		 * measured-interval history. Resetting INTERVAL_TIMER still means
+		 * the next accepted crossing measures the window from this blind
+		 * commutation to that crossing, which IS a real measurement. */
 		SET_INTERVAL_TIMER_COUNT(0);
 	} else {
 		// Cancel race: SET_AND_ENABLE_COM_INT clears the peripheral flag,
@@ -171,7 +252,13 @@ RAM_FUNC void PeriodElapsedCallback()
 		}
 	}
 	commutate();
-	commutation_interval = ((commutation_interval) + ((lastzctime + thiszctime) >> 1)) >> 1;
+	/* Only a measured crossing updates the interval estimate. A blind step
+	 * contributes nothing: see the note in the deadline branch above for the
+	 * runaway this prevents. The estimate simply holds, so the next deadline
+	 * stays at 1.5x the last MEASURED interval instead of compounding. */
+	if (!blind) {
+		commutation_interval = ((commutation_interval) + ((lastzctime + thiszctime) >> 1)) >> 1;
+	}
 	/* See zc_trend: predict the interval about to be timed, not the lagging
 	 * average of the ones already measured. */
 	uint32_t predicted = commutation_interval;
@@ -214,6 +301,14 @@ RAM_FUNC void PeriodElapsedCallback()
 			SET_AND_ENABLE_COM_INT((uint16_t)deadline);
 		}
 	}
+	/* Taint the interval average for as long as an extrapolated interval can
+	 * still be inside e_com_time's six-deep window or inside the previous
+	 * endpoint of the jump check's comparison. */
+	if (blind) {
+		zc_taint = ZC_TAINT_COMMUTATIONS;
+	} else if (zc_taint) {
+		zc_taint--;
+	}
 	if (!blind && zero_crosses < 10000) {
 		zero_crosses++;
 	}
@@ -238,10 +333,58 @@ RAM_FUNC void interruptRoutine()
 	// finally accepted.
 	uint16_t zc_pwm_cnt = (uint16_t)TIM1->CNT;
 #endif
-	//   if (average_interval > 125) {
-	//        if ((INTERVAL_TIMER_COUNT < 125) && (duty_cycle < 600) && (zero_crosses < 500)) { // should be impossible, desync?exit anyway
-	//           return;
-	//        }
+	/*
+	 * NO MINIMUM-INTERVAL GATE HERE.
+	 *
+	 * A gate rejecting any edge arriving sooner than a quarter of the tracked
+	 * interval used to sit at this point. It was built on the hypothesis that
+	 * the wrong-phase lock this branch chases is a false lock onto switching-
+	 * transient noise, and the F051 has no hardware defence against that -
+	 * comparator output blanking is a G0/G4 peripheral feature (see the
+	 * MCU_G071 guard in Mcu/f051/Src/peripherals.c enableCorePeripherals);
+	 * the STM32F0 COMP has no blanking source at all, so the software confirm
+	 * loop below is the only filter and it deliberately tolerates
+	 * filter_level/4 bad samples. Upstream AM32 carries the same guard,
+	 * commented out, immediately below ("should be impossible, desync?").
+	 *
+	 * The hypothesis was wrong, and the measurement that killed it is worth
+	 * recording so it is not rebuilt. A PWM-phase histogram of ACCEPTED
+	 * crossings (hwci_perf zc_phase_hist, binned on TIM1->CNT at ISR entry;
+	 * TIM1 is edge-aligned UP so CNT maps monotonically onto the PWM period)
+	 * was taken across healthy running and two hand-provoked grinds on an AOS
+	 * Supernova 2207 1980KV, 6S, 5" tri-blade, ARK 4IN1:
+	 *
+	 *     class   frac@turn-on  frac@turn-off  peak enrich  bins holding 80%
+	 *     healthy         0.5%          22.2%          9.8               6.7
+	 *     grind           0.6%           5.8%          5.7              11.0
+	 *     uniform         3.1%           9.4%          1.0              26
+	 *
+	 * Healthy running is sharply locked to the turn-off edge, which is what a
+	 * genuine crossing looks like when the floating phase is only clean during
+	 * PWM-off. The grind is BROADER than healthy and DEPLETED at both
+	 * switching edges - the opposite of a switching artefact. Nor is it
+	 * broadband noise: the intervals repeat far too tightly (see the detector
+	 * below). The edges the loop accepts during a grind are real BEMF
+	 * crossings at a phase relationship the commutation table does not match.
+	 *
+	 * That is fatal to any per-edge filter. A real crossing cannot be
+	 * rejected on its own merits without also rejecting correct ones, and the
+	 * early edge of the pair is as likely to be the genuine one as the late
+	 * edge. The gate also disarmed itself in practice: rejected edges leave
+	 * commutation_interval alone, but ACCEPTED-but-wrong ones update it, so
+	 * the threshold ratcheted down with the estimate it was derived from -
+	 * measured ci 719 -> 570 -> 527 -> 217 -> 86 -> 52 with the gate
+	 * following 179 -> 142 -> 131 -> 54 -> 21 -> 13. A detector whose
+	 * threshold derives from the quantity the failure corrupts cannot work.
+	 *
+	 * The replacement is a sequence test, not an edge test: see the
+	 * wrong-phase lock detector further down this function.
+	 */
+#ifdef HWCI_PERF
+	/* Interval at ISR entry, for the per-commutation trace only - with the
+	 * gate gone nothing in the control path reads it. */
+	const uint32_t zc_elapsed = INTERVAL_TIMER_COUNT;
+#endif
 	//        stuckcounter++; // stuck at 100 interrupts before the main loop happens
 	//                        // again.
 	//        if (stuckcounter > 100) {
@@ -273,6 +416,7 @@ RAM_FUNC void interruptRoutine()
 		for (int i = 0; i < filter_level; i++) {
 			if (getCompOutputLevel() == rising) {
 				if (++bad > tolerance) {
+					HWCI_ZC_TRACE_EV(HWCI_ZC_EV_REJ_CONFIRM, zc_elapsed);
 					HWCI_PERF_CONFIRM_REJECT();
 					return;
 				}
@@ -286,6 +430,7 @@ RAM_FUNC void interruptRoutine()
 #	else
 		if (getCompOutputLevel() == rising) {
 #	endif
+			HWCI_ZC_TRACE_EV(HWCI_ZC_EV_REJ_CONFIRM, zc_elapsed);
 			HWCI_PERF_CONFIRM_REJECT();
 			return;
 		}
@@ -395,12 +540,107 @@ RAM_FUNC void interruptRoutine()
 	 * escalation. Demag authority is handled separately in control_loop.c.
 	 */
 	zc_blind_ticks = 0;
-	lastzctime = thiszctime;
+	/* Per-commutation trace: this edge passed the minimum-interval gate AND
+	 * the confirm loop, so it is what the loop actually acted on. The
+	 * trigger arms on the entry signature of the false lock - an accepted
+	 * interval less than half the tracked estimate - so the ring freezes
+	 * holding the commutations either side of entry. Instrumentation only:
+	 * it changes no control decision. */
+	HWCI_ZC_TRACE_EV(HWCI_ZC_EV_ACCEPT, zc_elapsed);
 #ifdef MCU_F051
-	thiszctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
+	const uint16_t newzctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
 #else
-	thiszctime = INTERVAL_TIMER_COUNT;
+	const uint16_t newzctime = (uint16_t)INTERVAL_TIMER_COUNT;
 #endif
+	/*
+	 * WRONG-PHASE LOCK DETECTOR.
+	 *
+	 * Every other rail in this file - the dead-reckoning budget, the stall
+	 * threshold, the demag run - keys on the ABSENCE of crossings. The
+	 * failure this catches is the opposite: an excess of them. The loop
+	 * settles onto real BEMF crossings at a phase relationship the
+	 * commutation table does not match, reports 16-21x the physically
+	 * possible eRPM, and every existing detector reads a healthy motor
+	 * because crossings keep arriving. bemf_timeout_happened stayed at 0
+	 * through every episode captured on the bench.
+	 *
+	 * Bench evidence (F051, AOS 2207 1980KV, 6S, 5in 3-blade), consecutive
+	 * accepted intervals through a grind:
+	 *
+	 *     863 383 712 382 837 330 846 341 753 340 878 311 861 343 ...
+	 *
+	 * Ratio of each to the one before: 0.44 1.86 0.54 2.19 0.39 2.56 0.40
+	 * 2.21 0.45 2.58 0.35 2.77 ... - a hard 2:1 alternation sustained for
+	 * sixteen-plus commutations. A 2207 carrying a prop cannot halve and
+	 * double its speed every 400us; rotor inertia puts that many orders of
+	 * magnitude out of reach. The two-step product stays near 1.0, so the
+	 * loop is running at roughly twice the true commutation rate.
+	 *
+	 * Why the test is on the RATIO of consecutive raw measurements:
+	 *
+	 *  - It is scale-free. It cannot be walked down by the failure it is
+	 *    looking for. The jump check keyed on average_interval and the
+	 *    minimum-interval gate keyed on commutation_interval both derive
+	 *    their threshold from the quantity the false lock corrupts, so as
+	 *    the estimate collapses the threshold collapses with it and the
+	 *    detector disarms itself exactly when it is needed. Measured: ci
+	 *    719 -> 570 -> 527 -> 217 -> 86 -> 52 with the gate tracking it
+	 *    down 179 -> 142 -> 131 -> 54 -> 21 -> 13.
+	 *
+	 *  - It does not need to know WHICH edge is spurious. A PWM-phase
+	 *    histogram of accepted crossings settled that question the other
+	 *    way: in the grind the accepted edges are BROADER in phase than in
+	 *    healthy running (80% of the mass in 11 of 32 bins vs 6.7) and are
+	 *    DEPLETED at both switching edges - 0.6% at turn-on and 5.8% at
+	 *    turn-off against 3.1% and 9.4% for a uniform distribution, where
+	 *    healthy running is sharply locked to turn-off at 22.2%. They are
+	 *    not switching transients and they are not broadband noise (the
+	 *    intervals repeat far too tightly). They are real crossings, and no
+	 *    per-edge filter can reject a real crossing without also rejecting
+	 *    the correct ones. Only the sequence is impossible.
+	 *
+	 * An isolated missed crossing gives T, 2T, 0.5T - one alternation, which
+	 * is legitimate and common, so a run of ZC_ALT_RUN_MIN is required
+	 * before anything is charged. The captures show sixteen-plus.
+	 *
+	 * The response is duty authority, not a rail: this feeds the existing
+	 * position-confidence fade in control_loop.c. Untrusted commutation
+	 * means less power - less energy into a wrong-phase lock, shorter demag,
+	 * and a lock that cannot sustain itself - rather than another trip point
+	 * that restarts the loop through the startup path at full setpoint.
+	 */
+	if (zc_alt_hold != 0u) {
+		/* One of the two intervals under comparison was measured from a
+		 * blind commutation rather than a crossing, so its 2:1 shape is
+		 * an artefact. Discard it and hold the run at zero. */
+		zc_alt_hold--;
+		zc_alt_run = 0;
+	} else if (zero_crosses >= ZC_DEADLINE_MIN_ZC && lastzctime != 0u && thiszctime != 0u) {
+		const uint32_t a = newzctime, b = thiszctime, c = lastzctime;
+		/* 1.6x either way: the grind's short legs measured 0.35-0.54 and
+		 * its long legs 1.86-2.77, so this clears both with margin while
+		 * staying far outside anything rotor inertia permits. */
+		const uint8_t up_ab = (a * 5u) > (b * 8u);
+		const uint8_t dn_ab = (a * 8u) < (b * 5u);
+		const uint8_t up_bc = (b * 5u) > (c * 8u);
+		const uint8_t dn_bc = (b * 8u) < (c * 5u);
+		if ((up_ab && dn_bc) || (dn_ab && up_bc)) {
+			if (zc_alt_run < 255u) {
+				zc_alt_run++;
+			}
+			if (zc_alt_run == ZC_ALT_RUN_MIN) {
+				/* Freeze the per-commutation ring the moment the
+				 * detector arms, so a capture holds the run-up
+				 * into the lock and the first commutations of the
+				 * fade. Instrumentation only. */
+				HWCI_ZC_TRACE_TRIGGER();
+			}
+		} else {
+			zc_alt_run = 0;
+		}
+	}
+	lastzctime = thiszctime;
+	thiszctime = newzctime;
 	SET_INTERVAL_TIMER_COUNT(0);
 	SET_AND_ENABLE_COM_INT(waitTime + 1); // enable COM_TIMER interrupt
 	__enable_irq();
@@ -420,9 +660,12 @@ void startMotor()
 		zc_deadline_armed = 0;
 		zc_blind_steps = 0;
 		zc_blind_ticks = 0;
+		zc_taint = 0;	    // no extrapolated intervals survive a stop
 		bemfZcResetTrend(); // no interval history across a stop
 		zc_pre_seen = 1;
 		zc_demag_run = 0;
+		zc_alt_run = 0; // no interval history survives a stop
+		zc_alt_hold = 0;
 		commutate();
 		commutation_interval = 10000;
 		SET_INTERVAL_TIMER_COUNT(5000);

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -126,7 +126,29 @@ RAM_FUNC void PeriodElapsedCallback()
 		// Deadline firing, not a commutation scheduled by an accepted
 		// zero-cross (interruptRoutine cancels the deadline first).
 		zc_deadline_armed = 0;
+		/*
+		 * AB_NO_MISS_RAIL: drop the miss-RATE half of this test and keep
+		 * the consecutive half. The bucket keeps counting either way, so
+		 * anything watching it still sees the rate; only the restart is
+		 * removed.
+		 *
+		 * Worth knowing what the threshold actually is before deciding
+		 * whether removing it is reasonable. The bucket gains
+		 * ZC_MISS_BUCKET_INC (3) per blind step and drains 1 per accepted
+		 * crossing, so at miss fraction f it moves by 4f - 1 per
+		 * commutation: it drains to zero below a 25% miss rate and climbs
+		 * to the limit above it. That is a cliff with no hysteresis - one
+		 * side runs indefinitely, the other restarts indefinitely, and an
+		 * article whose demag rate sits near 25% oscillates across it.
+		 * Whether a sustained 25%+ miss rate is better served by blind
+		 * stepping (upstream keeps flying, degraded) or by a restart is
+		 * exactly what this switch exists to measure.
+		 */
+#ifdef AB_NO_MISS_RAIL
+		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT) {
+#else
 		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT || zc_miss_bucket >= ZC_MISS_BUCKET_LIMIT) {
+#endif
 			// Position unknown for too long (consecutively or as a
 			// sustained miss rate): stop stepping blind. Kick the
 			// INTERVAL_TIMER past the 45000 stall threshold so the

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -25,41 +25,34 @@
  * A missed crossing costs one extrapolated step, not a mode change - there
  * is no fallback to poll mode at runtime.
  */
-#define ZC_BLIND_STEP_LIMIT 8 /* consecutive extrapolated steps before the stall rail takes over */
 /*
- * Miss-RATE rail. zc_blind_steps only counts CONSECUTIVE misses - an
- * alternating real/missed pattern (the demag signature) resets it on every
- * accepted crossing and would blind-step indefinitely at ~12.5% interval
- * inflation per miss, never reaching the step limit, the trust rail (real
- * crossings keep the average under the changeover band) or the stall rail
- * (both paths reset INTERVAL_TIMER). Leaky bucket: each blind step adds
- * ZC_MISS_BUCKET_INC, each accepted crossing drains 1, at
- * ZC_MISS_BUCKET_LIMIT the handler stops stepping blind and hands the loop
- * to the stall rail exactly like the consecutive-step limit. Sustained miss
- * rates above 1-in-4 climb; 8 consecutive misses reach the limit on the
- * same deadline event as ZC_BLIND_STEP_LIMIT, so the consecutive case is
- * unchanged. Alternating 50% trips after ~12 misses (~4 electrical revs).
+ * Dead-reckoning budget. A blind step commutates on extrapolated timing, so
+ * between the last accepted crossing and the next one the rotor position is
+ * an estimate. zc_blind_ticks accumulates that estimated time (INTERVAL_TIMER
+ * ticks) and an accepted crossing clears it: it is "how long since the rotor
+ * last told us where it was".
+ *
+ * That single quantity replaces the consecutive-blind-step limit, the leaky
+ * miss-rate bucket and the blind-grind window that used to sit here and in
+ * faults.c. All three were answering the same question - how much blind is
+ * too much - in different units, each with its own tuned threshold, and each
+ * answering it by RESTARTING. The miss-rate bucket in particular gained 3 per
+ * blind step and drained 1 per accepted crossing, so it tripped above a 25%
+ * miss rate exactly: a cliff with no hysteresis, where one side runs forever
+ * and the other restarts forever, and a restart cannot improve the miss rate
+ * that caused it.
+ *
+ * There is no threshold to pick here. Upstream restarts when INTERVAL_TIMER
+ * shows no commutation evidence for BEMF_STALL_TICKS, and the only reason
+ * that rail could not see a blind grind is that blind steps reset
+ * INTERVAL_TIMER. Measuring the blind time separately restores upstream's own
+ * criterion - and with it upstream's behaviour, which is to keep flying on
+ * degraded timing rather than stop. A 50% miss rate now flies: every accepted
+ * crossing clears the budget, so only a genuine absence of crossings can
+ * exhaust it.
  */
-#define ZC_MISS_BUCKET_INC 3
-#define ZC_MISS_BUCKET_LIMIT 24
-/*
- * Blind stepping requires an ESTABLISHED closed loop. At the poll->interrupt
- * handoff commutation_interval is whatever the startup noise made of it -
- * bench: noise-shrunk to ~1300 ticks while the true interval of the barely
- * moving rotor is 5-10x longer - so a deadline at 1.5x the believed interval
- * fires BEFORE the first real crossing can arrive, commutates blind, and
- * drags the stator field away from the rotor. The result is a stable false
- * lock: noise bursts get accepted as crossings, blind steps bridge the gaps
- * between bursts (bench: ~40% of commutations blind, phantom ~15k eRPM,
- * rotor stalled at 3 A), and the stall rail almost never fires because every
- * blind step resets INTERVAL_TIMER. Below this zero-cross count the handler
- * keeps legacy semantics (commutate once per accepted crossing, no re-arm):
- * a noise chain then dies at the 45000-tick stall rail and the poll path
- * kick-steps the rotor exactly as ark-release does. 100 matches the startup
- * self-heal window in commutate() and the "stable running" gates elsewhere;
- * zero_crosses resets on desync/stop, so every re-acquisition passes through
- * the legacy path again before blind stepping re-arms.
- */
+#define ZC_DEAD_RECKONING_BUDGET BEMF_STALL_TICKS
+
 #define ZC_DEADLINE_MIN_ZC 100
 
 /*
@@ -126,49 +119,20 @@ RAM_FUNC void PeriodElapsedCallback()
 		// Deadline firing, not a commutation scheduled by an accepted
 		// zero-cross (interruptRoutine cancels the deadline first).
 		zc_deadline_armed = 0;
-		/*
-		 * AB_NO_MISS_RAIL: drop the miss-RATE half of this test and keep
-		 * the consecutive half. The bucket keeps counting either way, so
-		 * anything watching it still sees the rate; only the restart is
-		 * removed.
-		 *
-		 * Worth knowing what the threshold actually is before deciding
-		 * whether removing it is reasonable. The bucket gains
-		 * ZC_MISS_BUCKET_INC (3) per blind step and drains 1 per accepted
-		 * crossing, so at miss fraction f it moves by 4f - 1 per
-		 * commutation: it drains to zero below a 25% miss rate and climbs
-		 * to the limit above it. That is a cliff with no hysteresis - one
-		 * side runs indefinitely, the other restarts indefinitely, and an
-		 * article whose demag rate sits near 25% oscillates across it.
-		 * Whether a sustained 25%+ miss rate is better served by blind
-		 * stepping (upstream keeps flying, degraded) or by a restart is
-		 * exactly what this switch exists to measure.
-		 */
-#ifdef AB_NO_MISS_RAIL
-		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT) {
-#else
-		if (zc_blind_steps >= ZC_BLIND_STEP_LIMIT || zc_miss_bucket >= ZC_MISS_BUCKET_LIMIT) {
-#endif
-			// Position unknown for too long (consecutively or as a
-			// sustained miss rate): stop stepping blind. Kick the
-			// INTERVAL_TIMER past the 45000 stall threshold so the
-			// main-loop rail (faultHandleBemfIntervalStall) restarts
-			// through the startup path on its next pass instead of
-			// 22 ms from now. That rail also charges the cross-episode
-			// desync bucket - do NOT charge here as well (it double-
-			// counted the episode), and the stall rail is guaranteed to
-			// see it: comparator interrupts are masked, so no accepted
-			// crossing can reset INTERVAL_TIMER before the main loop.
+		if (zc_blind_ticks >= ZC_DEAD_RECKONING_BUDGET) {
+			// No accepted crossing for a whole dead-reckoning budget:
+			// position is genuinely unknown, not merely uncertain. Hand
+			// off exactly as before - kick INTERVAL_TIMER past the stall
+			// threshold so faultHandleBemfIntervalStall restarts through
+			// the startup path on its next main-loop pass, and charges the
+			// episode bucket once. With phase interrupts masked nothing can
+			// reset INTERVAL_TIMER before it runs.
 			maskPhaseInterrupts();
-			SET_INTERVAL_TIMER_COUNT(46000);
+			SET_INTERVAL_TIMER_COUNT(BEMF_STALL_TICKS + 1000u);
 			return;
 		}
 		blind = 1;
 		zc_blind_steps++;
-		zc_miss_bucket += ZC_MISS_BUCKET_INC;
-		if (zc_blind_window_count < 255) {
-			zc_blind_window_count++; // grind-rate window (faults.c, 1 kHz)
-		}
 		HWCI_PERF_BLIND_STEP();
 		// Take the full elapsed time as the (late) crossing measurement
 		// and commutate now. The inflated interval feeds the average so
@@ -179,6 +143,7 @@ RAM_FUNC void PeriodElapsedCallback()
 		if (elapsed > 65535u) {
 			elapsed = 65535u;
 		}
+		zc_blind_ticks += elapsed; // extrapolated time, cleared by a real crossing
 		lastzctime = thiszctime;
 		thiszctime = (uint16_t)elapsed;
 		SET_INTERVAL_TIMER_COUNT(0);
@@ -410,9 +375,17 @@ RAM_FUNC void interruptRoutine()
 		zc_demag_run = 0;
 	}
 	zc_pre_seen = 0;
-	if (zc_miss_bucket) {
-		zc_miss_bucket--; // accepted crossing drains the miss-rate bucket
-	}
+	/*
+	 * The rotor has just reported its position, so the dead-reckoning budget
+	 * is spent and starts again. This clears unconditionally, INCLUDING on a
+	 * demag-late crossing: a late report is still a report, and normal
+	 * spool-up under load is genuinely demag-late for long stretches (high
+	 * slip current). Charging those to the budget walks a hard start into a
+	 * restart, which is the kick loop the demag-late block above is explicit
+	 * about avoiding - its response is a current reduction only, never an
+	 * escalation. Demag authority is handled separately in control_loop.c.
+	 */
+	zc_blind_ticks = 0;
 	lastzctime = thiszctime;
 #ifdef MCU_F051
 	thiszctime = (uint16_t)(INTERVAL_TIMER_COUNT - zc_grid_comp);
@@ -437,8 +410,7 @@ void startMotor()
 		DISABLE_COM_TIMER_INT(); // a stale blind-step deadline must not commutate the restart
 		zc_deadline_armed = 0;
 		zc_blind_steps = 0;
-		zc_miss_bucket = 0;
-		zc_blind_window_count = 0;
+		zc_blind_ticks = 0;
 		bemfZcResetTrend(); // no interval history across a stop
 		zc_pre_seen = 1;
 		zc_demag_run = 0;

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -143,6 +143,16 @@ RAM_FUNC void PeriodElapsedCallback()
 		if (elapsed > 65535u) {
 			elapsed = 65535u;
 		}
+		/*
+		 * Not atomic on Cortex-M0, and does not need to be: the only other
+		 * writer is the clear in interruptRoutine, and maskPhaseInterrupts()
+		 * three lines up has already shut the comparator EXTI off - so no
+		 * accepted crossing can land between this load and its store. The
+		 * remaining concurrent access is the read in setInput (DShot ISR on
+		 * F051), which can see the pre-increment value for one frame; that
+		 * is a monotone counter read one update late, and it costs at most
+		 * one frame of slightly-too-generous duty authority.
+		 */
 		zc_blind_ticks += elapsed; // extrapolated time, cleared by a real crossing
 		lastzctime = thiszctime;
 		thiszctime = (uint16_t)elapsed;
@@ -347,16 +357,15 @@ RAM_FUNC void interruptRoutine()
 	// mistimed lock (bench 2026-07-22: ~30% slow at 8-10x current on ~1/3
 	// of warm snap starts, 100% of hot ones; never self-heals; invisible
 	// to the desync jump check and the trust rail because the interval is
-	// steady and fast-looking). Charge the miss bucket and let the
-	// consecutive counter drive the same power cut as blind steps
-	// (control_loop): less current shortens demag, the pre-level dwell
-	// reappears and the loop re-times itself - the firmware equivalent of
-	// the throttle-blip escape verified on the bench. Sustained demag-late
-	// accepts escalate to the stall rail exactly like a sustained miss
-	// rate. Gated to CI > 500 (250 us+), where the healthy pre-level dwell
-	// spans many main-loop passes so the sampler cannot miss it.
+	// steady and fast-looking). Count the consecutive run and let it fade
+	// duty authority (control_loop): less current shortens demag, the
+	// pre-level dwell reappears and the loop re-times itself - the firmware
+	// equivalent of the throttle-blip escape verified on the bench. Gated to
+	// CI > 500 (250 us+), where the healthy pre-level dwell spans many
+	// main-loop passes so the sampler cannot miss it.
 	//
-	// The response is the power cut ONLY - no miss-bucket charge, no stall
+	// The response is the authority fade ONLY - a demag-late crossing still
+	// clears the dead-reckoning budget, so it can never reach the stall
 	// rail. Normal spool-up under load is genuinely demag-late for long
 	// stretches (high slip current), so any restart escalation turns every
 	// hard start into a kick loop (bench: 2-3 restarts and ~10 desyncs per

--- a/Src/bemf_zc.c
+++ b/Src/bemf_zc.c
@@ -377,52 +377,59 @@ RAM_FUNC void interruptRoutine()
 	// is scaled (42/10/7 on F051) to keep the same wall-clock window as the
 	// stock ~56-cycle sampling cadence.
 #ifdef MCU_F051
-	// Glitch-tolerant variant: the ~16-cycle cadence lands on a brief
-	// comparator glitch ~3x more often than stock sampling, and a strict
-	// all-samples-must-agree confirm defers detection to the NEXT
-	// comparator edge - up to a PWM period late. Bench-measured on the
-	// ARK 4IN1: 2-3x higher commutation jitter at 15-20 kHz commutation
-	// rates vs stock cadence (upstream 2.1% vs 5.4% at full throttle).
-	// Tolerating up to filter_level/4 bad samples per window accepts
-	// through isolated glitches while a genuinely un-crossed level still
-	// rejects via the early-out; the full window length (and so the
-	// sustained-noise immunity of the filter_level retune) is unchanged.
 	{
 		/*
-		 * Glitch-tolerant quota: up to filter_level/4 samples may read the
-		 * pre-crossing level. This is an ARK divergence from upstream, which
-		 * rejects on the FIRST bad sample (the #else branch below, still
-		 * used by every other MCU). It exists because 33d93ad moved this
-		 * loop to RAM and inlined getCompOutputLevel, taking the sampling
-		 * cadence from ~56 cycles to ~16; that lands on brief comparator
-		 * glitches about 3x more often, and a strict confirm then defers
-		 * detection to the next comparator edge - up to a PWM period late -
-		 * which bench-measured 2-3x higher commutation jitter at 15-20 kHz
-		 * (23c8387).
+		 * HELD-LEVEL CONFIRM (position-scored), F051 only.
 		 *
-		 * SUSPECT, AND KNOWN TO BE. Scoring the window by COUNT ignores
-		 * WHERE the bad samples fall, so a comparator that never really
-		 * settled can pass with 32 of 42 samples right - and the F051 has no
-		 * hardware comparator blanking (a G0/G4 peripheral feature; the
-		 * STM32F0 COMP has no blanking source at all), so this loop is the
-		 * only noise defence on this silicon.
+		 * This is the entry door to the wrong-phase lock, and the one place
+		 * ARK diverges from upstream on the zero-cross path.
 		 *
-		 * A position-scored replacement was tried - back half of the window
-		 * must be entirely clean, front half unscored, on the grounds that a
-		 * real crossing is a permanent level change while a glitch is
-		 * transient. It was reverted here NOT because it was disproved but
-		 * because it went to the bench in the same build as a duty-fade
-		 * change, so the resulting behaviour could not be attributed to
-		 * either. Reintroduce it on its own.
+		 * Upstream - the non-F051 branch immediately below, still used by
+		 * every other MCU - rejects an edge on the FIRST sample that reads
+		 * the pre-crossing level. ARK replaced that here with a quota: count
+		 * bad samples, accept if fewer than filter_level/4 are wrong.
+		 *
+		 * The quota was not gratuitous. 33d93ad moved this loop to RAM and
+		 * inlined getCompOutputLevel, taking the sampling cadence from ~56
+		 * cycles to ~16, which lands on brief comparator glitches about 3x
+		 * more often; a strict confirm then defers detection to the next
+		 * comparator edge, up to a PWM period late, and bench-measured 2-3x
+		 * higher commutation jitter at 15-20 kHz (23c8387).
+		 *
+		 * But scoring by COUNT ignores WHERE the bad samples fall. Up to ten
+		 * of forty-two may read wrong ANYWHERE, including at the very end of
+		 * the window - where "wrong" means the level never actually held. On
+		 * the F051 that matters more than anywhere else: there is no hardware
+		 * comparator blanking (a G0/G4 peripheral feature; the STM32F0 COMP
+		 * has no blanking source at all), so this loop is the entire filter.
+		 * Bench capture with the rotor STATIONARY showed accepted intervals
+		 * of 54, 103 and 59 ticks - around 200k eRPM - self-sustaining on the
+		 * ESC's own commutation transients, which are exactly the kind of
+		 * never-settled level a count-scored window admits.
+		 *
+		 * Score by POSITION instead. A real zero crossing is a PERMANENT
+		 * level change; a glitch is transient. So the back half of the window
+		 * must be entirely clean and the front half is not scored at all.
+		 * That is simultaneously STRICTER than the quota - which tolerated
+		 * bad samples precisely where they disprove the crossing - and MORE
+		 * FORGIVING than upstream, because glitches cluster in the post-edge
+		 * settling region this now ignores. The quota's purpose (do not
+		 * reject a real crossing over one glitch) is kept; its side effect
+		 * (accept a level that never held) is not.
+		 *
+		 * At filter_level 42 the back half is 21 samples, ~7us of held level
+		 * at this cadence - far longer than commutation-transient ringing,
+		 * and still inside the crossing itself.
+		 *
+		 * MEASURE JITTER when touching this. perf_zc_jitter_max is what the
+		 * quota was bought with; if it regresses, move the scoring boundary
+		 * rather than going back to a count.
 		 */
-		int bad = 0;
-		const int tolerance = filter_level >> 2;
+		const int scored_from = filter_level >> 1;
 		for (int i = 0; i < filter_level; i++) {
-			if (getCompOutputLevel() == rising) {
-				if (++bad > tolerance) {
-					HWCI_PERF_CONFIRM_REJECT();
-					return;
-				}
+			if (getCompOutputLevel() == rising && i >= scored_from) {
+				HWCI_PERF_CONFIRM_REJECT();
+				return;
 			}
 		}
 	}

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -80,19 +80,34 @@ RAM_FUNC void commutate()
 	__enable_irq();
 	changeCompInput();
 #ifndef NO_POLLING_START
-	// Poll re-entry, startup window only. On real hardware, PWM /
-	// comparator noise during the first start kicks can shrink
-	// commutation_interval below the changeover and hand off to interrupt
-	// mode with no usable BEMF; once old_routine is 0 the 20 kHz poll
-	// drive stops sampling entirely and the motor never starts (bench:
-	// FAULT_STUCK with zero crossings, CI pinned ~19.6k from the stall
-	// rail's restart cycle). Legacy healed that by re-asserting poll mode
-	// on every slow-average commutation; keep the self-heal while
-	// starting (zero_crosses resets on desync/stop, so recovery paths get
-	// it too). Established closed loop never exits here - a missed
-	// crossing is one blind step (PeriodElapsedCallback) and false locks
-	// are the trust rail's job (runtimeProcessDesyncCheck).
-	if (zero_crosses < 100 && average_interval > polling_mode_changeover + 500) {
+	/*
+	 * Poll-mode re-entry (upstream AM32, restored for established run too).
+	 *
+	 * Layered recovery with blind stepping:
+	 *
+	 *   1) Missed ZC in closed loop → blind-step at the current estimate
+	 *      (bemf_zc.c). Transient dropouts ride through without a mode
+	 *      change and without a desync restart - that is the ARK improvement.
+	 *
+	 *   2) When the measured average interval has gone slow past the poll
+	 *      changeover (same test as upstream), fall back to open-loop poll
+	 *      ZC at the commanded duty. That is stock recovery: leave interrupt
+	 *      closed-loop, hunt BEMF in the 20 kHz poll path, re-enter CL when
+	 *      the interval is short enough again (zcfoundroutine / startMotor
+	 *      handoff thresholds below).
+	 *
+	 * Blind does not feed the interval average, so a short run of blinds
+	 * does not itself push average_interval into this band. Sustained lost
+	 * lock that lengthens the measured average - or a coast through the
+	 * changeover - takes the poll exit like upstream. Jump desync and the
+	 * stall rail remain separate exits (runtime_loop / faults).
+	 *
+	 * The zero_crosses < 100 gate that used to wrap this test made poll
+	 * re-entry startup-only and left established CL with no upstream-style
+	 * soft exit; that is removed. Startup self-heal is unchanged: the same
+	 * condition still fires early when noise collapses CI into a fake CL.
+	 */
+	if (average_interval > polling_mode_changeover + 500) {
 		old_routine = 1;
 	}
 #endif
@@ -181,10 +196,9 @@ void zcfoundroutine()
 	bad_count = 0;
 
 	zero_crosses++;
-	// Poll mode is startup-only: these enter thresholds are unchanged, but
-	// once in interrupt mode there is no re-entry (see commutate) - the
-	// blind-step deadline in PeriodElapsedCallback rides through missed
-	// crossings and a genuinely lost rotor restarts through this ramp.
+	// Poll → interrupt handoff thresholds (upstream). Closed loop may later
+	// fall back to poll via the average_interval test in commutate(); these
+	// conditions re-enter interrupt ZC when the ramp is fast enough again.
 #ifdef NO_POLLING_START // changes to interrupt mode after 2 zero crosses, does not re-enter
 	if (zero_crosses > 2) {
 		old_routine = 0;
@@ -204,9 +218,10 @@ void zcfoundroutine()
 	}
 #endif
 	if (!old_routine) {
-		// Fresh closed-loop run: a blind-step budget left over from a
-		// previous run must not shorten this one, and a stale deadline
-		// flag must not misread the first scheduled commutation.
+		// Fresh closed-loop run (first handoff from poll, or re-entry after
+		// poll recovery): a blind-step budget left over from a previous run
+		// must not shorten this one, and a stale deadline flag must not
+		// misread the first scheduled commutation.
 		zc_deadline_armed = 0;
 		zc_blind_steps = 0;
 		zc_blind_ticks = 0;

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -218,8 +218,5 @@ void zcfoundroutine()
 		// history yet and must not read as demag-late.
 		zc_pre_seen = 1;
 		zc_demag_run = 0;
-		// lastzctime/thiszctime carry no measurement of this run, so the
-		// first two intervals of it must not be compared against them.
-		zc_alt_run = 0;
 	}
 }

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -209,7 +209,7 @@ void zcfoundroutine()
 		// flag must not misread the first scheduled commutation.
 		zc_deadline_armed = 0;
 		zc_blind_steps = 0;
-		zc_miss_bucket = 0;
+		zc_blind_ticks = 0;
 		// Fresh closed loop: the interval trend from a previous run (or
 		// from the poll ramp) is not a measurement of this one.
 		bemfZcResetTrend();

--- a/Src/commutation.c
+++ b/Src/commutation.c
@@ -218,5 +218,8 @@ void zcfoundroutine()
 		// history yet and must not read as demag-late.
 		zc_pre_seen = 1;
 		zc_demag_run = 0;
+		// lastzctime/thiszctime carry no measurement of this run, so the
+		// first two intervals of it must not be compared against them.
+		zc_alt_run = 0;
 	}
 }

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -505,7 +505,7 @@ void setInput()
 	 * at low rpm (each blind step is a longer slice of the budget) than at
 	 * high rpm, which is the right way round.
 	 */
-	if (!old_routine && running && (zc_blind_ticks || zc_demag_run || zc_alt_run >= ZC_ALT_RUN_MIN)) {
+	if (!old_routine && running && (zc_blind_ticks || zc_demag_run)) {
 		/* Scale the commanded duty by remaining confidence rather than
 		 * clamping to a fixed ceiling: no full-scale constant, and the
 		 * reduction is proportional to what was actually asked for.
@@ -530,36 +530,30 @@ void setInput()
 		}
 		stale += demag;
 		/*
-		 * Wrong-phase lock (bemf_zc.c). Crossings are arriving in
-		 * abundance, so zc_blind_ticks and zc_demag_run are both ZERO
-		 * here and the fade above reads full confidence while the loop
-		 * commutates at twice the true rate - that is exactly how the
-		 * grind kept full duty authority on the bench.
+		 * NO WRONG-PHASE LOCK TERM HERE, and the reason is worth keeping.
 		 *
-		 * Charged as a flat slice of the budget per alternation rather
-		 * than scaled by commutation_interval like demag: the interval
-		 * estimate is precisely the quantity this failure corrupts (it
-		 * collapsed to 32-145 in every captured episode), so scaling by
-		 * it would make the response weakest where the lock is deepest.
-		 * A sixteenth of the budget each reaches the floor eight
-		 * alternations past the threshold, ~1-2 ms at the accepted-edge
-		 * rates measured during a grind (5-15k/s).
+		 * A detector for the self-excited lock was built on the interval
+		 * ALTERNATION it shows (a hard 2:1 in every grind capture) and was
+		 * wired into this fade. Bench baselining refuted it outright: the
+		 * same alternation is normal low-duty behaviour on this hardware,
+		 * and it is stronger when healthy than when broken - 84-100% of
+		 * consecutive pairs at duty 112-176 while running perfectly well,
+		 * against 54-70% during an actual grind. It is anti-correlated with
+		 * the fault. Wired to a fade it killed healthy low-throttle runs,
+		 * which is what startup is.
 		 *
-		 * Floored at half the budget for the same reason as demag: the
-		 * one benign way to sustain an alternation is missing every
-		 * other crossing, which warrants a current reduction but not a
-		 * stop. Reduced current is itself the recovery here - it starves
-		 * the wrong-phase lock and shortens demag - so the fade only has
-		 * to break the lock, not halt the motor. If crossings do stop
-		 * arriving, the dead-reckoning budget takes over as before.
+		 * That failure is now handled where it can be seen for what it is:
+		 * the impossible-eRPM rail in runtime_loop.c compares reported eRPM
+		 * against what the applied duty can physically produce, using the
+		 * governor's own learned duty-per-eRPM slope. Healthy 0.73-1.11,
+		 * grind 7.42-9.25 - a real separation instead of an overlap.
+		 *
+		 * The lesson for anything added here later: a candidate must be
+		 * checked against HEALTHY captures before it is believed, not only
+		 * against captures of the fault. Both detectors that failed on this
+		 * problem fired on the fault correctly and were never asked whether
+		 * they stayed quiet otherwise.
 		 */
-		if (zc_alt_run >= ZC_ALT_RUN_MIN) {
-			uint32_t alt = (uint32_t)(zc_alt_run - ZC_ALT_RUN_MIN + 1u) * (BEMF_STALL_TICKS / 16u);
-			if (alt > BEMF_STALL_TICKS / 2u) {
-				alt = BEMF_STALL_TICKS / 2u;
-			}
-			stale += alt;
-		}
 		const uint32_t confidence = (stale < BEMF_STALL_TICKS) ? (BEMF_STALL_TICKS - stale) : 0u;
 		const uint32_t allowed = ((uint32_t)duty_cycle_setpoint * confidence) / BEMF_STALL_TICKS;
 		if (duty_cycle_setpoint > allowed) {

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -439,12 +439,35 @@ void setInput()
 			}
 		}
 		if (!prop_brake_active) {
-			if (input >= 47 && (zero_crosses < (uint32_t)(30 >> eepromBuffer.stall_protection))) {
+			/*
+			 * Acquisition / re-acquire duty authority (one policy).
+			 *
+			 * Until zero_crosses reaches the same horizon that arms the
+			 * missed-ZC blind deadline (100), hold the commanded duty in
+			 * the startup band. That is the existing startup floor/ceiling
+			 * - previously only applied for the first ~30 crosses
+			 * (30 >> stall_protection) - extended so a post-desync restart
+			 * (zero_crosses cleared on the stall/desync path) cannot
+			 * re-apply full stick duty while phase is still soft.
+			 *
+			 * Bench wrong-phase entry was exactly that: hard step →
+			 * brief desync → duty back at 450-500 within tens of ms with
+			 * zc still low, then ci collapse and a sustained grind with
+			 * bemfTO still 0. This is not a grind detector; it is the
+			 * same acquisition authority applied for the full window.
+			 *
+			 * last_duty_cycle is pulled down too so the 20 kHz ramp does
+			 * not spend milliseconds walking off the pre-desync duty.
+			 */
+			if (input >= 47 && zero_crosses < 100u) {
 				if (duty_cycle_setpoint < min_startup_duty) {
 					duty_cycle_setpoint = min_startup_duty;
 				}
 				if (duty_cycle_setpoint > startup_max_duty_cycle) {
 					duty_cycle_setpoint = startup_max_duty_cycle;
+				}
+				if (last_duty_cycle > startup_max_duty_cycle) {
+					last_duty_cycle = startup_max_duty_cycle;
 				}
 			}
 

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -491,48 +491,60 @@ void setInput()
 	if (!old_routine && running && zero_crosses > 150 && duty_cycle_setpoint > gov_duty_ceiling) {
 		duty_cycle_setpoint = gov_duty_ceiling;
 	}
-#	ifndef AB_NO_BLIND_DUTY_CUT
-	uint8_t zc_untrusted_steps = zc_blind_steps;
-	if (zc_demag_run > zc_untrusted_steps) {
-		zc_untrusted_steps = zc_demag_run;
-	}
-#	endif
-	// zc_grind_hold_ms keeps the cut engaged through a blind-grind (faults.c):
-	// without it a single accepted crossing resets zc_blind_steps, the cap
-	// releases, and duty re-slews into the next spike (bench: 102 A limit
-	// cycle at 19.5% miss rate, pr48-snap-rail-1).
 	/*
-	 * AB_NO_BLIND_DUTY_CUT: leave duty alone on untrusted steps.
+	 * Position-confidence duty authority.
 	 *
-	 * This is the switch that makes the other two legible. The cut fires at
-	 * two untrusted steps, which is far below where the miss rail trips, so
-	 * with it in place a build with AB_NO_MISS_RAIL still chops throttle to
-	 * 250/500 on every burst of misses - and "throttle keeps cutting but the
-	 * ESC no longer restarts" is hard to tell from "nothing changed" on a
-	 * bench. Removing all three is the closest this tree gets to upstream's
-	 * behaviour of riding out a bad patch at commanded throttle.
+	 * Replaces a two-step cliff (cap 500 at two untrusted steps, 250 at four
+	 * or during a grind hold) with a continuous fade over the same
+	 * dead-reckoning budget the restart uses. Authority is full while the
+	 * rotor is reporting its position and falls linearly to zero as the
+	 * budget is spent, reaching zero exactly where bemf_zc.c hands off to the
+	 * stall rail - so there is no step to fall off and no separate threshold
+	 * to tune. A handful of blind steps now costs a few percent of throttle
+	 * instead of three quarters of it, which is the difference between an
+	 * article that flies through a rough patch and one that cannot take off.
 	 *
-	 * It is also the switch with the most protection behind it: on boards
-	 * without a VDS trip this cap is what bounds energy into a possibly
-	 * wrong phase. Bench only.
+	 * The protective intent is unchanged where it matters: sustained dead
+	 * reckoning still walks authority down to nothing, and it does so faster
+	 * at low rpm (each blind step is a longer slice of the budget) than at
+	 * high rpm, which is the right way round.
 	 */
-#	ifndef AB_NO_BLIND_DUTY_CUT
-	if (!old_routine && running && (zc_untrusted_steps >= 2 || zc_grind_hold_ms)) {
-		/* Fixed protective cut — do NOT raise the floor with EEPROM
-		 * min_startup_duty / startup power. A misconfigured high
-		 * startup duty is exactly what this cut must bound; scaling
-		 * it away left wrong-phase drive near full heat. Worst case
-		 * the motor coasts and the stall rail restarts (or the
-		 * episode bucket latches). */
-		uint16_t blind_cap = (zc_untrusted_steps >= 4 || zc_grind_hold_ms) ? 250 : 500;
-		if (duty_cycle_setpoint > blind_cap) {
-			duty_cycle_setpoint = blind_cap;
+	if (!old_routine && running && (zc_blind_ticks || zc_demag_run)) {
+		/* Scale the commanded duty by remaining confidence rather than
+		 * clamping to a fixed ceiling: no full-scale constant, and the
+		 * reduction is proportional to what was actually asked for.
+		 * setInput recomputes the setpoint from the input every call, so
+		 * this does not compound. */
+		uint32_t stale = zc_blind_ticks;
+		/*
+		 * Demag-late crossings are arriving, just late, so the loop is
+		 * mistimed rather than lost. Same fade, charged per consecutive
+		 * late step, but floored at half the budget: unlike dead
+		 * reckoning this condition has no restart behind it (bemf_zc.c
+		 * deliberately does not escalate it, because a loaded spool-up is
+		 * legitimately demag-late for long stretches), so authority has
+		 * to bottom out somewhere the motor still turns. The current
+		 * reduction is itself the recovery - less current shortens demag
+		 * and the pre-crossing dwell reappears - so the fade only has to
+		 * be deep enough to break the spiral, not to stop the motor.
+		 */
+		uint32_t demag = (uint32_t)zc_demag_run * commutation_interval;
+		if (demag > BEMF_STALL_TICKS / 2u) {
+			demag = BEMF_STALL_TICKS / 2u;
 		}
-		if (last_duty_cycle > blind_cap) {
-			last_duty_cycle = blind_cap;
+		stale += demag;
+		const uint32_t confidence = (stale < BEMF_STALL_TICKS) ? (BEMF_STALL_TICKS - stale) : 0u;
+		const uint32_t allowed = ((uint32_t)duty_cycle_setpoint * confidence) / BEMF_STALL_TICKS;
+		if (duty_cycle_setpoint > allowed) {
+			duty_cycle_setpoint = (uint16_t)allowed;
+		}
+		/* Pull last_duty_cycle down too: the 20 kHz slew limiter ramps
+		 * from it, so capping only the setpoint would leave ramp-down
+		 * time standing between the loss of confidence and the cap. */
+		if (last_duty_cycle > allowed) {
+			last_duty_cycle = (uint16_t)allowed;
 		}
 	}
-#	endif /* !AB_NO_BLIND_DUTY_CUT */
 #endif
 }
 

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -491,14 +491,32 @@ void setInput()
 	if (!old_routine && running && zero_crosses > 150 && duty_cycle_setpoint > gov_duty_ceiling) {
 		duty_cycle_setpoint = gov_duty_ceiling;
 	}
+#	ifndef AB_NO_BLIND_DUTY_CUT
 	uint8_t zc_untrusted_steps = zc_blind_steps;
 	if (zc_demag_run > zc_untrusted_steps) {
 		zc_untrusted_steps = zc_demag_run;
 	}
+#	endif
 	// zc_grind_hold_ms keeps the cut engaged through a blind-grind (faults.c):
 	// without it a single accepted crossing resets zc_blind_steps, the cap
 	// releases, and duty re-slews into the next spike (bench: 102 A limit
 	// cycle at 19.5% miss rate, pr48-snap-rail-1).
+	/*
+	 * AB_NO_BLIND_DUTY_CUT: leave duty alone on untrusted steps.
+	 *
+	 * This is the switch that makes the other two legible. The cut fires at
+	 * two untrusted steps, which is far below where the miss rail trips, so
+	 * with it in place a build with AB_NO_MISS_RAIL still chops throttle to
+	 * 250/500 on every burst of misses - and "throttle keeps cutting but the
+	 * ESC no longer restarts" is hard to tell from "nothing changed" on a
+	 * bench. Removing all three is the closest this tree gets to upstream's
+	 * behaviour of riding out a bad patch at commanded throttle.
+	 *
+	 * It is also the switch with the most protection behind it: on boards
+	 * without a VDS trip this cap is what bounds energy into a possibly
+	 * wrong phase. Bench only.
+	 */
+#	ifndef AB_NO_BLIND_DUTY_CUT
 	if (!old_routine && running && (zc_untrusted_steps >= 2 || zc_grind_hold_ms)) {
 		/* Fixed protective cut — do NOT raise the floor with EEPROM
 		 * min_startup_duty / startup power. A misconfigured high
@@ -514,6 +532,7 @@ void setInput()
 			last_duty_cycle = blind_cap;
 		}
 	}
+#	endif /* !AB_NO_BLIND_DUTY_CUT */
 #endif
 }
 

--- a/Src/control_loop.c
+++ b/Src/control_loop.c
@@ -301,15 +301,11 @@ void setInput()
 	if (escMaySixStepThrottle()) {
 		if (input >= 47 + (80 * eepromBuffer.use_sine_start)) {
 			// Re-entry into six-step happens HERE, at input-frame rate -
-			// not in runtimeMotorModeTick. The episode-rail coast (holdoff
-			// or latched fault) must gate this branch or the mode tick's
-			// running=0 and this restart chatter against each other at
-			// kHz rate, pulsing startMotor() commutations through the
-			// whole "coast". escIsFault() also covers the latch when
-			// stuck_rotor_protection is disabled in EEPROM (the
-			// faultHandleStuckRotorIfNeeded gate above honors that flag;
-			// the episode rail is independent of it).
-			if (!escIsDriving() && !escIsFault() && !faultDesyncRestartHoldoffActive()) {
+			// not in runtimeMotorModeTick. A latched stuck rotor must gate
+			// this branch or the mode tick's running=0 and this restart
+			// chatter against each other at kHz rate, pulsing startMotor()
+			// commutations through the whole stop.
+			if (!escIsDriving() && !escIsFault()) {
 				/* comStep/fullBrake gateDriverEnsure() wakes DRV once. */
 				allOff();
 				if (!old_routine) {
@@ -509,7 +505,7 @@ void setInput()
 	 * at low rpm (each blind step is a longer slice of the budget) than at
 	 * high rpm, which is the right way round.
 	 */
-	if (!old_routine && running && (zc_blind_ticks || zc_demag_run)) {
+	if (!old_routine && running && (zc_blind_ticks || zc_demag_run || zc_alt_run >= ZC_ALT_RUN_MIN)) {
 		/* Scale the commanded duty by remaining confidence rather than
 		 * clamping to a fixed ceiling: no full-scale constant, and the
 		 * reduction is proportional to what was actually asked for.
@@ -533,6 +529,37 @@ void setInput()
 			demag = BEMF_STALL_TICKS / 2u;
 		}
 		stale += demag;
+		/*
+		 * Wrong-phase lock (bemf_zc.c). Crossings are arriving in
+		 * abundance, so zc_blind_ticks and zc_demag_run are both ZERO
+		 * here and the fade above reads full confidence while the loop
+		 * commutates at twice the true rate - that is exactly how the
+		 * grind kept full duty authority on the bench.
+		 *
+		 * Charged as a flat slice of the budget per alternation rather
+		 * than scaled by commutation_interval like demag: the interval
+		 * estimate is precisely the quantity this failure corrupts (it
+		 * collapsed to 32-145 in every captured episode), so scaling by
+		 * it would make the response weakest where the lock is deepest.
+		 * A sixteenth of the budget each reaches the floor eight
+		 * alternations past the threshold, ~1-2 ms at the accepted-edge
+		 * rates measured during a grind (5-15k/s).
+		 *
+		 * Floored at half the budget for the same reason as demag: the
+		 * one benign way to sustain an alternation is missing every
+		 * other crossing, which warrants a current reduction but not a
+		 * stop. Reduced current is itself the recovery here - it starves
+		 * the wrong-phase lock and shortens demag - so the fade only has
+		 * to break the lock, not halt the motor. If crossings do stop
+		 * arriving, the dead-reckoning budget takes over as before.
+		 */
+		if (zc_alt_run >= ZC_ALT_RUN_MIN) {
+			uint32_t alt = (uint32_t)(zc_alt_run - ZC_ALT_RUN_MIN + 1u) * (BEMF_STALL_TICKS / 16u);
+			if (alt > BEMF_STALL_TICKS / 2u) {
+				alt = BEMF_STALL_TICKS / 2u;
+			}
+			stale += alt;
+		}
 		const uint32_t confidence = (stale < BEMF_STALL_TICKS) ? (BEMF_STALL_TICKS - stale) : 0u;
 		const uint32_t allowed = ((uint32_t)duty_cycle_setpoint * confidence) / BEMF_STALL_TICKS;
 		if (duty_cycle_setpoint > allowed) {
@@ -645,7 +672,7 @@ RAM_FUNC void tenKhzRoutine()
 		if (one_khz_loop_counter > PID_LOOP_DIVIDER) { // 1khz PID loop
 			PROCESS_ADC_FLAG = 1;		       // set flag to do new adc read at lower priority
 			one_khz_loop_counter = 0;
-			faultDesyncEpisodeTick1kHz();
+			faultAcqResistTick1kHz();
 			if (use_current_limit && escIsDriving()) {
 				use_current_limit_adjust -=
 					(int16_t)(doPidCalculations(&currentPid, actual_current, eepromBuffer.limits.current * 2 * 100) /
@@ -712,11 +739,10 @@ RAM_FUNC void tenKhzRoutine()
 			// (each desync episode halving the configured ramp for the
 			// rest of the power cycle) was tried, shipped, and reverted -
 			// per-ESC learned state is invisible to the FC and makes a
-			// multirotor asymmetric. See the note in
-			// faultDesyncEpisodeCharge. These limits are what the eeprom
-			// says and stay that way; a ramp that outruns the motor is a
-			// tuning defect, and repeated desyncs are bounded by the
-			// episode latch, not by quietly slowing this ESC down.
+			// multirotor asymmetric. See the note at the top of faults.c.
+			// These limits are what the eeprom says and stay that way; a
+			// ramp that outruns the motor is a tuning defect, fixed by
+			// retuning, not by quietly slowing this one ESC down.
 			if ((duty_cycle - last_duty_cycle) > max_duty_cycle_change) {
 				duty_cycle = last_duty_cycle + max_duty_cycle_change;
 			}

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -209,40 +209,17 @@ void faultUpdateBemfTimeoutPolicy(void)
 #define ACQ_FAIL_CLEAR_ZC 500
 
 /*
- * Blind-GRIND rail. The episode rail above only sees DISCRETE failures
- * (jump desync, stall trip). Bench 2026-07-23 (pr48-snap-rail-1, 900KV +
- * 10x5x3 6S, snap 0.20->0.55): a spinning snap can drop the loop into a
- * CONTINUOUS partial desync that sits below every threshold - 423 blind
- * steps/s at a 19.5% miss rate (miss bucket needs >25% and net-drains;
- * consecutive counter resets on every accepted crossing; CI step +45% is
- * under the jump check's 50%; the stall rail never fires because blind
- * steps keep resetting INTERVAL_TIMER) - while the power cut engages and
- * releases in a limit cycle (one accepted crossing resets zc_blind_steps,
- * duty re-slews at max_ramp, spike to 102 A, desync, repeat).
- *
- * The unambiguous signal is the blind-step RATE: healthy runs total 9-27
- * blind steps per RUN; the grind produces 40+ per 100 ms. Sample
- * zc_blind_window_count each 100 ms; ONE hot window holds the power cut
- * AND forces the stall rail (mask + kick INTERVAL_TIMER, same primitives
- * as the blind-limit handoff), which restarts the loop and charges the
- * episode bucket (zero_crosses is far above 100 in a grind), so
- * repetition escalates through backoff to the latch like any other
- * episode source.
- *
- * Restart on the FIRST hot window, not after N consecutive: requiring
- * consecutive hot windows is self-defeating (bench pr48-snap-rail-2) -
- * the held cut drops the blind rate below threshold, the streak resets,
- * no restart ever fires, and each hold expiry re-slews duty into a fresh
- * spike (33-88 A at ~600 ms period). The detection margin carries a
- * single-window trigger, and a false trip costs one restart plus one
- * episode charge that drains in ~1.2 s of healthy running.
+ * The blind-grind rail that used to live here (sample the blind-step count
+ * every 100 ms, force a restart on one hot window, hold a power cut for
+ * 250 ms) is gone. It existed because blind steps reset INTERVAL_TIMER and so
+ * hid a grind from the stall rail below; bemf_zc.c now measures dead-reckoning
+ * time directly in zc_blind_ticks, which makes a grind visible to that one
+ * rail without a second rate detector, three more tuned constants, and a
+ * restart on a single sampling window. Duty during a grind is handled by the
+ * continuous authority fade in control_loop.c rather than a held cut.
  */
-#define GRIND_WINDOW_MS 100
-#define GRIND_WINDOW_BLIND_LIMIT 15 /* >=150 blind/s = grind; healthy bursts stay single-digit */
-#define GRIND_HOLD_MS 250
 
 static uint8_t desync_episode_drain_ms;
-static uint8_t grind_window_ms;
 
 static void desync_episode_apply_backoff(void)
 {
@@ -351,30 +328,6 @@ void faultDesyncEpisodeTick1kHz(void)
 	if (desync_restart_holdoff_ms > 0) {
 		desync_restart_holdoff_ms--;
 	}
-	if (zc_grind_hold_ms > 0) {
-		zc_grind_hold_ms--;
-	}
-
-	/* Blind-grind window (see block comment above the constants). */
-	if (++grind_window_ms >= GRIND_WINDOW_MS) {
-		grind_window_ms = 0;
-		uint8_t blind_in_window = zc_blind_window_count;
-		zc_blind_window_count = 0; // a step between read and clear is one lost count - fine
-		if (blind_in_window >= GRIND_WINDOW_BLIND_LIMIT && running && !old_routine) {
-			// Hot window: hold the power cut (bridges the gap until the
-			// restart takes and covers any deferred path) and force the
-			// stall rail, same primitives as the blind-limit handoff in
-			// PeriodElapsedCallback: with phase interrupts masked and
-			// the deadline disarmed, nothing can reset INTERVAL_TIMER
-			// before the main loop runs faultHandleBemfIntervalStall,
-			// which restarts and charges the episode bucket.
-			zc_grind_hold_ms = GRIND_HOLD_MS;
-			maskPhaseInterrupts();
-			DISABLE_COM_TIMER_INT();
-			zc_deadline_armed = 0;
-			SET_INTERVAL_TIMER_COUNT(46000);
-		}
-	}
 
 	/* Drain only in established, trusted closed loop. bemf_timeout_happened
 	 * is deliberately NOT in the gate: it stays nonzero until
@@ -402,7 +355,7 @@ uint8_t faultDesyncRestartHoldoffActive(void)
 void faultHandleBemfIntervalStall(void)
 {
 	/* Six-step only (not sine soft-start). */
-	if (INTERVAL_TIMER_COUNT > 45000 && (escInOpenLoop() || escInClosedLoop())) {
+	if (INTERVAL_TIMER_COUNT > BEMF_STALL_TICKS && (escInOpenLoop() || escInClosedLoop())) {
 		bemf_timeout_happened++;
 
 		maskPhaseInterrupts();
@@ -414,13 +367,13 @@ void faultHandleBemfIntervalStall(void)
 		// heavy props legitimately kick many times at low throttle, and
 		// charging those latched the ESC on the 4th kick. This gate also
 		// covers the blind/miss-limit handoff (bemf_zc kicks
-		// INTERVAL_TIMER to 46000 with comparator interrupts masked, so
+		// INTERVAL_TIMER past BEMF_STALL_TICKS with comparator interrupts masked, so
 		// this rail is guaranteed to run next pass): blind stepping only
 		// arms at zero_crosses >= 100, so those episodes always charge.
 		if (zero_crosses > 100) {
 			/* Established run died here. This is the ONLY place the
 			 * stall rail is counted, and it is the aggregation point
-			 * for the grind rail and the blind/miss-limit handoff,
+			 * for the dead-reckoning budget handoff in bemf_zc.c,
 			 * both of which reach the loop through this trip - see
 			 * faultErrorCount(). */
 			fault_stall_trips++;

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -121,18 +121,10 @@ void faultUpdateBemfTimeoutPolicy(void)
 		bemf_timeout_happened = 0;
 	}
 	if (adjusted_input == 0) {
-		// Zero throttle is pilot intervention: clear the episode rail the
-		// same way the legacy latch clears. Deliberately NOT on
-		// zero_crosses > 1000 - a bad-tune cycle that respins fast between
-		// desyncs must keep accumulating (that reset defeating the stuck
-		// latch is one of the gaps this rail exists to close).
-		//
-		// Also clear the acquisition-rail partial batch: otherwise 19 early
-		// desyncs, a pilot cut, then one more early desync on the next blip
-		// would fire a JUMP-sized charge as if the cut never happened.
-		// Match episode-bucket pilot semantics.
-		desync_episode_bucket = 0;
-		desync_restart_holdoff_ms = 0;
+		// Zero throttle is pilot intervention: clear the acquisition-rail
+		// partial batch too, or 19 early desyncs, a pilot cut, then one more
+		// early desync on the next blip would count a resisted start as if
+		// the cut never happened.
 		acq_fail_desyncs = 0;
 	}
 	if (zero_crosses > 100 && adjusted_input < 200) {
@@ -157,49 +149,12 @@ void faultUpdateBemfTimeoutPolicy(void)
 }
 
 /*
- * Cross-episode desync protection. Per-episode rails (blind-step cap, miss
- * bucket, demag-late power cut) bound a single event; this bucket bounds a
- * *repeating* restart→desync cycle from a bad tune / wrong prop match.
+ * Acquisition-rail batching (see faultNoteEarlyDesync in faults.h).
  *
- * Charge rates are tuned so 3-5 hard episodes latch within ~1-2 s of cycling,
- * while a couple of honest in-flight desyncs drain out in a few seconds of
- * healthy closed-loop (stall: 4 episodes at 12; jump: 5 at 8).
- *
- * The FIRST episode must restart immediately - an honest in-flight desync
- * that coasts even 100 ms is a dropped motor on a quad - so restart holdoff
- * only arms once the bucket shows repetition (>= MIN_BUCKET, i.e. from the
- * second episode on) and then grows so the FETs spend most of each later
- * cycle cooling instead of immediately re-entering the wrong-phase spike.
- * Stall path: ep2 300 ms, ep3 500 ms, ep4 latch. Jump path: ep2 100 ms,
- * ep3 300 ms, ep4 500 ms, ep5 latch.
- */
-#define DESYNC_EPISODE_LIMIT 40
-#define DESYNC_EPISODE_CHARGE_JUMP 8
-#define DESYNC_EPISODE_CHARGE_STALL 12
-#define DESYNC_EPISODE_DRAIN_MS 100  /* -1 charge per this many ms of healthy CL */
-#define DESYNC_BACKOFF_MIN_BUCKET 16 /* below this (first episode): no holdoff */
-#define DESYNC_BACKOFF_BASE_MS 100
-#define DESYNC_BACKOFF_STEP_MS 25
-#define DESYNC_BACKOFF_MAX_MS 500
-/*
- * Acquisition rail (see faultNoteEarlyDesync in faults.h).
- *
- * 20 early desyncs with no successful acquisition in between buy one
- * JUMP-sized charge. Deliberately conservative: a healthy hard start spends
- * 2-4 rough desyncs acquiring, so 20 is unambiguously abnormal, while at the
- * ~20/s rate a genuinely stuck loop produces it still charges once a second.
- * The point of this rail is to make the failure VISIBLE to the escalation
- * machinery (bucket, holdoff, latch) and to the fault_acq_resist_events
- * counter, not to be the fastest path to the latch. It deliberately does
- * nothing to the ramp: a start that cannot complete is at least as likely
- * mechanically resisted (grass, debris) as mis-tuned, and duty is
- * near-always slewing during a start, so there is no signal here that
- * separates the two - see faultDesyncEpisodeCharge. Established-run rails
- * (dead-reckoning budget / stall) still need zero_crosses > 100 and only engage once
- * the loop actually gets past that gate.
- *
- * This constant is a starting point from SITL and wants bench calibration
- * against real hard starts before release.
+ * 20 early desyncs with no successful acquisition in between count as one
+ * resisted start. Deliberately conservative: a healthy hard start spends 2-4
+ * rough desyncs acquiring, so 20 is unambiguously abnormal, while at the
+ * ~20/s rate a genuinely stuck loop produces it still counts once a second.
  *
  * ACQ_FAIL_CLEAR_ZC is deliberately well above the 100 that arms blind
  * stepping: the count must only be forgiven by an acquisition that actually
@@ -209,102 +164,51 @@ void faultUpdateBemfTimeoutPolicy(void)
 #define ACQ_FAIL_CLEAR_ZC 500
 
 /*
- * The blind-grind rail that used to live here (sample the blind-step count
- * every 100 ms, force a restart on one hot window, hold a power cut for
- * 250 ms) is gone. It existed because blind steps reset INTERVAL_TIMER and so
- * hid a grind from the stall rail below; bemf_zc.c now measures dead-reckoning
- * time directly in zc_blind_ticks, which makes a grind visible to that one
- * rail without a second rate detector, three more tuned constants, and a
- * restart on a single sampling window. Duty during a grind is handled by the
- * continuous authority fade in control_loop.c rather than a held cut.
+ * WHY THERE IS NO EPISODE ESCALATOR HERE ANY MORE.
+ *
+ * This file used to carry an ARK-only leaky bucket across restart cycles:
+ * every jump-desync charged 8 and every stall trip charged 12, a bucket over
+ * 16 armed a growing allOff() coast (ep2 300 ms, ep3 500 ms on the stall
+ * path), and 40 latched ESC_FAULT_STUCK. Bench-reported symptom on a 2160kv
+ * article: the ESC cycled between long power cuts and set throttle, got very
+ * hot, and could not take off, where stock AM32 on the same article stayed
+ * flying through the same induced desyncs.
+ *
+ * Running the arithmetic explains the report exactly - three stall episodes
+ * inside a few seconds buy a 300 ms cut, then a 500 ms cut, then a latch, and
+ * the bucket needs 4 s of clean closed loop to drain. None of it is upstream.
+ *
+ * The reasoning error was treating LOST SYNC and LOST ROTOR as the same
+ * event. They are not:
+ *
+ *   lost sync   - the rotor is turning, the ESC no longer knows where it is.
+ *                 Coasting cannot improve this; it only removes the drive
+ *                 that would let the loop re-find the rotor, and on a quad it
+ *                 is a dropped corner. Upstream rides it out and so do we.
+ *   lost rotor  - the rotor is not turning. Driving it dumps locked-rotor
+ *                 current into one phase pair, so this one MUST stop.
+ *
+ * Upstream separates them with two rails and no state in between: the stall
+ * rail hands back to poll ZC with the bridge live (faultHandleBemfIntervalStall
+ * below), and only faultHandleStuckRotorIfNeeded cuts power, when repeated
+ * stalls with no healthy run in between prove poll mode is not finding
+ * crossings either. Both are keyed on one throttle-scaled counter,
+ * bemf_timeout_happened. We now do exactly that.
+ *
+ * ARK's robustness over upstream is therefore entirely in FRONT of these
+ * rails, not layered on top of them: blind stepping rides out dropouts that
+ * would freewheel upstream for up to a full stall window, the dead-reckoning
+ * budget in bemf_zc.c bounds how long that may go on, and the authority fade
+ * scales duty by remaining confidence. Those reduce how often we reach
+ * upstream's rails. What happens once we do reach them is upstream's.
+ *
+ * The blind-grind rail that also used to live here (sample blind steps every
+ * 100 ms, force a restart on one hot window, hold a 250 ms power cut) is gone
+ * for the same reason plus one more: it existed only because blind steps
+ * reset INTERVAL_TIMER and so hid a grind from the stall rail. bemf_zc.c now
+ * measures dead-reckoning time directly in zc_blind_ticks, which restores the
+ * stall rail's own visibility without a second rate detector.
  */
-
-static uint8_t desync_episode_drain_ms;
-
-static void desync_episode_apply_backoff(void)
-{
-	if (desync_episode_bucket < DESYNC_BACKOFF_MIN_BUCKET) {
-		return; // first episode restarts immediately (legacy behavior)
-	}
-	uint16_t hold =
-		(uint16_t)(DESYNC_BACKOFF_BASE_MS + (uint16_t)(desync_episode_bucket - DESYNC_BACKOFF_MIN_BUCKET) * DESYNC_BACKOFF_STEP_MS);
-	if (hold > DESYNC_BACKOFF_MAX_MS) {
-		hold = DESYNC_BACKOFF_MAX_MS;
-	}
-	if (hold > desync_restart_holdoff_ms) {
-		desync_restart_holdoff_ms = hold;
-	}
-}
-
-void faultDesyncEpisodeCharge(desync_episode_kind_t kind)
-{
-#ifndef BRUSHED_MODE
-	uint8_t inc = DESYNC_EPISODE_CHARGE_STALL;
-	if (kind == DESYNC_EPISODE_JUMP || kind == DESYNC_EPISODE_ACQ_FAIL) {
-		/* The acquisition rail has already required ACQ_FAIL_DESYNC_LIMIT
-		 * events before getting here, so one charge per batch is the same
-		 * weight as a single established-run jump. */
-		inc = DESYNC_EPISODE_CHARGE_JUMP;
-	}
-	if ((uint16_t)desync_episode_bucket + inc > 255) {
-		desync_episode_bucket = 255;
-	} else {
-		desync_episode_bucket = (uint8_t)(desync_episode_bucket + inc);
-	}
-	desync_episode_drain_ms = 0;
-	desync_episode_apply_backoff();
-
-	// NO PERSISTENT LEARNED STATE. An episode charges the escalation
-	// machinery above (bucket -> holdoff -> latch) and nothing else: the
-	// configured ramp, and every other tuning parameter, is left exactly as
-	// loadEEpromSettings set it. This is a deliberate reversal of the
-	// learned ramp back-off that used to live here (each episode halved
-	// every regime's duty step for the rest of the power cycle, flooring at
-	// fine 0.1%/ms).
-	//
-	// Why it is gone, on a multirotor specifically: the halve is per-ESC
-	// state that the flight controller cannot see. The mixer assumes
-	// symmetric actuators, so one ESC that has learned a slower ramp than
-	// its three siblings is an asymmetric vehicle with no way to report it.
-	// That is not a hypothetical - it crashed a vehicle taking off after a
-	// ground spool in long grass, where prop obstruction at STEADY duty
-	// dragged an established run down and the episode was misread as "ramp
-	// too fast". On the production tune (max_ramp 20 -> all regimes 2) one
-	// halve already IS the fine-rate floor: a silent 20x slew-authority cut.
-	//
-	// An attribution gate was tried first (a slew witness requiring the
-	// limiter to be binding on rising demand before halving) and it does
-	// narrow the misattribution, but it keeps the architecture: still
-	// per-ESC learned divergence, still invisible to the FC, still one
-	// wrong attribution away from the same asymmetry. The line drawn
-	// instead is TRANSIENT SELF-RECOVERING RESPONSES ONLY - the bucket,
-	// holdoff and latch all converge back to configured settings, so an
-	// ESC either behaves as configured or stops. A too-fast ramp is a
-	// tuning defect and gets fixed by retuning, not by each ESC quietly
-	// deciding its own limit mid-flight. This also keeps us on upstream
-	// AM32's fixed-ramp semantics rather than diverging further.
-	//
-	// ACQ_FAIL episodes additionally bump fault_acq_resist_events, which is
-	// a counter only - see faults.h for why that one has to survive the
-	// self-healing.
-	if (kind == DESYNC_EPISODE_ACQ_FAIL) {
-		if (fault_acq_resist_events < 255) {
-			fault_acq_resist_events++;
-		}
-	}
-
-	if (desync_episode_bucket >= DESYNC_EPISODE_LIMIT) {
-		allOff();
-		maskPhaseInterrupts();
-		escToFaultStuck();
-#	ifdef USE_RGB_LED
-		setIndividualRGBLed(1, 0, 0);
-#	endif
-	}
-#else
-	(void)kind;
-#endif
-}
 
 void faultNoteEarlyDesync(void)
 {
@@ -313,11 +217,13 @@ void faultNoteEarlyDesync(void)
 		return;
 	}
 	acq_fail_desyncs = 0;
-	faultDesyncEpisodeCharge(DESYNC_EPISODE_ACQ_FAIL);
+	if (fault_acq_resist_events < 255) {
+		fault_acq_resist_events++;
+	}
 #endif
 }
 
-void faultDesyncEpisodeTick1kHz(void)
+void faultAcqResistTick1kHz(void)
 {
 #ifndef BRUSHED_MODE
 	/* A loop that got solidly established did acquire, whatever roughness
@@ -325,76 +231,43 @@ void faultDesyncEpisodeTick1kHz(void)
 	if (zero_crosses > ACQ_FAIL_CLEAR_ZC) {
 		acq_fail_desyncs = 0;
 	}
-	if (desync_restart_holdoff_ms > 0) {
-		desync_restart_holdoff_ms--;
-	}
-
-	/* Drain only in established, trusted closed loop. bemf_timeout_happened
-	 * is deliberately NOT in the gate: it stays nonzero until
-	 * zero_crosses > 1000 (5-10 s at crawler rpm), which would block drain
-	 * through exactly the healthy running that should earn it. */
-	if (escInClosedLoop() && zc_blind_steps == 0 && zc_demag_run == 0 && desync_episode_bucket > 0) {
-		if (desync_episode_drain_ms < 255) {
-			desync_episode_drain_ms++;
-		}
-		if (desync_episode_drain_ms >= DESYNC_EPISODE_DRAIN_MS) {
-			desync_episode_drain_ms = 0;
-			desync_episode_bucket--;
-		}
-	} else {
-		desync_episode_drain_ms = 0;
-	}
 #endif
-}
-
-uint8_t faultDesyncRestartHoldoffActive(void)
-{
-	return (uint8_t)(desync_restart_holdoff_ms > 0);
 }
 
 void faultHandleBemfIntervalStall(void)
 {
 	/* Six-step only (not sine soft-start). */
 	if (INTERVAL_TIMER_COUNT > BEMF_STALL_TICKS && (escInOpenLoop() || escInClosedLoop())) {
+		/* Upstream AM32 main.c, "INTERVAL_TIMER_COUNT > 45000", verbatim in
+		 * behaviour. bemf_timeout_happened is the counter that carries this
+		 * to the genuine stop in faultHandleStuckRotorIfNeeded; nothing here
+		 * cuts power or refuses to restart. */
 		bemf_timeout_happened++;
-
 		maskPhaseInterrupts();
-		// Charge the episode rail only when this run was ESTABLISHED
-		// before it died (the bad-tune restart->spool->desync cycle
-		// always reaches closed loop first). A start attempt that never
-		// got going is the legacy stuck-rotor rail's job, with its
-		// throttle-scaled tolerance (bemf_timeout 100 below input 150) -
-		// heavy props legitimately kick many times at low throttle, and
-		// charging those latched the ESC on the 4th kick. This gate also
-		// covers the blind/miss-limit handoff (bemf_zc kicks
-		// INTERVAL_TIMER past BEMF_STALL_TICKS with comparator interrupts masked, so
-		// this rail is guaranteed to run next pass): blind stepping only
-		// arms at zero_crosses >= 100, so those episodes always charge.
+
+		/* Counter only, for uavcan esc.Status error_count. Gated on an
+		 * ESTABLISHED run (the same zero_crosses > 100 that arms blind
+		 * stepping) so the many legitimate kicks a heavy prop needs at low
+		 * throttle are not reported as errors. This is also the aggregation
+		 * point for the dead-reckoning budget handoff in bemf_zc.c, which
+		 * reaches the loop through this trip - see faultErrorCount(). */
 		if (zero_crosses > 100) {
-			/* Established run died here. This is the ONLY place the
-			 * stall rail is counted, and it is the aggregation point
-			 * for the dead-reckoning budget handoff in bemf_zc.c,
-			 * both of which reach the loop through this trip - see
-			 * faultErrorCount(). */
 			fault_stall_trips++;
-			faultDesyncEpisodeCharge(DESYNC_EPISODE_STALL_RAIL);
 		}
-		if (escIsFault()) {
-			/* Episode rail latched: do not re-enter startup. */
-			zero_crosses = 0;
-			bemfZcResetTrend();
-			running = 0;
-			return;
-		}
+
+		/* old_routine = 1 (hand back to poll ZC); stop ONLY if throttle is
+		 * already commanded off, which is upstream's "input < 48" clause. */
 		escNoteStallOrDesync(1);
 		zero_crosses = 0;
 		bemfZcResetTrend();
-		if (faultDesyncRestartHoldoffActive()) {
-			/* Coast until holdoff expires; main loop will re-arm. */
-			running = 0;
-			allOff();
-			return;
-		}
+
+		/* Re-acquisition must not resume at the commanded setpoint: come
+		 * back at the startup floor and let max_ramp carry duty up, the same
+		 * resume upstream's desync path uses. Without this the loop re-enters
+		 * closed loop at whatever duty it lost sync on, which is the duty
+		 * that just failed. */
+		last_duty_cycle = min_startup_duty / 2;
+
 		zcfoundroutine();
 	}
 }

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -195,7 +195,7 @@ void faultUpdateBemfTimeoutPolicy(void)
  * mechanically resisted (grass, debris) as mis-tuned, and duty is
  * near-always slewing during a start, so there is no signal here that
  * separates the two - see faultDesyncEpisodeCharge. Established-run rails
- * (blind/grind/stall) still need zero_crosses > 100 and only engage once
+ * (dead-reckoning budget / stall) still need zero_crosses > 100 and only engage once
  * the loop actually gets past that gate.
  *
  * This constant is a starting point from SITL and wants bench calibration

--- a/Src/hwci_perf.c
+++ b/Src/hwci_perf.c
@@ -9,6 +9,9 @@
  */
 #include "hwci_perf.h"
 
+#include "common.h"
+#include "motor_runtime.h"
+
 #ifdef HWCI_PERF
 
 /*
@@ -30,6 +33,14 @@ volatile hwci_perf_t hwci_perf = {
  * commit macro skips binning). The main-loop snapshot keeps it tracking
  * tim1_arr. */
 volatile uint32_t hwci_zc_phase_scale_q16 = 0;
+
+/*
+ * Per-commutation ZC trace (see the block comment in hwci_perf.h). Starts
+ * ARMED - .frozen = 0 - so the very first false lock after a power cycle is
+ * captured without the host having to arm anything first. Re-arm with
+ * HWCI_CMD_ARM_ZC_TRACE once the buffer has been read.
+ */
+volatile hwci_zc_trace_t hwci_zc_trace;
 
 /*
  * Clear the sticky min/max accumulators so worst-case timing can be measured
@@ -58,6 +69,18 @@ void hwci_perf_apply_cmd(void)
 	switch (hwci_perf.host_cmd) {
 		case HWCI_CMD_RESET_STATS:
 			hwci_perf_reset_stats();
+			break;
+		case HWCI_CMD_ARM_ZC_TRACE:
+			/* Re-arm the per-commutation trace: drop the frozen
+			 * capture and start filling again. write_idx is left
+			 * alone - the ring is circular and the host reads it
+			 * oldest-first from write_idx once wrapped. */
+			hwci_zc_trace.post = 0u;
+			hwci_zc_trace.total = 0u;
+			hwci_zc_trace.write_idx = 0u;
+			hwci_zc_trace.wrapped = 0u;
+			hwci_zc_trace.ci_at_arm = (uint16_t)(commutation_interval > 65535u ? 65535u : commutation_interval);
+			hwci_zc_trace.frozen = 0u;
 			break;
 		default:
 			break;

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -54,7 +54,6 @@ volatile uint32_t zc_blind_ticks = 0;
 volatile uint8_t zc_pre_seen = 0;
 volatile uint8_t zc_demag_run = 0;
 volatile uint32_t zc_demag_accepts = 0;
-volatile uint8_t zc_alt_run = 0;
 volatile uint8_t ramp_divider;
 volatile uint8_t max_ramp_startup = RAMP_SPEED_STARTUP;
 volatile uint8_t max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -54,6 +54,7 @@ volatile uint32_t zc_blind_ticks = 0;
 volatile uint8_t zc_pre_seen = 0;
 volatile uint8_t zc_demag_run = 0;
 volatile uint32_t zc_demag_accepts = 0;
+volatile uint8_t zc_alt_run = 0;
 volatile uint8_t ramp_divider;
 volatile uint8_t max_ramp_startup = RAMP_SPEED_STARTUP;
 volatile uint8_t max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;
@@ -124,8 +125,6 @@ uint32_t REV_Id = 0;
 uint16_t armed_timeout_count;
 uint16_t reverse_speed_threshold = 1500;
 uint32_t desync_happened = 0;
-volatile uint8_t desync_episode_bucket = 0;
-volatile uint16_t desync_restart_holdoff_ms = 0;
 char maximum_throttle_change_ramp = 1;
 
 char crawler_mode = 0; // no longer used //

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -50,13 +50,11 @@ volatile uint32_t polling_mode_changeover;
 /* Missed-ZC blind-step fallback (bemf_zc.c) */
 volatile uint8_t zc_deadline_armed = 0;
 volatile uint8_t zc_blind_steps = 0;
-volatile uint8_t zc_miss_bucket = 0;
+volatile uint32_t zc_blind_ticks = 0;
 volatile uint8_t zc_pre_seen = 0;
 volatile uint8_t zc_demag_run = 0;
 volatile uint32_t zc_demag_accepts = 0;
 /* Blind-grind rail (faults.c): blind steps this 100 ms window / cut hold */
-volatile uint8_t zc_blind_window_count = 0;
-volatile uint16_t zc_grind_hold_ms = 0;
 volatile uint8_t ramp_divider;
 volatile uint8_t max_ramp_startup = RAMP_SPEED_STARTUP;
 volatile uint8_t max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -54,7 +54,6 @@ volatile uint32_t zc_blind_ticks = 0;
 volatile uint8_t zc_pre_seen = 0;
 volatile uint8_t zc_demag_run = 0;
 volatile uint32_t zc_demag_accepts = 0;
-/* Blind-grind rail (faults.c): blind steps this 100 ms window / cut hold */
 volatile uint8_t ramp_divider;
 volatile uint8_t max_ramp_startup = RAMP_SPEED_STARTUP;
 volatile uint8_t max_ramp_low_rpm = RAMP_SPEED_LOW_RPM;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -355,10 +355,83 @@ void runtimeSendTelemetryIfNeeded(void)
  * 8 ≈ 0.4 %/ms → full authority in ≤250 ms instead of a single-tick step. */
 #	define GOV_RELEASE_SLEW 8
 
+/*
+ * IMPOSSIBLE-eRPM RAIL - the wrong-phase / self-excited lock detector.
+ *
+ * A rotor cannot turn faster than the applied volts allow. gov_slope_q10 is
+ * already the measured duty-per-eRPM of THIS article at equilibrium, so
+ * (erpm * gov_slope_q10) >> 10 is "the duty this eRPM implies" - the same
+ * expression the ceiling below uses, read the other way round. If the loop
+ * reports an eRPM that would need several times the duty actually applied,
+ * the loop is not measuring the rotor.
+ *
+ * WHY THIS REFERENCE AND NOT THE OTHERS. Three previous attempts at this
+ * failure keyed their threshold on the interval estimate - the jump check on
+ * average_interval, a minimum-interval gate on commutation_interval, and an
+ * interval-alternation detector. All three derive from the quantity the
+ * failure corrupts, so they disarm themselves exactly as the lock deepens
+ * (measured: ci 719 -> 52 with the gate tracking it down 179 -> 13). Duty is
+ * commanded, not measured, and the slope is learned only while running
+ * clean, so neither moves when the timing collapses.
+ *
+ * Bench separation, three sessions on an ARK 4IN1 / AOS 2207 1980KV / 6S,
+ * 27 healthy windows spanning duty 80-1072 against 3 captured grinds:
+ *
+ *     healthy   ratio 0.73 - 1.11
+ *     grind     ratio 7.42 - 9.25
+ *
+ * The ratio is scale-invariant: e_rpm's units cancel between the estimator
+ * and this check, so it does not matter that e_rpm is scaled differently in
+ * open loop. Separation holds at 6.7x for every slope the estimator could
+ * plausibly settle on (4-9), which is why the margin can be set well clear
+ * of both edges instead of tuned.
+ *
+ * NOT keyed on eeprom motor_kv, deliberately. A safety rail that silently
+ * disarms when a user misconfigures KV is worse than no rail, and BLHeli_32
+ * needs no KV setting at all - the relationship is measurable, so measure it.
+ *
+ * The response is upstream's, not a new policy: mask the comparator and kick
+ * INTERVAL_TIMER past the stall threshold, which is exactly what the
+ * dead-reckoning budget does when position is genuinely unknown (bemf_zc.c).
+ * faultHandleBemfIntervalStall then runs on the next main-loop pass.
+ *
+ * MARGIN. Measured per accepted crossing across 15 healthy windows spanning
+ * duty 96-1072, against captured grinds:
+ *
+ *     healthy   window median 0.80 - 1.12   (per-event p99 1.50, max 1.60)
+ *     grind     window median 2.48 at duty 464; 7.42 - 9.25 at duty ~144
+ *
+ * A grind is a far smaller MULTIPLE at high duty than at low duty, because
+ * the ceiling it is compared against is higher. The first cut of this rail
+ * used 3, calibrated on low-duty grinds only, and sailed straight past a
+ * duty-464 grind sitting at 2.08. e_rpm derives from e_com_time, a sum of six
+ * commutations, so the 1 kHz tick sees the window MEDIAN rather than the
+ * per-event spread; 2 clears healthy by 78% and still catches 2.48.
+ *
+ * WHY THE REFERENCE IS A DECAYING PEAK AND NOT duty. On a hard throttle chop
+ * duty falls in one tick while the prop coasts, so a still-high eRPM is
+ * compared against a collapsed duty and the ratio spikes for as long as the
+ * rotor takes to slow - hundreds of ms. That would trip a 4 ms hysteresis on
+ * every chop. It is invisible in 3-second capture windows, which is how the
+ * first cut shipped without it being noticed. gov_duty_ref rises instantly
+ * with duty and decays ~1.5%/ms, so a chop leaves the reference high and the
+ * ratio near 1, while a steady-duty grind is unaffected - the whole spike is
+ * duty falling, not eRPM rising.
+ */
+#	define GOV_IMPLAUSIBLE_MARGIN 2u /* implied duty vs reference; 1.12 .. 2.48 */
+#	define GOV_IMPLAUSIBLE_MS 4u	  /* consecutive 1 kHz ticks before tripping  */
+#	define GOV_DUTY_REF_DECAY 6u	  /* >>6 per 1 kHz tick: ~1.5%/ms, ~64 ms tau */
+
 static uint16_t gov_prev_erpm;
 /* Test inject: while >0, freeze estimator and treat as ceiling-limited so the
  * un-latch window can complete without a desync/re-seed race (SITL/HWCI). */
 static uint16_t gov_force_hold_ms;
+/* Consecutive 1 kHz ticks the reported eRPM has been physically impossible
+ * for the applied duty. See GOV_IMPLAUSIBLE_MARGIN. */
+static uint8_t gov_implausible_ms;
+/* Slow-decaying peak of applied duty - the reference the rail compares
+ * against, so a throttle chop cannot masquerade as an impossible eRPM. */
+static uint16_t gov_duty_ref;
 
 static void runtimeGovClearState(void)
 {
@@ -369,6 +442,8 @@ static void runtimeGovClearState(void)
 	gov_release_ceil = 0;
 	gov_force_hold_ms = 0;
 	gov_duty_ceiling = 2000;
+	gov_duty_ref = 0;
+	gov_implausible_ms = 0;
 }
 
 __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
@@ -516,6 +591,32 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 	ceiling = 2000;
 #	endif
 	gov_duty_ceiling = ceiling;
+
+	/* Impossible-eRPM rail (see GOV_IMPLAUSIBLE_MARGIN above). Runs only
+	 * once the slope estimator is confident, which is the same gate the
+	 * ceiling uses - an unlearned slope would compare against nothing. */
+	if (duty > gov_duty_ref) {
+		gov_duty_ref = (uint16_t)duty;
+	} else {
+		gov_duty_ref -= gov_duty_ref >> GOV_DUTY_REF_DECAY;
+	}
+	if (closed && gov_conf >= GOV_CONF_ARM && gov_duty_ref > 0 &&
+	    ((erpm * gov_slope_q10) >> 10) > (uint32_t)gov_duty_ref * GOV_IMPLAUSIBLE_MARGIN) {
+		if (gov_implausible_ms < GOV_IMPLAUSIBLE_MS) {
+			gov_implausible_ms++;
+		}
+	} else {
+		gov_implausible_ms = 0;
+	}
+	if (gov_implausible_ms >= GOV_IMPLAUSIBLE_MS) {
+		gov_implausible_ms = 0;
+		/* Position is not being measured. Hand off exactly as the
+		 * dead-reckoning budget does: with the comparator masked
+		 * nothing can reset INTERVAL_TIMER before the main loop's
+		 * stall rail sees it. */
+		maskPhaseInterrupts();
+		SET_INTERVAL_TIMER_COUNT(BEMF_STALL_TICKS + 1000u);
+	}
 }
 #endif /* !BRUSHED_MODE */
 

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -413,7 +413,7 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 
 	// (b) slope estimator — frozen during test inject.
 	if (!gov_force_hold_ms && duty > 250 && last_duty_cycle == duty_cycle_setpoint && duty_cycle_setpoint < gov_duty_ceiling &&
-	    zc_blind_steps == 0 && zc_demag_run == 0 && zc_grind_hold_ms == 0 && erpm > 32) {
+	    zc_blind_steps == 0 && zc_demag_run == 0 && zc_blind_ticks == 0 && erpm > 32) {
 		uint32_t obs = (duty << 10) / erpm; // erpm > 32 keeps this in uint16
 		if (gov_conf == 0) {
 			gov_slope_q10 = (uint16_t)obs;
@@ -434,7 +434,7 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 	 * completes deterministically without depending on plant spin.
 	 */
 	const uint8_t gov_limited = gov_force_hold_ms || (closed && gov_conf >= GOV_CONF_ARM && duty_cycle_setpoint >= gov_duty_ceiling &&
-							  zc_blind_steps == 0 && zc_demag_run == 0 && zc_grind_hold_ms == 0);
+							  zc_blind_steps == 0 && zc_demag_run == 0 && zc_blind_ticks == 0);
 	if (gov_force_hold_ms) {
 		gov_force_hold_ms--;
 		if (gov_stuck_ms < GOV_STUCK_MS) {

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -131,7 +131,17 @@ void runtimeProcessDesyncCheck(void)
 		slow_avg_revs = 0;
 	}
 	if (desync_check && zero_crosses > 10) {
-		uint8_t desynced = (getAbsDif(last_average_interval, average_interval) > average_interval >> 1) &&
+		// An extrapolated interval is a prediction this firmware made, not
+		// a measurement of the rotor, so it is not evidence of desync -
+		// see bemfZcAverageTainted(). Without this gate our own blind
+		// stepping trips upstream's jump check: a run of blind steps pushes
+		// ~1.5x intervals through commutation_intervals[] into
+		// average_interval, which reads as a >50% jump between electrical
+		// revolutions at fault onset and restarts the loop on self-inflicted
+		// evidence. The dead-reckoning budget in bemf_zc.c is the rail that
+		// owns lost position; this one owns measured interval jumps.
+		uint8_t desynced = !bemfZcAverageTainted() &&
+				   (getAbsDif(last_average_interval, average_interval) > average_interval >> 1) &&
 				   (average_interval < 2000); // throttle resitricted before zc 20.
 		// Interrupt-ZC trust rail: with no per-commutation fallback to poll
 		// mode, a closed loop tracking artifact edges below usable BEMF
@@ -184,25 +194,23 @@ void runtimeProcessDesyncCheck(void)
 			zero_crosses = 0;
 			bemfZcResetTrend();
 			desync_happened++;
-			// Same established-run gate as the stall rail (see
-			// faultHandleBemfIntervalStall): interval jumps while the
-			// loop is still acquiring (zc 11..100) are normal startup
-			// roughness on light motors - charging them stacks holdoff
-			// onto honest starts until the bucket
-			// latches a motor that never got going (SITL racer model
-			// reproduces this under plain dshot spool). Legacy desync
-			// handling below still restarts; only the episode
-			// accounting is established-runs-only.
-			if (zc_at_desync > 100) {
-				faultDesyncEpisodeCharge(DESYNC_EPISODE_JUMP);
-			} else {
-				// Acquisition-regime desyncs are not charged directly
-				// (that is what the gate above exists to prevent), but
-				// they must not be free either: without this the loop
-				// can desync forever below zc 100 with every rail and
-				// counter reading zero. See faultNoteEarlyDesync.
+			// Acquisition-regime desyncs (zc 11..100) are normal
+			// startup roughness on light motors, but a loop that can
+			// NEVER get past acquisition would otherwise leave every
+			// counter reading zero. Count the batch so telemetry can
+			// show a resisted start; it changes no control decision.
+			// See faultNoteEarlyDesync.
+			if (zc_at_desync <= 100) {
 				faultNoteEarlyDesync();
 			}
+			// Upstream AM32 main.c desync handling, verbatim in
+			// behaviour from here down: stop only if throttle is
+			// already off or the loop is running very slow, hand back
+			// to poll ZC, resume duty at the startup floor and let
+			// max_ramp carry it back up. No power cut and no coast -
+			// the rotor is still turning and the drive is what lets
+			// the loop re-find it. See the note at the top of faults.c
+			// for why the escalator that used to sit here is gone.
 			if ((!eepromBuffer.bi_direction && (input > 47)) || commutation_interval > 1000) {
 				running = 0;
 			}
@@ -212,11 +220,6 @@ void runtimeProcessDesyncCheck(void)
 				average_interval = 5000;
 			}
 			last_duty_cycle = min_startup_duty / 2;
-			if (faultDesyncRestartHoldoffActive() || escIsFault()) {
-				running = 0;
-				allOff();
-				maskPhaseInterrupts();
-			}
 		}
 		desync_check = 0;
 		//	}
@@ -475,7 +478,7 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 	// applied in 4 ms desyncs where 24 A reached gradually stays locked -
 	// the cliff is dV/dt, not level). Nothing in flight bounds dV/dt
 	// except the configured slew limit itself: the learned back-off that
-	// used to claim that job was removed (faultDesyncEpisodeCharge), and
+	// used to claim that job was removed (see faults.c), and
 	// reactive pacing cannot work at all (control_loop.c). dV/dt is set
 	// by the ramp regime schedule and has to be right by configuration.
 	uint16_t ceiling = 2000;
@@ -609,22 +612,25 @@ void runtimeMotorModeTick(void)
 	/* Sleep DRV ENABLE / nSLEEP when not driving, braking, or beeping. */
 	gateDriverPoll();
 	stuckcounter = 0;
-	/* Post-desync coast: do not re-enter six-step until holdoff expires.
-	 * (setInput's start branch is gated the same way - this alone cannot
-	 * hold the motor off, it only kills a run that was already going.) */
-	if (faultDesyncRestartHoldoffActive() || escIsFault()) {
+	/* Latched stuck rotor (faultHandleStuckRotorIfNeeded): the rotor is not
+	 * turning, so do not re-enter six-step. This is the ONLY state that holds
+	 * the motor off - a desync or a stall trip on a turning rotor keeps
+	 * driving and re-acquires through poll. (setInput's start branch is gated
+	 * the same way; this alone cannot hold the motor off, it only kills a run
+	 * that was already going.) */
+	if (escIsFault()) {
 		if (running) {
 			running = 0;
 			allOff();
 			maskPhaseInterrupts();
 		}
 		// The early return skips the e_rpm update below; zero it so
-		// telemetry (DroneCAN) reports the coast instead of the last
-		// running rpm for up to the whole holdoff.
+		// telemetry (DroneCAN) reports the fault instead of the last
+		// running rpm for as long as the latch holds.
 		e_rpm = 0;
 		k_erpm = 0;
-		dcm_hold_ms = 0;       // a coast must not carry a stale ceiling into the restart
-		adv_kerpm_hold_ms = 0; // a coast is a real slowdown, not a dead estimate
+		dcm_hold_ms = 0;       // do not carry a stale ceiling into the restart
+		adv_kerpm_hold_ms = 0; // a latched stop is a real slowdown, not a dead estimate
 		return;
 	}
 	if (!escInSineStart()) {

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -328,7 +328,7 @@ void runtimeSendTelemetryIfNeeded(void)
  * is observable every loop and load bias errs conservative (lower gain ->
  * lower ceiling). A misconfigured KV byte is exactly the failure class
  * this protects against, so it must not be an input. The estimator only
- * samples in trusted steady state (slew settled, no blind/demag/grind,
+ * samples in trusted steady state (slew settled, no blind/demag time,
  * NOT riding the ceiling - riding it would drag the estimate down and
  * under-spool), and the ceiling only arms after GOV_CONF_ARM eligible
  * samples (~0.3 s cumulative steady running per power-up).

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -143,18 +143,17 @@ void runtimeProcessDesyncCheck(void)
 		uint8_t desynced = !bemfZcAverageTainted() &&
 				   (getAbsDif(last_average_interval, average_interval) > average_interval >> 1) &&
 				   (average_interval < 2000); // throttle resitricted before zc 20.
-		// Interrupt-ZC trust rail: with no per-commutation fallback to poll
-		// mode, a closed loop tracking artifact edges below usable BEMF
-		// (stable false lock: crossings keep arriving, so neither the
-		// blind-step deadline nor the jump check above can see it) needs a
-		// way out. Sustained slow averages hand back to the poll path
-		// legacy-style - soft, no desync accounting - so a throttle chop
-		// decelerating through the band behaves exactly as before. A
-		// genuine false lock has a stationary rotor: poll then finds no
-		// real crossings and the INTERVAL_TIMER stall rail escalates to a
-		// full restart on its own. The 4-rev gate keeps the lagging
-		// average during spool-up from tripping this, and transient
-		// dropouts are ridden out by blind steps.
+		// Slow-average → poll is primarily per-commutation in commutate()
+		// (upstream AM32, restored for established closed loop). Blind steps
+		// cover transient misses without a mode change; poll re-entry is the
+		// soft recovery when the measured average has truly gone long.
+		//
+		// This rev-gated path remains as a belt: desync_check only runs once
+		// per electrical revolution, so it can catch a lagging e_com_time
+		// window that has not yet been sampled on a commutate() after the
+		// average crossed the threshold. Same changeover test, same soft
+		// exit (no desync accounting). Transient dropouts still ride out on
+		// blind steps because those do not lengthen the measured average.
 		if (!old_routine && running) {
 			if (average_interval > polling_mode_changeover + 500) {
 				slow_avg_revs++;

--- a/Src/runtime_loop.c
+++ b/Src/runtime_loop.c
@@ -499,6 +499,19 @@ __attribute__((optimize("Os"))) static void runtimeTransientGovernorTick(void)
 			ceiling = gov_release_ceil;
 		}
 	}
+#	ifdef AB_NO_GOVERNOR
+	/*
+	 * Hold full authority. Everything above still runs - the slope
+	 * estimator, the confidence counter, the latch/un-latch bookkeeping
+	 * and gov_unlatch_count - so the governor's own view of the motor
+	 * stays observable; only its authority over duty is removed. Overriding
+	 * here rather than skipping the block also covers the soft-release
+	 * path, which would otherwise keep capping on the way back up. 2000 is
+	 * the setpoint's own maximum, so the comparison in control_loop.c can
+	 * never bind.
+	 */
+	ceiling = 2000;
+#	endif
 	gov_duty_ceiling = ceiling;
 }
 #endif /* !BRUSHED_MODE */

--- a/Src/settings.c
+++ b/Src/settings.c
@@ -166,8 +166,8 @@ void loadEEpromSettings(void)
 		// Reset to compile defaults first so this load is idempotent: the
 		// eeprom value below only lowers (min semantics). Nothing at
 		// runtime writes these - the ramp an ESC flies is the ramp
-		// configured here (see faultDesyncEpisodeCharge for why the
-		// learned back-off that used to clamp them was removed).
+		// configured here (see the note at the top of faults.c for why
+		// the learned back-off that used to clamp them was removed).
 		//
 		// NOTE the min semantics flatten the graded schedule: max_ramp 20
 		// (the current factory default, 2.0 %/ms) clamps ALL THREE regimes

--- a/hwci/hwci/config.py
+++ b/hwci/hwci/config.py
@@ -207,6 +207,25 @@ class RigConfig:
     pole_pairs: int = 7                     # the motor under test (authoritative)
     prop: str = "sim-prop"
 
+    # Where mechanical RPM comes from.
+    #
+    # "stand" (default): the Flight Stand's optical sensor. Needs a reflective
+    # marker on the bell; it is also the only source INDEPENDENT of the ESC, so
+    # it is the only one that can catch eRPM-vs-truth divergence.
+    #
+    # "esc_perf": derive it from the firmware's own e_rpm in the hwci_perf
+    # struct, read over SWD (mech = e_rpm_field * 100 / pole_pairs). Use when
+    # the optical sensor cannot be made to read a given bell - a bare or
+    # sharpie-marked bell with no tape will not trigger it, and a dropped
+    # marker mid-run shows up as a fake RPM collapse that trips the desync
+    # watch. This keeps the max_rpm safety limit and the collapse detector
+    # working, but note what it costs: the speed signal is now the ESC's own
+    # estimate, so it cannot cross-check that estimate. Desync evidence has to
+    # come from the firmware-side witnesses instead (zero_crosses going
+    # backwards, bemf_timeout, blind-step bursts), which are independent of
+    # this setting.
+    rpm_source: str = "stand"
+
     def resolved_obj_dir(self) -> Path:
         return Path(self.obj_dir) if self.obj_dir else Path(self.repo_root) / "obj"
 
@@ -227,6 +246,14 @@ class RigConfig:
                     f"rig config: {key} = 'sim' is not allowed in a rig file; "
                     "use a real backend or 'none' (or run with --sim for a "
                     "fully simulated run)")
+        if self.rpm_source not in ("stand", "esc_perf"):
+            raise ValueError(
+                f"rig config: rpm_source = {self.rpm_source!r} is not one of "
+                "['esc_perf', 'stand']")
+        if self.rpm_source == "esc_perf" and self.debugger_backend != "openocd":
+            raise ValueError(
+                "rig config: rpm_source 'esc_perf' reads the firmware e_rpm "
+                "over SWD, so it needs debugger_backend 'openocd'")
         if self.throttle_backend == "flightstand" and self.stand_backend == "none":
             raise ValueError(
                 "rig config: throttle_backend 'flightstand' needs a stand "

--- a/hwci/hwci/perf.py
+++ b/hwci/hwci/perf.py
@@ -70,6 +70,19 @@ FIELDS_V3: list[tuple[str, str]] = FIELDS_V2 + [
     ("zc_confirm_reject", "I"),
 ]
 
+# main_instrumented (upstream baseline) reused version number 3 for a different
+# append: BDShot RX/TX health (96 bytes). Current ARK v3 is confirm_reject only
+# (84 bytes). Decode by header size so A/B flashes of main_instrumented still
+# read correctly (see branch main_instrumented Inc/hwci_perf.h).
+FIELDS_V3_MAIN_INSTRUMENTED: list[tuple[str, str]] = FIELDS_V2 + [
+    ("dshot_rx_good", "I"),
+    ("dshot_rx_bad", "I"),
+    ("dshot_tx_frames", "I"),
+    ("dshot_last_com_us", "H"),
+    ("dshot_telem_mode", "B"),
+    ("dshot_edt_mode", "B"),
+]
+
 # v4 appends the 32-bin PWM-phase histogram of accepted zero-crossings
 # (HWCI_PERF_ZC_PHASE_*). A repeat-count code ("32H") decodes to a tuple.
 ZC_PHASE_BINS = 32
@@ -117,6 +130,11 @@ def _format(fields: list[tuple[str, str]]) -> str:
 
 _FORMAT_BY_VERSION = {v: _format(f) for v, f in FIELDS_BY_VERSION.items()}
 SIZE_BY_VERSION = {v: struct.calcsize(fmt) for v, fmt in _FORMAT_BY_VERSION.items()}
+_FORMAT_V3_MAIN_INSTRUMENTED = _format(FIELDS_V3_MAIN_INSTRUMENTED)
+_SIZE_V3_MAIN_INSTRUMENTED = struct.calcsize(_FORMAT_V3_MAIN_INSTRUMENTED)
+assert _SIZE_V3_MAIN_INSTRUMENTED == 96
+# PerfReader accepts any size we can decode (ARK versions + main_instrumented).
+KNOWN_SIZES = set(SIZE_BY_VERSION.values()) | {_SIZE_V3_MAIN_INSTRUMENTED}
 
 _FORMAT = _FORMAT_BY_VERSION[VERSION]
 SIZE = SIZE_BY_VERSION[VERSION]  # 172 bytes (v6: 168, v5: 152, v4: 148, v3: 84, v2: 80, v1: 64)
@@ -216,13 +234,23 @@ def decode(data: bytes, *, host_monotonic: float | None = None,
             raise PerfDecodeError(
                 f"bad magic 0x{magic:08x} (expected 0x{MAGIC:08x}); "
                 "is the firmware built with HWCI_PERF=1?")
-        if version not in FIELDS_BY_VERSION:
-            raise PerfDecodeError(
-                f"struct version {version} unknown to host "
-                f"(knows {sorted(FIELDS_BY_VERSION)}); update hwci/hwci/perf.py")
-    fields = FIELDS_BY_VERSION.get(version) or FIELDS
-    ver = version if version in FIELDS_BY_VERSION else VERSION
-    fmt, expected = _FORMAT_BY_VERSION[ver], SIZE_BY_VERSION[ver]
+    # main_instrumented: version 3 + size 96 is BDShot append, not ARK confirm_reject.
+    if version == 3 and size == _SIZE_V3_MAIN_INSTRUMENTED:
+        fields = FIELDS_V3_MAIN_INSTRUMENTED
+        fmt, expected = _FORMAT_V3_MAIN_INSTRUMENTED, _SIZE_V3_MAIN_INSTRUMENTED
+        ver = 3
+    elif version in FIELDS_BY_VERSION:
+        fields = FIELDS_BY_VERSION[version]
+        ver = version
+        fmt, expected = _FORMAT_BY_VERSION[ver], SIZE_BY_VERSION[ver]
+    elif validate:
+        raise PerfDecodeError(
+            f"struct version {version} unknown to host "
+            f"(knows {sorted(FIELDS_BY_VERSION)}); update hwci/hwci/perf.py")
+    else:
+        fields = FIELDS
+        ver = VERSION
+        fmt, expected = _FORMAT_BY_VERSION[ver], SIZE_BY_VERSION[ver]
     if len(data) < expected:
         raise PerfDecodeError(
             f"v{ver} struct needs {expected} bytes, got {len(data)}")

--- a/hwci/hwci/perf_reader.py
+++ b/hwci/hwci/perf_reader.py
@@ -28,7 +28,7 @@ class PerfReader:
         # The ELF's struct size identifies the firmware's layout version: an
         # A/B session flashes old firmware whose struct predates newer fields,
         # and the harness must keep reading it (perf.decode is version-aware).
-        known = set(perf.SIZE_BY_VERSION.values())
+        known = getattr(perf, "KNOWN_SIZES", None) or set(perf.SIZE_BY_VERSION.values())
         if sym.size and sym.size not in known:
             raise perf.PerfDecodeError(
                 f"hwci_perf ELF size {sym.size} matches no known version "
@@ -52,9 +52,10 @@ class PerfReader:
             return
         # Pick the canonical layout matching the firmware's vintage by probing
         # for version-marker members, then verify every field of THAT layout.
+        # main_instrumented: 96-byte v3 is BDShot-only (no esc_state/confirm_reject).
         if "zc_blind_steps" in members:
             fields = perf.FIELDS_V7
-        elif "dshot_rx_good" in members:
+        elif "esc_state" in members and "dshot_rx_good" in members:
             fields = perf.FIELDS_V6
         elif "esc_state" in members:
             fields = perf.FIELDS_V5
@@ -62,6 +63,8 @@ class PerfReader:
             fields = perf.FIELDS_V4
         elif "zc_confirm_reject" in members:
             fields = perf.FIELDS_V3
+        elif "dshot_rx_good" in members:
+            fields = perf.FIELDS_V3_MAIN_INSTRUMENTED
         elif "zc_count" in members:
             fields = perf.FIELDS_V2
         else:

--- a/hwci/hwci/profiles/noprop_setpoint_steps.yaml
+++ b/hwci/hwci/profiles/noprop_setpoint_steps.yaml
@@ -1,0 +1,55 @@
+name: noprop_setpoint_steps
+description: >
+  Hard setpoint steps with NO propeller, both directions, for the PR #85
+  degrade-instead-of-restart work. The vector is the free-run snap-UP: with no
+  aerodynamic load the rotor accelerates fast enough that average_interval can
+  move more than 50% between electrical revolutions, which is exactly what the
+  jump-desync check in runtimeProcessDesyncCheck keys on - and with blind
+  stepping armed (zero_crosses >= 100) the extrapolated intervals feed that
+  same average. Snap-DOWN is the complementary case: a free bell coasts a long
+  time with no drag, so commanded duty collapses while the rotor is still fast.
+  What to read from a run: any allOff/power-cut segment (esc_state, perf_running
+  dropping while throttle is commanded high), blind-step count, and whether
+  zero_crosses ever goes backwards. Capped at 55% - 1980 KV on 6S free-runs
+  ~50k RPM at full throttle, so this profile must never approach 100%. ~20 s.
+sample_rate_hz: 200
+arm_settle_s: 2.0
+demag_commutation_spike: 3.0
+demag_rpm_drop_fraction: 0.25
+
+safety:
+  # A 10->50 snap on this article measured a legitimate 75 A inrush: at
+  # 5.1k RPM the bell makes only 2.6 V of BEMF against ~12.4 V commanded,
+  # across roughly 30 mOhm of phase resistance, and it accelerates out of it
+  # in ~10 ms. The first run of this profile aborted at a 20 A cap on exactly
+  # that transient with zero_crosses still climbing monotonically - the cap
+  # was wrong, not the firmware. 90 A clears it while still aborting below
+  # both the firmware's own limiter (eeprom limits.current = 102 A) and the
+  # 100-165 A wrong-phase runaways this rig has recorded historically.
+  max_current_a: 90.0
+  max_thrust_n: 2.0      # ~0 expected without a prop; trips on sensor faults
+  # NOT the overspeed guard on this bench - the 55% throttle cap above is,
+  # since 1980 KV on 6S cannot exceed ~27.4k mech at that duty. This limit is
+  # set above the 50k full-throttle free-run ceiling so it only catches a
+  # genuinely impossible reading, because with rpm_source esc_perf the RPM
+  # channel is the ESC's own estimate and that estimate is NOT trustworthy at
+  # very low throttle: measured on this article during rampdn at 2.5% duty and
+  # -0.04 A, it ran 643 -> 4886 -> 33743 in 60 ms with commutation_interval
+  # collapsing to 63 (31 us/commutation) - a false lock on artifact edges below
+  # usable BEMF, not an overspeed. Restore a tight limit here if the optical
+  # sensor is ever made to read this bell.
+  max_rpm: 55000
+  max_motor_temp_c: 80.0
+
+segments:
+  - {label: idle,    throttle: 0.00, duration_s: 2.0}
+  - {label: pre,     throttle: 0.10, duration_s: 3.0, ramp: true, steady: true}
+  - {label: up50,    throttle: 0.50, duration_s: 2.0}   # snap 10->50
+  - {label: dn10a,   throttle: 0.10, duration_s: 2.0}   # snap 50->10
+  - {label: up55,    throttle: 0.55, duration_s: 2.0}   # snap 10->55
+  - {label: dn15,    throttle: 0.15, duration_s: 2.0}   # snap 55->15
+  - {label: up40,    throttle: 0.40, duration_s: 1.5}   # mid-band snap
+  - {label: up55b,   throttle: 0.55, duration_s: 1.5}   # stacked snap, no settle
+  - {label: dn05,    throttle: 0.05, duration_s: 2.0}   # snap to near-idle
+  - {label: rampdn,  throttle: 0.00, duration_s: 2.0, ramp: true}
+  - {label: stop,    throttle: 0.00, duration_s: 1.0}

--- a/hwci/hwci/profiles/prop5_smoke.yaml
+++ b/hwci/hwci/profiles/prop5_smoke.yaml
@@ -1,0 +1,41 @@
+name: prop5_smoke
+description: >
+  Loaded bring-up and limit calibration for the 5" 3-blade on the AOS
+  Supernova 2207 1980KV at 6S. Deliberately modest - 10/20/30% steady holds
+  with gentle ramps - because nothing on this bench has run this article
+  loaded yet and the step-stress profile's current and thrust caps have to be
+  set from measured draw rather than guessed. Read max thrust and max current
+  per hold out of the report, then size prop5_setpoint_steps from them.
+  Never raise this profile's ceiling; make a new one. ~28 s.
+sample_rate_hz: 100
+arm_settle_s: 3.0
+steady_tail_fraction: 0.5
+
+safety:
+  # Sized to abort well before the article's full-throttle envelope: a 2207
+  # 1980KV on 6S with a 5" tri-blade makes roughly 18-22 N and pulls 45-55 A
+  # at 100%, and this profile never commands above 30%, where square/cube
+  # scaling puts thrust near 2 N and current in the low single digits. A trip
+  # here means the article is drawing far more than the operating point can
+  # account for, which is the abort we want.
+  max_current_a: 35.0
+  max_thrust_n: 14.0
+  max_motor_temp_c: 80.0
+  # NO max_rpm ON THIS BENCH, deliberately. The optical sensor cannot read
+  # this bell, so RPM comes from the ESC's own estimate (rig rpm_source
+  # esc_perf), and that estimate is garbage below the drive threshold: every
+  # spin-up ramps up through 0.3-0.5% commanded throttle where the comparator
+  # picks up artifact edges, commutation_interval collapses to ~38 (19 us),
+  # and the derived RPM reads 70-77k on a rotor making ~0.03 N of thrust.
+  # Four runs aborted on that before it was removed. Raising the running duty
+  # floor to 2% did NOT fix it - the artifact is below the threshold at which
+  # any floor applies. Thrust and current are the real guards here and, unlike
+  # RPM, both are measured independently of the ESC.
+
+segments:
+  - {label: idle,   throttle: 0.00, duration_s: 2.0}
+  - {label: t10,    throttle: 0.10, duration_s: 5.0, ramp: true,  steady: true}
+  - {label: t20,    throttle: 0.20, duration_s: 5.0, ramp: true,  steady: true}
+  - {label: t30,    throttle: 0.30, duration_s: 5.0, ramp: true,  steady: true}
+  - {label: rampdn, throttle: 0.00, duration_s: 3.0, ramp: true}
+  - {label: stop,   throttle: 0.00, duration_s: 2.0}

--- a/hwci/hwci/runner.py
+++ b/hwci/hwci/runner.py
@@ -22,6 +22,7 @@ at zero throttle, because AM32 beeps the motor whenever it has no input.
 """
 from __future__ import annotations
 
+import dataclasses
 import sys
 import threading
 import time
@@ -50,6 +51,10 @@ class Sources:
     telem_source: TelemSourceFn
     perf_reader: Optional[PerfReader] = None
     closers: list = field(default_factory=list)
+    # RigConfig.rpm_source / RigConfig.pole_pairs, carried here so run_profile
+    # can substitute the ESC-derived RPM without taking a rig dependency.
+    rpm_source: str = "stand"
+    pole_pairs: int = 7
 
     def close(self) -> None:
         for c in reversed(self.closers):
@@ -77,6 +82,59 @@ def _segment_throttle(seg, tick_in_seg: int, n_ticks: int, prev: float) -> float
         return seg.throttle
     frac = tick_in_seg / (n_ticks - 1)
     return prev + (seg.throttle - prev) * min(1.0, frac)
+
+
+#: hwci_perf.esc_state == ESC_CLOSED_LOOP (Inc/esc_state.h).
+_ESC_CLOSED_LOOP = 5
+
+
+def esc_perf_rpm(pf: PerfSample | None, pole_pairs: int) -> float | None:
+    """Mechanical RPM from the firmware's own e_rpm (hwci_perf, read over SWD).
+
+    CLOSED LOOP ONLY, and that restriction is load-bearing. In closed loop the
+    firmware computes ``e_rpm = 600000 / e_com_time`` (runtime_loop.c), which
+    is electrical RPM / 100 as Inc/hwci_perf.h documents, so mechanical RPM is
+    ``field * 100 / pole_pairs``. The open-loop startup path writes the SAME
+    field on a DIFFERENT scale - ``e_rpm = 600 / step_delay``, commented "in
+    hundreds" - so reading it there overstates speed by orders of magnitude.
+    That is not theoretical: it aborted a bench run with "rpm 73257 > limit
+    30000" on a motor whose free-run ceiling at 6S is ~50k, out of a startup
+    transient.
+
+    Returns None whenever the value cannot be trusted (no perf sample, no pole
+    count, not in closed loop). The caller leaves the stand's own RPM in place
+    in that case rather than substituting a zero, which would read as a
+    collapse and trip the desync watch on every normal spin-up.
+    """
+    if pf is None or pole_pairs <= 0:
+        return None
+    raw = getattr(pf, "raw", None) or {}
+    if int(raw.get("esc_state") or 0) != _ESC_CLOSED_LOOP:
+        return None
+    try:
+        erpm = float(pf.e_rpm)
+    except Exception:
+        try:
+            erpm = float(raw.get("e_rpm") or 0) * 100.0
+        except Exception:
+            return None
+    return erpm / float(pole_pairs)
+
+
+def substitute_esc_rpm(stand: StandSample | None, pf: PerfSample | None,
+                       pole_pairs: int) -> StandSample | None:
+    """Replace a stand sample's optical RPM with the ESC-derived one.
+
+    Applied before safety, the desync watch and the saved row, so every
+    downstream consumer sees one consistent RPM channel and needs no knowledge
+    of where it came from.
+    """
+    if stand is None:
+        return None
+    rpm = esc_perf_rpm(pf, pole_pairs)
+    if rpm is None:
+        return stand
+    return dataclasses.replace(stand, rpm=rpm)
 
 
 def enforce_safety(limits: SafetyLimits, stand: StandSample | None,
@@ -343,6 +401,7 @@ def run_profile(profile: Profile, sources: Sources, *,
     period = 1.0 / profile.sample_rate_hz
     rows: list[dict] = []
     aborted: str | None = None
+    rpm_from_esc = sources.rpm_source == "esc_perf"
 
     sources.throttle.arm()
     if sources.perf_reader is not None:
@@ -407,13 +466,21 @@ def run_profile(profile: Profile, sources: Sources, *,
                 sources.throttle.set(throttle)
                 stand = sources.stand.read_sample() if sources.stand is not None else None
                 pf = perf_get()
+                if rpm_from_esc:
+                    stand = substitute_esc_rpm(stand, pf, sources.pole_pairs)
                 tm = _safe(sources.telem_source)
-                enforce_safety(profile.safety, stand, tm)
                 # Record the ACTUAL sample time: after a host stall the
                 # schedule time would lie about how much wall clock the
                 # sample covers (and corrupt counter-rate math downstream).
                 t = (time.monotonic() - start) if realtime else t_sched
+                # Append BEFORE the safety and desync checks, so the sample
+                # that trips an abort is in the saved data. It used to be
+                # appended after, which meant every abort discarded exactly
+                # the one sample needed to diagnose it - the reported value
+                # appeared nowhere in samples.csv and the run looked healthy
+                # right up to the last row.
                 rows.append(make_row(t, seg.label, throttle, stand, tm, pf))
+                enforce_safety(profile.safety, stand, tm)
                 # Cut throttle immediately on live desync — do not finish the
                 # remaining profile segments into a freewheeling/desynced rotor.
                 desync_watch.check(throttle, stand, pf)
@@ -667,7 +734,8 @@ def build_live_sources(rig: RigConfig, profile: Profile, *,
 
     sources = Sources(throttle=throttle, stand=stand, perf_source=perf_source,
                       telem_source=telem_source, perf_reader=perf_reader,
-                      closers=closers)
+                      closers=closers, rpm_source=rig.rpm_source,
+                      pole_pairs=rig.pole_pairs)
     try:
         if perf_reader is not None:
             _ensure_app_alive(dbg, perf_reader, throttle)

--- a/hwci/scripts/dump_zc_trace.py
+++ b/hwci/scripts/dump_zc_trace.py
@@ -51,7 +51,7 @@ EV = "<HBB"               # interval, kind, duty8
 EV_SIZE = struct.calcsize(EV)
 
 KINDS = {0: "-", 1: "ACCEPT", 2: "REJ_MININT", 3: "REJ_CONFIRM",
-         4: "BLIND", 5: "BUDGET"}
+         4: "BLIND", 5: "BUDGET", 6: "REJ_TRUST"}
 # Mirrors HWCI_CMD_ARM_ZC_TRACE / hwci_perf.host_cmd.
 ARM_CMD = 0x5A
 # Mirrors HWCI_PERF_MAGIC in Inc/hwci_perf.h. Lives in .data, so it is only

--- a/hwci/scripts/dump_zc_trace.py
+++ b/hwci/scripts/dump_zc_trace.py
@@ -127,6 +127,12 @@ def main() -> int:
                     help="poll until frozen, print, re-arm, repeat")
     ap.add_argument("--arm", action="store_true",
                     help="just re-arm the trace and exit")
+    ap.add_argument("--live", type=float, metavar="SECONDS", default=None,
+                    help="stay attached and dump the ring every SECONDS "
+                         "whether or not it froze. This is the mode for "
+                         "characterising HEALTHY running: --watch only ever "
+                         "prints on a trigger, and the arm/drive/read flow "
+                         "needs the session dropped while you drive.")
     ap.add_argument("--out", default="zc_trace.log",
                     help="append every capture here as well as printing it; "
                          "--watch re-arms after each freeze, so without this "
@@ -199,6 +205,26 @@ def main() -> int:
         if args.arm:
             rearm()
             print("re-armed")
+            return 0
+
+        if args.live is not None:
+            print(f"PASSIVE - drive by hand. Dumping every {args.live}s. "
+                  "Ctrl-C to stop.")
+            rearm(verify=False)
+            n = 0
+            try:
+                while True:
+                    time.sleep(args.live)
+                    tr = read_trace(dbg, sym.address, sym.size)
+                    n += 1
+                    print(f"\n=== dump {n} "
+                          f"({'FROZEN - detector armed' if tr['frozen'] else 'live'}) ===")
+                    show(tr, args.out)
+                    # Always re-arm: frozen or not, the next dump should be a
+                    # fresh window rather than the same wrapped ring.
+                    rearm(verify=False)
+            except KeyboardInterrupt:
+                print(f"\nstopped after {n} dumps")
             return 0
 
         if not args.watch:

--- a/hwci/scripts/dump_zc_trace.py
+++ b/hwci/scripts/dump_zc_trace.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Dump the firmware's per-commutation ZC trace over SWD.
+
+PASSIVE. Opens OpenOCD, resolves ``hwci_zc_trace`` from the ELF and reads it.
+It never arms the stand, never commands throttle, never resets the target.
+
+The ring free-runs while armed and the FIRMWARE freezes it on the entry
+signature of the false lock - an accepted crossing whose interval is less than
+half the tracked estimate - then records HWCI_ZC_TRACE_POST more events. So a
+frozen buffer holds the commutations either side of entry, which is what a
+host-side freeze cannot catch (a whole poll period of latency, by which time
+the lock is established).
+
+Usage, with the motor being driven BY HAND:
+
+    # poll until the firmware trips the trigger, then print and re-arm
+    hwci/.venv/bin/python hwci/scripts/dump_zc_trace.py --config hwci/rig.yaml --watch
+
+    # one-shot read of whatever is in the buffer right now
+    hwci/.venv/bin/python hwci/scripts/dump_zc_trace.py --config hwci/rig.yaml
+
+``ci`` in the output is RECONSTRUCTED, not stored: the firmware logs only the
+measured interval per event (4 bytes/event was what the F051 RAM budget
+allowed), and the estimate is replayed here through the same IIR the firmware
+uses in PeriodElapsedCallback,
+
+    ci <- (ci + (last + this) / 2) / 2
+
+anchored on ci_at_arm and advanced ONLY on accepted crossings - blind steps do
+not update the estimate (see bemf_zc.c). Treat it as a close reconstruction,
+not ground truth.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hwci import elf as elfmod                        # noqa: E402
+from hwci.config import load_rig                      # noqa: E402
+from hwci.debugger.openocd import OpenOcdDebugger      # noqa: E402
+
+SYMBOL = "hwci_zc_trace"
+HDR = "<HBBIBBH"          # write_idx, frozen, post, total, wrapped, _pad, ci_at_arm
+HDR_SIZE = struct.calcsize(HDR)
+EV = "<HBB"               # interval, kind, duty8
+EV_SIZE = struct.calcsize(EV)
+
+KINDS = {0: "-", 1: "ACCEPT", 2: "REJ_MININT", 3: "REJ_CONFIRM",
+         4: "BLIND", 5: "BUDGET"}
+# Mirrors HWCI_CMD_ARM_ZC_TRACE / hwci_perf.host_cmd.
+ARM_CMD = 0x5A
+
+
+def read_trace(dbg, addr: int, size: int):
+    raw = dbg.read_memory(addr, size)
+    write_idx, frozen, post, total, wrapped, _pad, ci_at_arm = \
+        struct.unpack_from(HDR, raw, 0)
+    n = (size - HDR_SIZE) // EV_SIZE
+    evs = [struct.unpack_from(EV, raw, HDR_SIZE + i * EV_SIZE)
+           for i in range(n)]
+    return dict(write_idx=write_idx, frozen=frozen, post=post, total=total,
+                wrapped=wrapped, ci_at_arm=ci_at_arm, n=n, evs=evs)
+
+
+def ordered(tr):
+    """Oldest-first. Once wrapped, the oldest entry is at write_idx."""
+    evs, n, w = tr["evs"], tr["n"], tr["write_idx"]
+    if not tr["wrapped"]:
+        return evs[:w]
+    return evs[w:] + evs[:w]
+
+
+def show(tr, out=None) -> None:
+    lines: list[str] = []
+
+    def emit(line: str = "") -> None:
+        print(line)
+        lines.append(line)
+
+    evs = ordered(tr)
+    emit(f"\nframes={len(evs)} total={tr['total']} frozen={tr['frozen']} "
+         f"ci_at_arm={tr['ci_at_arm']}")
+    if not evs:
+        emit("  (empty - nothing recorded yet)")
+        _flush(lines, out)
+        return
+    ci = float(tr["ci_at_arm"]) or float(evs[0][0])
+    last = this = float(evs[0][0])
+    emit(f"{'#':>3} {'kind':<12} {'interval':>9} {'ci(recon)':>10} "
+         f"{'ratio':>7} {'duty':>6}")
+    for i, (interval, kind, duty8) in enumerate(evs):
+        ratio = (interval / ci) if ci else 0.0
+        flag = ""
+        if kind == 1 and ratio < 0.5:
+            flag = "  <-- TRIGGER (accepted at < ci/2)"
+        elif kind == 2:
+            flag = "  (gate rejected)"
+        emit(f"{i:>3} {KINDS.get(kind, '?'):<12} {interval:>9} {ci:>10.0f} "
+             f"{ratio:>7.2f} {duty8 * 8:>6}{flag}")
+        # Replay the firmware's estimate: accepted crossings only.
+        if kind == 1:
+            last, this = this, float(interval)
+            ci = (ci + (last + this) / 2.0) / 2.0
+    _flush(lines, out)
+
+
+def _flush(lines, out) -> None:
+    if not out:
+        return
+    with open(out, "a") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--watch", action="store_true",
+                    help="poll until frozen, print, re-arm, repeat")
+    ap.add_argument("--arm", action="store_true",
+                    help="just re-arm the trace and exit")
+    ap.add_argument("--out", default="zc_trace.log",
+                    help="append every capture here as well as printing it; "
+                         "--watch re-arms after each freeze, so without this "
+                         "a capture exists only in the terminal scrollback")
+    args = ap.parse_args()
+
+    rig = load_rig(args.config)
+    elf = rig.resolved_elf()
+    if elf is None:
+        print("error: no ELF for target; build first", file=sys.stderr)
+        return 2
+    sym = elfmod.find_symbol(str(elf), SYMBOL)
+    if not sym.size:
+        print(f"error: {SYMBOL} has no size in {elf}; is this an "
+              "HWCI_PERF=1 build?", file=sys.stderr)
+        return 2
+
+    dbg = OpenOcdDebugger(rig.openocd_configs, openocd_bin=rig.openocd_bin,
+                          search_dirs=rig.openocd_search_dirs).open()
+    try:
+        perf = elfmod.find_symbol(str(elf), "hwci_perf")
+        # host_cmd sits at offset 60 in hwci_perf and is frozen there across
+        # every struct version, precisely so an A/B session can command any
+        # vintage without a layout lookup (see Inc/hwci_perf.h).
+        cmd_addr = perf.address + 60
+
+        def rearm():
+            dbg.write_u32(cmd_addr, ARM_CMD)
+
+        print(f"{SYMBOL} @ 0x{sym.address:08x} ({sym.size} bytes)")
+        if args.arm:
+            rearm()
+            print("re-armed")
+            return 0
+
+        if not args.watch:
+            show(read_trace(dbg, sym.address, sym.size), args.out)
+            return 0
+
+        print("PASSIVE - drive by hand. Waiting for the firmware to trip the "
+              "trigger. Ctrl-C to stop.")
+        rearm()
+        try:
+            while True:
+                tr = read_trace(dbg, sym.address, sym.size)
+                if tr["frozen"]:
+                    show(tr, args.out)
+                    print("re-arming...\n")
+                    rearm()
+                    time.sleep(0.3)
+                time.sleep(0.05)
+        except KeyboardInterrupt:
+            print("\nstopped")
+        return 0
+    finally:
+        try:
+            dbg.close()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hwci/scripts/dump_zc_trace.py
+++ b/hwci/scripts/dump_zc_trace.py
@@ -54,6 +54,10 @@ KINDS = {0: "-", 1: "ACCEPT", 2: "REJ_MININT", 3: "REJ_CONFIRM",
          4: "BLIND", 5: "BUDGET"}
 # Mirrors HWCI_CMD_ARM_ZC_TRACE / hwci_perf.host_cmd.
 ARM_CMD = 0x5A
+# Mirrors HWCI_PERF_MAGIC in Inc/hwci_perf.h. Lives in .data, so it is only
+# present once the firmware's startup has run - which is exactly what makes it
+# a usable "is this image actually running?" probe.
+HWCI_PERF_MAGIC = 0x31435748
 
 
 def read_trace(dbg, addr: int, size: int):
@@ -144,13 +148,52 @@ def main() -> int:
                           search_dirs=rig.openocd_search_dirs).open()
     try:
         perf = elfmod.find_symbol(str(elf), "hwci_perf")
+        # Health check BEFORE anything else. Reading a trace out of a target
+        # that is not running THIS image yields plausible-looking garbage -
+        # a stale buffer, or another build's RAM at the same address - and
+        # there is no way to tell from the event data alone. A whole bench
+        # session was once logged as 101 "captures" that were one stale
+        # buffer reprinted, because this check did not exist.
+        magic, version, ssize = struct.unpack_from(
+            "<IHH", dbg.read_memory(perf.address, 8), 0)
+        if magic != HWCI_PERF_MAGIC:
+            print(f"error: hwci_perf.magic = 0x{magic:08X}, expected "
+                  f"0x{HWCI_PERF_MAGIC:08X}.\n"
+                  "The target is not running this firmware. Either it is "
+                  "unpowered / held in reset, or the flashed image is not\n"
+                  f"  {elf}\n"
+                  "Flash it first:\n"
+                  f"  hwci flash --config {args.config} --bin "
+                  f"{str(elf).replace('.elf', '.bin')}",
+                  file=sys.stderr)
+            return 2
+        print(f"target ok: hwci_perf v{version}, {ssize} bytes")
         # host_cmd sits at offset 60 in hwci_perf and is frozen there across
         # every struct version, precisely so an A/B session can command any
         # vintage without a layout lookup (see Inc/hwci_perf.h).
         cmd_addr = perf.address + 60
 
-        def rearm():
+        def rearm(verify: bool = True) -> bool:
+            """Re-arm and confirm the firmware consumed it.
+
+            The command is serviced from the main loop, so a target that is
+            wedged - or whose host_cmd offset does not match this ELF - will
+            silently never clear it. Without this check --watch spins on the
+            still-frozen buffer and reprints it every poll.
+            """
             dbg.write_u32(cmd_addr, ARM_CMD)
+            if not verify:
+                return True
+            for _ in range(40):
+                time.sleep(0.05)
+                if not read_trace(dbg, sym.address, sym.size)["frozen"]:
+                    return True
+            print("error: re-arm was not consumed within 2 s - the trace is "
+                  "still frozen.\nThe firmware services host_cmd from the "
+                  "main loop, so this means the target is wedged or is not "
+                  "running this image. Not reprinting the stale buffer.",
+                  file=sys.stderr)
+            return False
 
         print(f"{SYMBOL} @ 0x{sym.address:08x} ({sym.size} bytes)")
         if args.arm:
@@ -164,15 +207,19 @@ def main() -> int:
 
         print("PASSIVE - drive by hand. Waiting for the firmware to trip the "
               "trigger. Ctrl-C to stop.")
-        rearm()
+        if not rearm():
+            return 2
+        n = 0
         try:
             while True:
                 tr = read_trace(dbg, sym.address, sym.size)
                 if tr["frozen"]:
+                    n += 1
+                    print(f"\n=== capture {n} ===")
                     show(tr, args.out)
-                    print("re-arming...\n")
-                    rearm()
-                    time.sleep(0.3)
+                    print("re-arming...")
+                    if not rearm():
+                        return 2
                 time.sleep(0.05)
         except KeyboardInterrupt:
             print("\nstopped")

--- a/hwci/scripts/watch_perf.py
+++ b/hwci/scripts/watch_perf.py
@@ -45,8 +45,8 @@ from hwci.config import load_rig                      # noqa: E402
 from hwci.debugger.openocd import OpenOcdDebugger      # noqa: E402
 from hwci.perf_reader import PerfReader                # noqa: E402
 
-COLS = ("t", "ci", "rpm", "zc", "blind", "reject", "bemfTO", "state",
-        "running", "armed", "input", "duty")
+COLS = ("t", "ci", "rpm", "zc", "blind", "reject", "jitmax", "bemfTO",
+        "state", "running", "armed", "input", "duty")
 
 
 def main() -> int:
@@ -75,9 +75,9 @@ def main() -> int:
     with open(args.out, "w", newline="") as fh:
         w = csv.DictWriter(fh, fieldnames=COLS)
         w.writeheader()
-        print("%8s %6s %8s %7s %6s %7s %6s %5s %6s" %
-              ("t", "ci", "rpm", "zc", "blind", "reject", "bemfTO", "st",
-               "duty"))
+        print("%8s %6s %8s %7s %6s %7s %6s %6s %5s %6s" %
+              ("t", "ci", "rpm", "zc", "blind", "reject", "jitmax",
+               "bemfTO", "st", "duty"))
         try:
             while True:
                 loop_start = time.monotonic()
@@ -105,6 +105,7 @@ def main() -> int:
                     "zc": zc,
                     "blind": int(raw.get("zc_blind_steps") or 0),
                     "reject": int(raw.get("zc_confirm_reject") or 0),
+                    "jitmax": int(raw.get("zc_jitter_max") or 0),
                     "bemfTO": int(raw.get("bemf_timeout") or 0),
                     "state": state,
                     "running": int(raw.get("running") or 0),
@@ -126,9 +127,10 @@ def main() -> int:
                     or row["state"] != prev.get("state", row["state"])
                 )
                 if interesting or n % 25 == 0:
-                    print("%8.3f %6d %8.0f %7d %6d %7d %6d %5d %6d" %
+                    print("%8.3f %6d %8.0f %7d %6d %7d %6d %6d %5d %6d" %
                           (row["t"], ci, rpm, row["zc"], row["blind"],
-                           row["reject"], row["bemfTO"], state, row["duty"]))
+                           row["reject"], row["jitmax"], row["bemfTO"],
+                           state, row["duty"]))
                 prev = row
                 delay = period - (time.monotonic() - loop_start)
                 if delay > 0:

--- a/hwci/scripts/watch_perf.py
+++ b/hwci/scripts/watch_perf.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Passive hwci_perf logger - watch the ESC over SWD while a HUMAN drives it.
+
+This script has NO throttle authority. It opens OpenOCD, resolves hwci_perf
+from the ELF and polls it; it never arms the stand, never commands an output,
+and never resets the target. That is the whole point: the grinding wrong-phase
+state on this article is provoked by hard step inputs, and the safe way to
+capture it is for the operator to drive the throttle by hand while the host
+only observes.
+
+    hwci/.venv/bin/python hwci/scripts/watch_perf.py --config hwci/rig.yaml \
+        --out /tmp/grind.csv
+
+Prints a line whenever something interesting changes and writes every sample
+to CSV. Ctrl-C to stop.
+
+The columns are chosen for the wrong-phase grind specifically:
+
+  ci            commutation_interval, 0.5us units. In the grind this collapses
+                (19-38 was measured at near-zero rpm), so watch it against rpm.
+  rpm           mechanical, derived from the firmware's own e_rpm - CLOSED LOOP
+                ONLY, it is meaningless otherwise (see runner.esc_perf_rpm).
+  zc            zero_crosses. Going BACKWARDS = the loop restarted.
+  blind         zc_blind_steps, consecutive dead-reckoned commutations.
+  reject        zc_confirm_reject, edges the ZC filter threw out. A healthy
+                loop rejects a steady trickle; a wrong-phase lock accepts
+                almost everything, so this going QUIET while ci collapses is
+                the signature to look for.
+  bemfTO        bemf_timeout_happened - the stall rail, and the counter that
+                escalates to the genuine stuck-rotor stop.
+  state         esc_state: 4 = OPEN_LOOP (poll ZC), 5 = CLOSED_LOOP,
+                7 = FAULT_STUCK.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hwci.config import load_rig                      # noqa: E402
+from hwci.debugger.openocd import OpenOcdDebugger      # noqa: E402
+from hwci.perf_reader import PerfReader                # noqa: E402
+
+COLS = ("t", "ci", "rpm", "zc", "blind", "reject", "bemfTO", "state",
+        "running", "armed", "input", "duty")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--out", default="perf_watch.csv")
+    ap.add_argument("--hz", type=float, default=50.0)
+    args = ap.parse_args()
+
+    rig = load_rig(args.config)
+    elf = rig.resolved_elf()
+    if elf is None:
+        print("error: no ELF for target; build first", file=sys.stderr)
+        return 2
+
+    dbg = OpenOcdDebugger(rig.openocd_configs, openocd_bin=rig.openocd_bin,
+                          search_dirs=rig.openocd_search_dirs).open()
+    reader = PerfReader(dbg, str(elf))
+    print(f"watching hwci_perf @ 0x{reader.address:08x} via {elf.name}")
+    print("PASSIVE - no throttle is commanded. Drive by hand. Ctrl-C to stop.\n")
+
+    period = 1.0 / args.hz
+    t0 = time.monotonic()
+    prev = {}
+    n = 0
+    with open(args.out, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=COLS)
+        w.writeheader()
+        print("%8s %6s %8s %7s %6s %7s %6s %5s %6s" %
+              ("t", "ci", "rpm", "zc", "blind", "reject", "bemfTO", "st",
+               "duty"))
+        try:
+            while True:
+                loop_start = time.monotonic()
+                try:
+                    pf = reader.read()
+                except Exception as e:
+                    if n == 0:
+                        print(f"perf read failed: {e!r}", file=sys.stderr)
+                    time.sleep(period)
+                    continue
+                raw = getattr(pf, "raw", None) or {}
+                state = int(raw.get("esc_state") or 0)
+                ci = int(raw.get("commutation_interval") or 0)
+                zc = int(raw.get("zero_cross_count") or 0)
+                rpm = 0.0
+                if state == 5 and rig.pole_pairs:
+                    try:
+                        rpm = float(pf.e_rpm) / rig.pole_pairs
+                    except Exception:
+                        rpm = 0.0
+                row = {
+                    "t": round(time.monotonic() - t0, 4),
+                    "ci": ci,
+                    "rpm": round(rpm, 1),
+                    "zc": zc,
+                    "blind": int(raw.get("zc_blind_steps") or 0),
+                    "reject": int(raw.get("zc_confirm_reject") or 0),
+                    "bemfTO": int(raw.get("bemf_timeout") or 0),
+                    "state": state,
+                    "running": int(raw.get("running") or 0),
+                    "armed": int(raw.get("armed") or 0),
+                    "input": int(raw.get("input") or 0),
+                    "duty": int(raw.get("duty_cycle") or 0),
+                }
+                w.writerow(row)
+                n += 1
+                if n % 20 == 0:
+                    fh.flush()
+                # Print on anything worth seeing: a restart, a blind burst, a
+                # collapsing interval while barely turning, or a stall trip.
+                interesting = (
+                    prev.get("zc", 0) - row["zc"] > 2
+                    or row["blind"] > 0
+                    or row["bemfTO"] != prev.get("bemfTO", row["bemfTO"])
+                    or (row["state"] == 5 and 0 < ci < 200)
+                    or row["state"] != prev.get("state", row["state"])
+                )
+                if interesting or n % 25 == 0:
+                    print("%8.3f %6d %8.0f %7d %6d %7d %6d %5d %6d" %
+                          (row["t"], ci, rpm, row["zc"], row["blind"],
+                           row["reject"], row["bemfTO"], state, row["duty"]))
+                prev = row
+                delay = period - (time.monotonic() - loop_start)
+                if delay > 0:
+                    time.sleep(delay)
+        except KeyboardInterrupt:
+            print(f"\nstopped; {n} samples -> {args.out}")
+        finally:
+            try:
+                dbg.close()
+            except Exception:
+                pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hwci/scripts/watch_zc_phase.py
+++ b/hwci/scripts/watch_zc_phase.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Passive PWM-phase histogram of ACCEPTED zero-crossings.
+
+PASSIVE. Opens OpenOCD, resolves hwci_perf from the ELF and polls it. It never
+arms the stand, never commands throttle, never resets the target. Drive the
+motor BY HAND while this watches.
+
+WHAT THIS DECIDES
+-----------------
+The twelve ZC traces captured on the bench all enter the wrong-phase grind the
+same way: an accepted crossing at ratio ~1.5, immediately followed by an
+accepted crossing at ratio 0.22-0.48, the pair summing to ~2.0. Timing alone
+cannot say which of those two edges is the impostor:
+
+  (a) the 1.5 is spurious and the 0.45 is the real crossing arriving on
+      schedule after one was missed  -> tightening the minimum-interval gate
+      to ci/2 would reject the REAL edge and entrench the lock;
+  (b) the 0.45 is spurious           -> a ci/2 gate kills the grind outright.
+
+TIM1 on the F051 is edge-aligned (LL_TIM_COUNTERMODE_UP) in PWM1 mode, so
+TIM1->CNT maps monotonically onto the PWM period and the phase histogram is a
+direct test. Switching transients are locked to the PWM edges:
+
+    turn-ON  -> bin 0
+    turn-OFF -> bin ~ HWCI_ZC_PHASE_BINS * duty_cycle / 2000
+
+A real back-EMF crossing is asynchronous to the PWM carrier, so its phase must
+SMEAR. It will not be flat, though, and that is the interpretation trap: the
+floating phase is only observable over part of the PWM period, so even a
+perfectly healthy loop shows a broad hump spanning the sensing window (PR #23
+measured 3.3x edge-window enrichment at t30). What distinguishes the two cases
+is the SHAPE, not the mere presence of structure:
+
+    healthy  -> broad hump, several bins wide, moving with duty
+    noise    -> narrow spike pinned to bin 0 or to the turn-off bin
+
+Hence: always take a baseline on a smooth ramp at comparable duty BEFORE
+provoking the grind, and compare R1 and the bar shape between the two. A single
+grind capture in isolation proves nothing.
+
+The F051 has no hardware comparator blanking (that is a G0/G4 peripheral
+feature), which is exactly why the turn-on transient can be seen here at all.
+
+READING THE OUTPUT
+------------------
+  R1      circular resultant length of the delta distribution, 0..1.
+          ~0 = uniform (asynchronous, healthy), ->1 = pinned to one phase.
+          Bins are circular over the PWM period, so R1 is invariant to WHICH
+          bin the peak lands in - it measures concentration, not location.
+  peak    enrichment of the fullest bin over uniform (1.0 = uniform).
+  bin     index of the fullest bin, with (on)/(off) annotated when it lands on
+          a predicted switching bin.
+  bar     the 32 bins of the window delta, scaled to the window max.
+  arr*    marks a window in which tim1_arr moved: variable_pwm rescaled the
+          bins mid-window, so that line's distribution is smeared. Ignore it.
+
+Counts are only binned while zero_crosses >= 100 (same "stable running" gate
+as the rest of the ZC instrumentation), so a desync that zeroes the crossing
+count blanks the histogram for 100 crossings - watch the zc column.
+
+Usage:
+
+    hwci/.venv/bin/python hwci/scripts/watch_zc_phase.py --config hwci/rig.yaml
+
+Take a baseline on a smooth ramp first, then provoke the grind with a step and
+compare R1 across the two.
+"""
+from __future__ import annotations
+
+import argparse
+import cmath
+import csv
+import math
+import os
+import struct
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from hwci import elf as elfmod                        # noqa: E402
+from hwci.config import load_rig                      # noqa: E402
+from hwci.debugger.openocd import OpenOcdDebugger      # noqa: E402
+from hwci.perf_reader import PerfReader                # noqa: E402
+
+BINS = 32
+# duty_cycle is 0..2000 in firmware terms; CCR = duty_cycle * tim1_arr / 2000,
+# so the turn-off edge sits at this fraction of the period regardless of ARR.
+DUTY_FULL_SCALE = 2000.0
+BLOCKS = " ▁▂▃▄▅▆▇█"
+COLS = ("t", "n", "R1", "peak", "peak_bin", "off_bin", "ci", "rpm", "zc",
+        "duty", "state", "tim1_arr", "hist")
+
+
+def resultant(hist) -> float:
+    """Circular resultant length of a binned phase distribution, 0..1."""
+    total = sum(hist)
+    if total <= 0:
+        return 0.0
+    acc = sum(h * cmath.exp(2j * math.pi * k / BINS) for k, h in enumerate(hist))
+    return abs(acc) / total
+
+
+def bar(hist) -> str:
+    top = max(hist) if hist else 0
+    if top <= 0:
+        return " " * BINS
+    return "".join(BLOCKS[min(len(BLOCKS) - 1, (h * (len(BLOCKS) - 1) + top - 1) // top)]
+                   for h in hist)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--window", type=float, default=0.5,
+                    help="seconds of histogram delta to accumulate per line")
+    ap.add_argument("--hz", type=float, default=50.0)
+    ap.add_argument("--min-count", type=int, default=20,
+                    help="skip windows with fewer than this many binned "
+                         "crossings; R1 is meaningless on a handful of samples")
+    ap.add_argument("--out", default="zc_phase.csv")
+    args = ap.parse_args()
+
+    rig = load_rig(args.config)
+    elf = rig.resolved_elf()
+    if elf is None:
+        print("error: no ELF for target; build first", file=sys.stderr)
+        return 2
+
+    dbg = OpenOcdDebugger(rig.openocd_configs, openocd_bin=rig.openocd_bin,
+                          search_dirs=rig.openocd_search_dirs).open()
+    try:
+        reader = PerfReader(dbg, str(elf))
+        # tim1_arr is not in hwci_perf; read the global directly so a window
+        # spanning a variable_pwm rescale can be flagged rather than believed.
+        try:
+            arr_sym = elfmod.find_symbol(str(elf), "tim1_arr")
+            arr_addr = arr_sym.address
+        except Exception:
+            arr_addr = None
+
+        def read_arr() -> int:
+            if arr_addr is None:
+                return 0
+            try:
+                return struct.unpack_from("<H", dbg.read_memory(arr_addr, 2), 0)[0]
+            except Exception:
+                return 0
+
+        print(f"watching hwci_perf @ 0x{reader.address:08x} via {elf.name}")
+        print("PASSIVE - no throttle is commanded. Drive by hand. Ctrl-C to stop.")
+        print("Baseline on a smooth ramp first, then step into the grind.\n")
+        print(f"{'t':>7} {'n':>5} {'R1':>5} {'peak':>5} {'bin':>9} "
+              f"{'ci':>6} {'rpm':>6} {'duty':>5} {'st':>2}  bars")
+
+        period = 1.0 / args.hz
+        t0 = time.monotonic()
+        prev_hist = None
+        acc = [0] * BINS
+        win_start = t0
+        arr_seen: set[int] = set()
+        duty_seen: list[int] = []
+
+        with open(args.out, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=COLS)
+            w.writeheader()
+            try:
+                while True:
+                    loop_start = time.monotonic()
+                    try:
+                        pf = reader.read()
+                    except Exception as e:
+                        if prev_hist is None:
+                            print(f"perf read failed: {e!r}", file=sys.stderr)
+                        time.sleep(period)
+                        continue
+                    raw = getattr(pf, "raw", None) or {}
+                    hist = list(raw.get("zc_phase_hist") or [])
+                    if len(hist) != BINS:
+                        print("error: firmware has no v4+ zc_phase_hist; "
+                              "rebuild with HWCI_PERF=1", file=sys.stderr)
+                        return 2
+                    if prev_hist is not None:
+                        for i in range(BINS):
+                            acc[i] += (hist[i] - prev_hist[i]) & 0xFFFF
+                    prev_hist = hist
+                    duty_seen.append(int(raw.get("duty_cycle") or 0))
+                    arr_seen.add(read_arr())
+
+                    now = time.monotonic()
+                    if now - win_start >= args.window:
+                        n = sum(acc)
+                        state = int(raw.get("esc_state") or 0)
+                        ci = int(raw.get("commutation_interval") or 0)
+                        zc = int(raw.get("zero_cross_count") or 0)
+                        duty = round(sum(duty_seen) / len(duty_seen)) if duty_seen else 0
+                        rpm = 0.0
+                        if state == 5 and rig.pole_pairs:
+                            try:
+                                rpm = float(pf.e_rpm) / rig.pole_pairs
+                            except Exception:
+                                rpm = 0.0
+                        arr = max(arr_seen) if arr_seen else 0
+                        moved = len(arr_seen) > 1
+                        off_bin = int(BINS * duty / DUTY_FULL_SCALE) % BINS
+                        if n >= args.min_count:
+                            r1 = resultant(acc)
+                            pk = max(range(BINS), key=lambda i: acc[i])
+                            enrich = acc[pk] / (n / BINS)
+                            tag = ""
+                            if pk == 0:
+                                tag = "(on)"
+                            elif abs(pk - off_bin) <= 1:
+                                tag = "(off)"
+                            print(f"{now - t0:>7.2f} {n:>5d} {r1:>5.2f} "
+                                  f"{enrich:>5.1f} {pk:>4d}{tag:<5} "
+                                  f"{ci:>6d} {rpm:>6.0f} {duty:>5d} {state:>2d}  "
+                                  f"|{bar(acc)}|{'  arr*' if moved else ''}")
+                            w.writerow({
+                                "t": round(now - t0, 3), "n": n,
+                                "R1": round(r1, 4), "peak": round(enrich, 2),
+                                "peak_bin": pk, "off_bin": off_bin, "ci": ci,
+                                "rpm": round(rpm, 1), "zc": zc, "duty": duty,
+                                "state": state,
+                                "tim1_arr": ("*" if moved else "") + str(arr),
+                                "hist": ";".join(str(v) for v in acc),
+                            })
+                            fh.flush()
+                        acc = [0] * BINS
+                        win_start = now
+                        arr_seen = set()
+                        duty_seen = []
+
+                    delay = period - (time.monotonic() - loop_start)
+                    if delay > 0:
+                        time.sleep(delay)
+            except KeyboardInterrupt:
+                print(f"\nstopped -> {args.out}")
+    finally:
+        try:
+            dbg.close()
+        except Exception:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Original thrash / upstream-like recovery intent only — **without** the later aggressive untrusted-duty energy cut that regressed free-run on the 1980KV no-prop bench.

### Included (through `f2fe855`)
- **Degrade instead of restart** on sustained miss/demag (`8365681`): drop ARK-only restart rails; dead-reckoning budget; soft authority fade vs stall wall-clock (not the K=4 commutation energy rewrite).
- **Layered recovery** (`a9f2849`): blind for transient misses, poll re-entry for slow average, acq duty while `zero_crosses < 100`, half-interval early-edge reject.
- **F051 position-scored ZC confirm** (`7e99a17`) and related ZC work already on that stack.
- SITL test updates so hold/blind expectations match blind-vs-jump-desync (`f2fe855`).

### Explicitly **not** included (from PR #85 tip after this)
- `2d6f036` *make untrusted commutation cost energy, not just time* (K=4 continuous fade flooring duty on short free-run blind storms).
- Follow-on SITL-only fixes for that cut (`95807b7`, `43aa674`).

### Why this split
PR #85’s goal was: **stop thrash/restart loops** and **fail more like upstream AM32** (keep flying degraded). Free-run A/B on this article showed **ark-release completes 5→75%**; tip with `2d6f036` **aborts ~50% thr** with duty collapse. That energy-cut commit was also marked not bench-run. This PR restores the thrash-oriented stack for review/merge without that free-run regression.

## Test plan
- [ ] SITL suite (especially blind / hold / accel predictor tests on this tip).
- [ ] Free-run `noprop_validate_5_75` (step ≥5%) vs ark-release — expect complete, not mid-run eRPM abort.
- [ ] Prop hard-step / thrash A/B vs ark-release (original success metric).
- [ ] Smooth ramp prop still lights off cleanly.

## Relation to #85
#85 tip continues as the experimental full stack (energy cut + later dig-in). This PR is the **shippable original intent** subset for thrash/upstream-like recovery.