### PR TITLE
chore: name release binaries ARK32_<target>_<version>

### DIFF
--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -59,24 +59,24 @@ jobs:
           fi
 
           # Configurator resolves:
-          #   AM32_${escInfo.meta.am32.fileName}_${tagWithoutV_and_rc}.hex
-          # so every artifact must stay AM32_<target>_<version>.hex.
+          #   ARK32_${escInfo.meta.am32.fileName}_${tagWithoutV_and_rc}.hex
+          # so every artifact must stay ARK32_<target>_<version>.hex.
           bad=0
           for f in "${hexes[@]}"; do
             base=$(basename "$f")
             case "$base" in
-              AM32_*_*.hex)
-                # Reject empty target/version segments (AM32__.hex, AM32_x_.hex).
+              ARK32_*_*.hex)
+                # Reject empty target/version segments (ARK32__.hex, ARK32_x_.hex).
                 # MAJOR.MINOR[.PATCH][-tag], e.g. 3.0-ark, 3.0.1-ark
-                if [[ ! "$base" =~ ^AM32_[A-Za-z0-9][A-Za-z0-9_]*_[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9._-]+)?\.hex$ ]]; then
-                  echo "error: hex name does not match AM32_<target>_<MAJOR.MINOR[.PATCH][-tag]>.hex: $base" >&2
+                if [[ ! "$base" =~ ^ARK32_[A-Za-z0-9][A-Za-z0-9_]*_[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9._-]+)?\.hex$ ]]; then
+                  echo "error: hex name does not match ARK32_<target>_<MAJOR.MINOR[.PATCH][-tag]>.hex: $base" >&2
                   bad=1
                 else
                   echo "ok: $base"
                 fi
                 ;;
               *)
-                echo "error: hex name does not match AM32_<target>_<version>.hex: $base" >&2
+                echo "error: hex name does not match ARK32_<target>_<version>.hex: $base" >&2
                 bad=1
                 ;;
             esac
@@ -92,9 +92,9 @@ jobs:
             for f in "${hexes[@]}"; do
               base=$(basename "$f")
               case "$base" in
-                AM32_*_"${expect_ver}".hex) ;;
+                ARK32_*_"${expect_ver}".hex) ;;
                 *)
-                  echo "error: $base is not AM32_<target>_${expect_ver}.hex (tag ${GITHUB_REF_NAME})" >&2
+                  echo "error: $base is not ARK32_<target>_${expect_ver}.hex (tag ${GITHUB_REF_NAME})" >&2
                   bad=1
                   ;;
               esac
