### PR TITLE
chore: ignore repo-root sitl-venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tools/
 windows-tools.zip
 .settings/
 Mcu/SITL/venv/
+sitl-venv/
 .pytest_cache/
 **/__pycache__/
 **/sitl_ci.log


### PR DESCRIPTION
## Summary

Add `sitl-venv/` to `.gitignore` so a local host-side SITL/pytest virtualenv at the repo root does not show up as untracked files.

`Mcu/SITL/venv/` was already ignored; this matches the same pattern for a venv created at the workspace root.

## Test plan

- [x] `git status` clean with `sitl-venv/` present on disk
- [ ] No product/firmware impact