### PR TITLE
fix: embed full ship version in .file_name region

### DIFF
--- a/Inc/version.h
+++ b/Inc/version.h
@@ -1,11 +1,13 @@
 /*
  * Firmware version for releases.
  *
- * MAJOR.MINOR track the upstream AM32 base this tree is based on (EEPROM and
- * protocol still use only these two numeric fields).
- * VERSION_PATCH is the ARK ship-increment (artifact names only; not in EEPROM).
- * VERSION_TAG is appended to built artifact names (e.g. 3.0.2-ark) so binaries
- * from the ARK Electronics fork are not confused with upstream AM32 builds.
+ * MAJOR.MINOR track the upstream AM32 base this tree is based on (EEPROM still
+ * stores only these two numeric fields for protocol compatibility).
+ * VERSION_PATCH is the ARK ship-increment. It is included in artifact names
+ * (e.g. 3.0.2-ark) and embedded as a second C-string in the 32-byte
+ * `.file_name` flash region (`FILE_NAME\0MAJOR.MINOR.PATCH[-TAG]\0`) so the
+ * ARK32 configurator can show the full ship version after connect.
+ * VERSION_TAG marks ARK-fork builds vs upstream AM32.
  * Update this file for new releases.
  */
 #define VERSION_MAJOR 3

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -12,8 +12,23 @@
 #include "targets.h"
 #include "eeprom.h"
 #include "signal.h"
+#include "version.h"
 
 #include <assert.h>
+
+/* Ship version embedded after FILE_NAME in the .file_name region so the
+ * configurator can show major.minor.patch[-tag]. EEPROM still only has the
+ * two upstream major/minor bytes. */
+#define AM32_VER_STR_HELPER(x) #x
+#define AM32_VER_STR(x) AM32_VER_STR_HELPER(x)
+#if defined(VERSION_PATCH) && defined(VERSION_TAG)
+#	define FIRMWARE_VERSION_EMBED                                                                                                     \
+		AM32_VER_STR(VERSION_MAJOR) "." AM32_VER_STR(VERSION_MINOR) "." AM32_VER_STR(VERSION_PATCH) "-" VERSION_TAG
+#elif defined(VERSION_PATCH)
+#	define FIRMWARE_VERSION_EMBED AM32_VER_STR(VERSION_MAJOR) "." AM32_VER_STR(VERSION_MINOR) "." AM32_VER_STR(VERSION_PATCH)
+#else
+#	define FIRMWARE_VERSION_EMBED AM32_VER_STR(VERSION_MAJOR) "." AM32_VER_STR(VERSION_MINOR)
+#endif
 
 //===========================================================================
 //=============================  Defaults =============================
@@ -103,8 +118,14 @@ uint16_t low_cell_volt_cutoff = 330; // 3.3volts per cell
 
 /* used: nothing in C reads this - the configurator reads the .file_name region
  * out of the image - so LTO drops it as dead without the attribute, leaving the
- * section empty and the firmware unidentifiable. */
-const char filename[30] __attribute__((used)) AM32_FLASH_SECTION(".file_name") = FILE_NAME;
+ * section empty and the firmware unidentifiable.
+ *
+ * Layout (32-byte region below EEPROM): `FILE_NAME\0VERSION\0…`
+ * VERSION is the full ship string (e.g. 3.0.2-ark). Older tools only decode
+ * up to the first NUL and still see the board identity for asset matching.
+ */
+const char filename[32] __attribute__((used)) AM32_FLASH_SECTION(".file_name") = FILE_NAME "\0" FIRMWARE_VERSION_EMBED;
+_Static_assert(sizeof(FILE_NAME "\0" FIRMWARE_VERSION_EMBED) <= 32, "FILE_NAME + version exceed .file_name region");
 _Static_assert(sizeof(FIRMWARE_NAME) <= 13, "Firmware name too long"); // max 12 character firmware name plus NULL
 
 // move these to targets folder or peripherals for each mcu


### PR DESCRIPTION
## Summary

ARK ship releases use `VERSION_PATCH` in artifact names (`3.0.2-ark`), but EEPROM only stores major/minor (`3.0`) for AM32 protocol compatibility. The configurator therefore always showed **3.0** after flash.

## Change

Embed the full ship string as a **second C-string** in the 32-byte `.file_name` region:

```
ARK_4IN1_F051\03.0.2-ark\0…
```

- Asset matching still uses only `FILE_NAME` (decode up to first NUL).
- Configurator (companion PR) reads the second string for display.
- No EEPROM layout change.

## Companion

[ark32-configurator: show patch version + match 3.0.x assets](https://github.com/ARK-Electronics/ark32-configurator/pulls)

## Test plan

- [ ] Build `ARK_4IN1_F051`; `strings` / hex dump of `.file_name` shows board name + `3.0.2-ark`
- [ ] Size / codegen checks still pass (`.file_name` non-empty)
- [ ] With updated configurator, connect after flash shows `3.0.2-ark`