@@ -109,7 +109,7 @@ jobs:
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
-          name: AM32-binaries
+          name: ARK32-binaries
           path: |
             obj/*.hex
           retention-days: 60

--- a/.github/workflows/SITL-calibration.yml
+++ b/.github/workflows/SITL-calibration.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           mkdir calibration_run && cd calibration_run
           python3 ../Mcu/SITL/run_calibration_tests.py \
-            --sitl ../obj/AM32_AM32_SITL_CAN_*.elf \
+            --sitl ../obj/ARK32_AM32_SITL_CAN_*.elf \
             --dataset ${{ matrix.dataset }} \
             --artifacts ../calibration_artifacts
 

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           mkdir sitl_test_run && cd sitl_test_run
           ../sitl-venv/bin/python ../Mcu/SITL/run_ci_tests.py \
-            --sitl ../obj/AM32_AM32_SITL_CAN_*.elf \
+            --sitl ../obj/ARK32_AM32_SITL_CAN_*.elf \
             --junitxml=sitl-results.xml
 
       - name: Upload SITL log on failure
@@ -69,7 +69,7 @@ jobs:
           mkdir gui_test_run && cd gui_test_run
           python3 ../Mcu/SITL/gui_ci_test.py \
             --gui-python ../Mcu/SITL/venv/bin/python3 \
-            --sitl ../obj/AM32_AM32_SITL_CAN_*.elf
+            --sitl ../obj/ARK32_AM32_SITL_CAN_*.elf
 
       - name: Upload SITL log on failure
         if: failure()
@@ -105,7 +105,7 @@ jobs:
           # range (49152-65535), which Hyper-V/WinNAT reserves in blocks on
           # the hosted runners - bind() there fails with EACCES ("Permission
           # denied"). Anything below 49152 is outside the reservable range.
-          ./obj/AM32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1 \
+          ./obj/ARK32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1 \
             --input-port 17733 --state-port 17734 >boot.log 2>&1 &
           sleep 3
           kill %1 || true
@@ -123,7 +123,7 @@ jobs:
         run: |
           cd $(cygpath -u "$GITHUB_WORKSPACE")
           mkdir -p sitl-windows
-          cp obj/AM32_AM32_SITL_CAN_*.elf sitl-windows/AM32_SITL_CAN.exe
+          cp obj/ARK32_AM32_SITL_CAN_*.elf sitl-windows/AM32_SITL_CAN.exe
           cp /bin/cygwin1.dll sitl-windows/
 
       - name: Upload Windows SITL binary

--- a/.github/workflows/capture-gui.yml
+++ b/.github/workflows/capture-gui.yml
@@ -37,7 +37,7 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           python3 scripts/capture_gui_test.py \
-            --sitl obj/AM32_AM32_SITL_CAN_*.elf
+            --sitl obj/ARK32_AM32_SITL_CAN_*.elf
 
   build:
     strategy:

--- a/.github/workflows/sitl-gui.yml
+++ b/.github/workflows/sitl-gui.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           make AM32_SITL_CAN SITL_CROSS=win
           mkdir -p sitl-windows
-          cp obj/AM32_AM32_SITL_CAN_*.elf sitl-windows/AM32_SITL_CAN.exe
+          cp obj/ARK32_AM32_SITL_CAN_*.elf sitl-windows/AM32_SITL_CAN.exe
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -66,8 +66,8 @@ jobs:
         with:
           name: ark-f051-hwci-perf
           path: |
-            obj/AM32_ARK_4IN1_F051_*.elf
-            obj/AM32_ARK_4IN1_F051_*.bin
+            obj/ARK32_ARK_4IN1_F051_*.elf
+            obj/ARK32_ARK_4IN1_F051_*.bin
           if-no-files-found: ignore
           retention-days: 14
 
@@ -110,8 +110,8 @@ jobs:
         with:
           name: ark-4in1-factory-image
           path: |
-            obj/AM32_ARK_4IN1_F051_*.factory.bin
-            obj/AM32_ARK_4IN1_F051_*.factory.hex
-            obj/AM32_ARK_4IN1_F051_*.eeprom.bin
+            obj/ARK32_ARK_4IN1_F051_*.factory.bin
+            obj/ARK32_ARK_4IN1_F051_*.factory.hex
+            obj/ARK32_ARK_4IN1_F051_*.eeprom.bin
           if-no-files-found: error
           retention-days: 30

--- a/Bootloaders/README.md
+++ b/Bootloaders/README.md
@@ -71,7 +71,7 @@ The blob lands at the `.bl_image` symbols, so it can be pulled straight back out
 
 ```sh
 arm-none-eabi-objcopy -O binary --only-section=.bl_image \
-  obj/AM32_ARK_4IN1_F051_*.elf /tmp/embedded.bin
+  obj/ARK32_ARK_4IN1_F051_*.elf /tmp/embedded.bin
 cmp -n "$(wc -c < Bootloaders/AM32_F051_BOOTLOADER_ARK4IN1_V18.bin)" \
   /tmp/embedded.bin Bootloaders/AM32_F051_BOOTLOADER_ARK4IN1_V18.bin
 ```

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ OBJCOPY = $(ARM_SDK_PREFIX)objcopy
 ECHO = echo
 
 # common variables
-IDENTIFIER := AM32
+# Release / build artifact prefix: ARK32_<FILE_NAME>_<version>.{hex,bin,elf}
+# (not upstream AM32_). Bootloader blobs under Bootloaders/ keep their AM32_* names.
+IDENTIFIER := ARK32
 
 # Folders
 HAL_FOLDER := Mcu

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -11,7 +11,7 @@ commutation, DroneCAN protocol, parameters) without ESC hardware.
 make AM32_SITL_CAN
 ```
 
-produces `obj/AM32_AM32_SITL_CAN_<version>.elf`, a normal Linux
+produces `obj/ARK32_AM32_SITL_CAN_<version>.elf`, a normal Linux
 executable.
 
 ### Sanitizers and valgrind
@@ -42,7 +42,7 @@ the sim thread; the wrapper sets it.
 ## Running
 
 ```
-obj/AM32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
+obj/ARK32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
 ```
 
 Options:
@@ -187,7 +187,7 @@ python3 Mcu/SITL/make_gui_env.py
   bad-CRC injection), e.g.:
 
 ```
-obj/AM32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1
+obj/ARK32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1
 python3 Mcu/SITL/dshot_test.py --type dshot600 --bidir --edt --throttle 800
 ```
 
@@ -260,7 +260,7 @@ interrupts are delivered by parking the firmware thread with SIGUSR1,
 which gdb must pass through silently. `Mcu/SITL/gdbinit` sets that up:
 
 ```
-gdb -x Mcu/SITL/gdbinit --args obj/AM32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1
+gdb -x Mcu/SITL/gdbinit --args obj/ARK32_AM32_SITL_CAN_*.elf --can-uri none --input-type 1
 (gdb) break tenKhzRoutine
 (gdb) run
 ```

--- a/Mcu/SITL/build_sitl_gui.py
+++ b/Mcu/SITL/build_sitl_gui.py
@@ -49,7 +49,7 @@ def _find_sitl(given):
     if sys.platform.startswith('win') and os.path.isfile(win):
         return win
     hits = sorted(glob.glob(os.path.join(ROOT, 'obj',
-                                         'AM32_AM32_SITL_CAN_*.elf')))
+                                         'ARK32_AM32_SITL_CAN_*.elf')))
     return hits[0] if hits else None
 
 

--- a/Mcu/SITL/gui_ci_test.py
+++ b/Mcu/SITL/gui_ci_test.py
@@ -146,7 +146,7 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('--gui-python', required=True)
     # don't hardcode the firmware version in the default binary path
-    pat = os.path.join(HERE, '..', '..', 'obj', 'AM32_AM32_SITL_CAN_*.elf')
+    pat = os.path.join(HERE, '..', '..', 'obj', 'ARK32_AM32_SITL_CAN_*.elf')
     hits = sorted(glob.glob(pat))
     ap.add_argument('--sitl', default=os.path.normpath(hits[0]) if hits else None)
     args = ap.parse_args()

--- a/Mcu/SITL/run_calibration_tests.py
+++ b/Mcu/SITL/run_calibration_tests.py
@@ -23,7 +23,7 @@ Designed for CI:
   for human review
 
 usage:
-  run_calibration_tests.py --sitl ../obj/AM32_AM32_SITL_CAN_*.elf
+  run_calibration_tests.py --sitl ../obj/ARK32_AM32_SITL_CAN_*.elf
   run_calibration_tests.py --dataset ark_900kv_noprop --skip-chirp
 '''
 
@@ -409,7 +409,7 @@ def main():
     sitl_bin = os.path.abspath(ARGS.sitl) if ARGS.sitl else None
     if not sitl_bin:
         import glob
-        cands = glob.glob(os.path.join(REPO, 'obj/AM32_AM32_SITL_CAN_*.elf'))
+        cands = glob.glob(os.path.join(REPO, 'obj/ARK32_AM32_SITL_CAN_*.elf'))
         if not cands:
             raise SystemExit('no SITL binary, pass --sitl')
         sitl_bin = cands[0]

--- a/Mcu/SITL/run_coverage.sh
+++ b/Mcu/SITL/run_coverage.sh
@@ -14,14 +14,14 @@ BUILD=1
 [ "$1" = "--no-build" ] && BUILD=0
 
 if [ "$BUILD" = 1 ]; then
-    rm -f obj/AM32_AM32_SITL_CAN_2.20.elf obj/AM32_AM32_SITL_CAN_2.20.d \
+    rm -f obj/ARK32_AM32_SITL_CAN_2.20.elf obj/ARK32_AM32_SITL_CAN_2.20.d \
           obj/*.gcda obj/*.gcno
     make AM32_SITL_CAN SITL_COVERAGE=1
 fi
 rm -f obj/*.gcda
 
 mkdir -p coverage
-python3 Mcu/SITL/run_ci_tests.py --sitl obj/AM32_AM32_SITL_CAN_*.elf || true
+python3 Mcu/SITL/run_ci_tests.py --sitl obj/ARK32_AM32_SITL_CAN_*.elf || true
 
 FILTERS=(--filter 'Src/' --filter 'Mcu/SITL/sim/' --filter 'Mcu/SITL/Src/'
          --exclude 'Src/DroneCAN/dsdl_generated/'

--- a/Mcu/SITL/sim_runner.py
+++ b/Mcu/SITL/sim_runner.py
@@ -38,7 +38,7 @@ def bundled_sitl():
         if os.path.isfile(cand):
             return cand
     import glob
-    for pat in ('obj/AM32_AM32_SITL_CAN_*.elf', 'obj/AM32_SITL_CAN*'):
+    for pat in ('obj/ARK32_AM32_SITL_CAN_*.elf', 'obj/ARK32_AM32_SITL_CAN*'):
         hits = sorted(glob.glob(os.path.join(base, pat)))
         if hits:
             return hits[0]

--- a/Mcu/SITL/sitl_can_test.py
+++ b/Mcu/SITL/sitl_can_test.py
@@ -5,7 +5,7 @@ test AM32 SITL over DroneCAN multicast UDP
 runs a throttle ramp via esc.RawCommand and reports esc.Status
 telemetry. Needs the SITL binary already running on the same mcast bus,
 eg:
-  obj/AM32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
+  obj/ARK32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
   python3 Mcu/SITL/sitl_can_test.py --throttle 0.5 --duration 20
 '''
 

--- a/Mcu/SITL/sitl_harness.py
+++ b/Mcu/SITL/sitl_harness.py
@@ -26,7 +26,7 @@ from sitl_gui_backend import SimStream  # noqa: E402
 def find_sitl_binary(explicit=None):
     if explicit:
         return os.path.abspath(explicit)
-    pat = os.path.join(REPO_ROOT, 'obj', 'AM32_AM32_SITL_CAN_*.elf')
+    pat = os.path.join(REPO_ROOT, 'obj', 'ARK32_AM32_SITL_CAN_*.elf')
     hits = sorted(glob.glob(pat))
     if not hits:
         return None

--- a/Mcu/SITL/tests/conftest.py
+++ b/Mcu/SITL/tests/conftest.py
@@ -26,7 +26,7 @@ def pytest_addoption(parser):
         '--sitl',
         action='store',
         default=None,
-        help='path to AM32 SITL binary (default: newest obj/AM32_AM32_SITL_CAN_*.elf)',
+        help='path to AM32 SITL binary (default: newest obj/ARK32_AM32_SITL_CAN_*.elf)',
     )
 
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Native Linux build of the firmware against a simulated motor / bridge / battery,
 ```bash
 make arm_sdk_install   # once, for cross toolchain (SITL itself is host gcc)
 make AM32_SITL_CAN
-obj/AM32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
+obj/ARK32_AM32_SITL_CAN_*.elf --node-id 10 --verbose
 ```
 
 ### HITL / Hardware-CI
@@ -85,7 +85,7 @@ make -j$(nproc) ARK_4IN1_F051
 
 # Production full-flash image (bootloader + app + factory EEPROM defaults)
 make factory-image
-# -> obj/AM32_ARK_4IN1_F051_<ver>.factory.bin  (flash at 0x08000000)
+# -> obj/ARK32_ARK_4IN1_F051_<ver>.factory.bin  (flash at 0x08000000)
 make factory-image-check   # same + layout/defaults gate (CI)
 ```
 
@@ -107,7 +107,7 @@ That links the release app, then runs [`scripts/build_factory_image.py`](scripts
 | Application @ `0x08001000` | `make ARK_4IN1_F051` |
 | EEPROM @ `0x08007C00` | [`factory/ARK_4IN1_F051_eeprom_defaults.json`](factory/ARK_4IN1_F051_eeprom_defaults.json) |
 
-Ship/program `obj/AM32_ARK_4IN1_F051_*.factory.bin` (or `.factory.hex`). Defaults (PWM-by-RPM, 1020 kV, 2 %/ms ramp, 15° fixed advance, PWM min/max 1020/1980 µs) are documented in [`factory/README.md`](factory/README.md).
+Ship/program `obj/ARK32_ARK_4IN1_F051_*.factory.bin` (or `.factory.hex`). Defaults (PWM-by-RPM, 1020 kV, 2 %/ms ramp, 15° fixed advance, PWM min/max 1020/1980 µs) are documented in [`factory/README.md`](factory/README.md).
 
 Optional static analysis / size / format helpers:
 

--- a/factory/README.md
+++ b/factory/README.md
@@ -22,10 +22,10 @@ Artifacts under `obj/`:
 
 | File | Contents |
 |------|----------|
-| `AM32_ARK_4IN1_F051_<ver>.bin` / `.hex` | Application only (existing make target) |
-| `AM32_ARK_4IN1_F051_<ver>.factory.bin` | **Full 32 KiB flash** — BL + app + EEPROM |
-| `AM32_ARK_4IN1_F051_<ver>.factory.hex` | Same image as Intel HEX |
-| `AM32_ARK_4IN1_F051_<ver>.eeprom.bin` | 1 KiB EEPROM page alone (debug / SWD poke) |
+| `ARK32_ARK_4IN1_F051_<ver>.bin` / `.hex` | Application only (existing make target) |
+| `ARK32_ARK_4IN1_F051_<ver>.factory.bin` | **Full 32 KiB flash** — BL + app + EEPROM |
+| `ARK32_ARK_4IN1_F051_<ver>.factory.hex` | Same image as Intel HEX |
+| `ARK32_ARK_4IN1_F051_<ver>.eeprom.bin` | 1 KiB EEPROM page alone (debug / SWD poke) |
 
 Flash the `.factory.bin` (or `.factory.hex`) at **`0x08000000`** with ST-Link / OpenOCD / production fixture. No configurator step is required for stock defaults.
 
@@ -34,8 +34,8 @@ Example OpenOCD (ST-Link + STM32F0):
 ```bash
 openocd -f interface/stlink.cfg -f target/stm32f0x.cfg \
   -c "init; halt; flash erase_sector 0 0 last; \
-      flash write_bank 0 obj/AM32_ARK_4IN1_F051_3.0.2-ark.factory.bin 0; \
-      flash verify_bank 0 obj/AM32_ARK_4IN1_F051_3.0.2-ark.factory.bin 0; \
+      flash write_bank 0 obj/ARK32_ARK_4IN1_F051_3.0.2-ark.factory.bin 0; \
+      flash verify_bank 0 obj/ARK32_ARK_4IN1_F051_3.0.2-ark.factory.bin 0; \
       reset run; exit"
 ```
 

--- a/hwci/docs/BENCH_SETUPS.md
+++ b/hwci/docs/BENCH_SETUPS.md
@@ -30,7 +30,7 @@ only one device may drive the ESC signal wire.
 ```bash
 cd hwci
 # flash + free-run smoke (stand drives throttle)
-.venv/bin/python -m hwci flash --config rig.yaml --bin ../obj/AM32_ARK_4IN1_F051_*.bin
+.venv/bin/python -m hwci flash --config rig.yaml --bin ../obj/ARK32_ARK_4IN1_F051_*.bin
 .venv/bin/python -m hwci run --config rig.yaml --profile noprop_smoke_100pct_3a --out runs/stand-smoke-1
 ```
 
@@ -53,7 +53,7 @@ cd hwci
 cd hwci
 # flash instrumented FW (throttle not driven by harness)
 .venv/bin/python -m hwci flash --config config/rig.px4_bdshot.yaml \
-  --bin ../obj/AM32_ARK_4IN1_F051_*.bin
+  --bin ../obj/ARK32_ARK_4IN1_F051_*.bin
 
 # drive motor via PX4 ACTUATOR_TEST (soft re-fire + ramp-down)
 ./scripts/px4_motor_stream.py --port /dev/ttyACM2 \

--- a/hwci/docs/setup_px4_bdshot.md
+++ b/hwci/docs/setup_px4_bdshot.md
@@ -169,7 +169,7 @@ Practical interim approach:
 
    ```bash
    cd hwci
-   .venv/bin/python -m hwci flash --config rig.yaml --bin ../obj/AM32_ARK_4IN1_F051_*.bin
+   .venv/bin/python -m hwci flash --config rig.yaml --bin ../obj/ARK32_ARK_4IN1_F051_*.bin
    # Use OpenOCD live mem, or a short custom poller reading hwci_perf
    ```
 

--- a/hwci/hwci/build.py
+++ b/hwci/hwci/build.py
@@ -14,13 +14,13 @@ class BuildArtifacts:
 
 
 def find_artifact(obj_dir: Path, target: str, ext: str) -> Path | None:
-    """Newest ``obj/AM32_<target>_*.<ext>`` build artifact, or None.
+    """Newest ``obj/ARK32_<target>_*.<ext>`` build artifact, or None.
 
     The single place that knows the Makefile's artifact naming; RigConfig's
     ELF resolution reuses it so the flashed binary and the parsed ELF can
     never be picked by two different rules.
     """
-    hits = sorted(obj_dir.glob(f"AM32_{target}_*.{ext}"))
+    hits = sorted(obj_dir.glob(f"ARK32_{target}_*.{ext}"))
     return hits[-1] if hits else None
 
 

--- a/hwci/scripts/gov_force_low_slope.py
+++ b/hwci/scripts/gov_force_low_slope.py
@@ -10,7 +10,7 @@ ceiling-bind. Pair with profile ``pr65_gov_unlatch_900kv``:
       --battery-cells 6 --out runs/pr65-gov-unlatch
 
   # terminal B — ~4 s into seed25 (after arm_settle + ramp + ~1 s hold)
-  python3 scripts/gov_force_low_slope.py --elf ../obj/AM32_ARK_4IN1_F051_*.elf \\
+  python3 scripts/gov_force_low_slope.py --elf ../obj/ARK32_ARK_4IN1_F051_*.elf \\
       --slope 8 --conf 300
 
 Default slope 8 is well below a healthy 900KV/10\" Q10 observation and binds

--- a/hwci/scripts/run_gov_unlatch_hwci.py
+++ b/hwci/scripts/run_gov_unlatch_hwci.py
@@ -6,7 +6,7 @@ not fight the ST-Link. Timing: poke starts after arm_settle+ramp+seed head.
 
   cd hwci
   python3 scripts/run_gov_unlatch_hwci.py \\
-      --elf ../obj/AM32_ARK_4IN1_F051_3.0-ark.elf \\
+      --elf ../obj/ARK32_ARK_4IN1_F051_3.0-ark.elf \\
       --out runs/pr65-gov-unlatch-$(date +%Y%m%d_%H%M%S)
 """
 from __future__ import annotations

--- a/scripts/build_factory_image.py
+++ b/scripts/build_factory_image.py
@@ -281,7 +281,7 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--bootloader", type=Path, required=True,
                    help="Bootloaders/AM32_F051_BOOTLOADER_*.bin")
     p.add_argument("--app", type=Path, required=True,
-                   help="obj/AM32_ARK_4IN1_F051_*.bin application image")
+                   help="obj/ARK32_ARK_4IN1_F051_*.bin application image")
     p.add_argument("--version-h", type=Path, default=Path("Inc/version.h"))
     p.add_argument("--out-bin", type=Path, required=True,
                    help="full 32 KiB flash image (.bin)")

--- a/scripts/capture_gui_test.py
+++ b/scripts/capture_gui_test.py
@@ -13,7 +13,7 @@ motor - notably that Abort stops a run in flight.
 
   capture_gui_test.py
   capture_gui_test.py --binary dist/am32-capture
-  capture_gui_test.py --sitl obj/AM32_AM32_SITL_CAN_2.20.elf
+  capture_gui_test.py --sitl obj/ARK32_AM32_SITL_CAN_2.20.elf
 '''
 
 import argparse

--- a/scripts/check-codegen-ark.sh
+++ b/scripts/check-codegen-ark.sh
@@ -43,7 +43,7 @@ fi
 
 ELF="${1:-}"
 if [ -z "$ELF" ]; then
-  ELF=$(ls -1 obj/AM32_ARK_4IN1_F051_*.elf 2>/dev/null | head -1 || true)
+  ELF=$(ls -1 obj/ARK32_ARK_4IN1_F051_*.elf 2>/dev/null | head -1 || true)
 fi
 if [ -z "$ELF" ] || [ ! -f "$ELF" ]; then
   echo "error: no ARK F051 elf — build ARK_4IN1_F051 first" >&2

--- a/scripts/check-factory-image-ark.sh
+++ b/scripts/check-factory-image-ark.sh
@@ -12,14 +12,14 @@ BL="${BL_IMAGE_F051:-Bootloaders/AM32_F051_BOOTLOADER_ARK4IN1_V18.bin}"
 DEFAULTS_JSON="${FACTORY_DEFAULTS:-factory/ARK_4IN1_F051_eeprom_defaults.json}"
 
 shopt -s nullglob
-factory_bins=("$OBJ"/AM32_ARK_4IN1_F051_*.factory.bin)
+factory_bins=("$OBJ"/ARK32_ARK_4IN1_F051_*.factory.bin)
 # App .bin only: exclude factory, eeprom, and local experiment names (*nsleep*).
 app_bins=()
-for f in "$OBJ"/AM32_ARK_4IN1_F051_*.bin; do
+for f in "$OBJ"/ARK32_ARK_4IN1_F051_*.bin; do
 	base="$(basename "$f")"
 	case "$base" in
 		*.factory.bin|*.eeprom.bin|*factory*|*nsleep*|*hwci*) ;;
-		AM32_ARK_4IN1_F051_*.bin) app_bins+=("$f") ;;
+		ARK32_ARK_4IN1_F051_*.bin) app_bins+=("$f") ;;
 	esac
 done
 

--- a/scripts/check-size-ark.sh
+++ b/scripts/check-size-ark.sh
@@ -32,9 +32,9 @@ RAM_CAPACITY="${RAM_CAPACITY:-8000}"
 FLASH_MAX_PCT="${FLASH_MAX_PCT:-99.8}"
 RAM_MAX_PCT="${RAM_MAX_PCT:-90}"
 
-ELF=$(ls -1 obj/AM32_ARK_4IN1_F051_*.elf 2>/dev/null | head -1 || true)
+ELF=$(ls -1 obj/ARK32_ARK_4IN1_F051_*.elf 2>/dev/null | head -1 || true)
 if [ -z "$ELF" ] || [ ! -f "$ELF" ]; then
-  echo "error: no obj/AM32_ARK_4IN1_F051_*.elf — build ARK_4IN1_F051 HWCI_PERF=1 first" >&2
+  echo "error: no obj/ARK32_ARK_4IN1_F051_*.elf — build ARK_4IN1_F051 HWCI_PERF=1 first" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

Ship artifacts were `AM32_<FILE_NAME>_<version>.*`. Rename the Makefile `IDENTIFIER` to **ARK32** so release/build outputs are:

- `ARK32_ARK_4IN1_F051_3.0.2-ark.hex` / `.bin` / `.elf`
- `ARK32_ARK_4IN1_F051_3.0.2-ark.factory.bin` / `.factory.hex` / `.eeprom.bin`
- SITL: `ARK32_AM32_SITL_CAN_<version>.elf`

## Changes

- `Makefile`: `IDENTIFIER := ARK32`
- CI: hex naming assert, workflow globs, archive name `ARK32-binaries`
- Factory/size/codegen scripts, HWCI artifact finder, SITL path globs, docs

**Unchanged:** bootloader blobs `Bootloaders/AM32_F051_BOOTLOADER_*`, target `FILE_NAME` strings in flash (`ARK_4IN1_F051`), and `AM32_MCU` C defines.

## Companion

Configurator asset matching must use `ARK32_` (see ark32-configurator PR #12 follow-up commit `chore: match ARK32_ release asset prefix`). Without that, flash-from-release shows NOT FOUND.

## Test plan

- [x] `make -n ARK_4IN1_F051` emits `ARK32_ARK_4IN1_F051_3.0.2-ark.elf`
- [ ] CI "Assert hex naming convention" passes
- [ ] Configurator finds `ARK32_ARK_4IN1_F051_*.hex` for the connected board