### PR TITLE
ci(build): cache the pinned Arm GCC and reject truncated downloads

### DIFF
--- a/.github/actions/setup-arm-sdk/action.yml
+++ b/.github/actions/setup-arm-sdk/action.yml
@@ -1,0 +1,29 @@
+name: Setup pinned Arm GCC
+description: Restore or install the xPack GNU Arm Embedded GCC pin from make/tools.mk
+
+runs:
+  using: composite
+  steps:
+    - name: Read toolchain pin
+      id: pin
+      shell: bash
+      run: |
+        ver=$(sed -n 's/^XPACK_GCC_VER := //p' make/tools.mk)
+        if [ -z "$ver" ]; then
+          echo "error: XPACK_GCC_VER not found in make/tools.mk" >&2
+          exit 1
+        fi
+        echo "ver=$ver" >> "$GITHUB_OUTPUT"
+        echo "dir=tools/linux/xpack-arm-none-eabi-gcc-$ver" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Arm GCC
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pin.outputs.dir }}
+        key: xpack-gcc-${{ runner.os }}-${{ runner.arch }}-${{ steps.pin.outputs.ver }}
+
+    - name: Install Arm GCC
+      shell: bash
+      run: |
+        make arm_sdk_install
+        make arm_sdk_check

--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -42,12 +42,11 @@ jobs:
         with:
           submodules: "recursive"
 
+      - name: Install Arm toolchain
+        uses: ./.github/actions/setup-arm-sdk
+
       - name: Build CI
-        run: |
-          # Installs + verifies the xPack GCC 15 pin from make/tools.mk.
-          make arm_sdk_install
-          make arm_sdk_check
-          make -j8
+        run: make -j8
 
       - name: Assert hex naming convention
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -55,9 +55,7 @@ jobs:
           submodules: recursive
 
       - name: Install Arm toolchain
-        run: |
-          make arm_sdk_install
-          make arm_sdk_check
+        uses: ./.github/actions/setup-arm-sdk
 
       - name: Build ARK + size check
         run: make size-check-ark -j$(nproc)
@@ -82,9 +80,7 @@ jobs:
           submodules: recursive
 
       - name: Install Arm toolchain
-        run: |
-          make arm_sdk_install
-          make arm_sdk_check
+        uses: ./.github/actions/setup-arm-sdk
 
       # Guards the two things LTO breaks without failing a build or a test:
       # RAM_FUNC hot paths inlined back into flash, and .file_name /
@@ -103,9 +99,7 @@ jobs:
           submodules: recursive
 
       - name: Install Arm toolchain
-        run: |
-          make arm_sdk_install
-          make arm_sdk_check
+        uses: ./.github/actions/setup-arm-sdk
 
       - name: Build + verify factory full-flash image
         run: make factory-image-check -j$(nproc)

--- a/make/tools_install.mk
+++ b/make/tools_install.mk
@@ -14,15 +14,19 @@ XPACK_GCC_VER ?= 15.2.1-1.1
 XPACK_GCC_DIR ?= xpack-arm-none-eabi-gcc-$(XPACK_GCC_VER)
 XPACK_GCC_REL := https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v$(XPACK_GCC_VER)
 
-# Download helper: wget preferred, curl fallback. No apt/system-gcc fallback.
+# Download helper: curl preferred (retries + HTTP fail), wget fallback.
+# Refuse a truncated or non-gzip file so a GitHub HTML error page cannot
+# reach `tar` as "unexpected end of file".
 define xpack_download
-	if command -v wget >/dev/null 2>&1; then \
-		wget -q --show-progress -O $(1) $(2) || wget -q -O $(1) $(2); \
-	elif command -v curl >/dev/null 2>&1; then \
-		curl -fL --retry 3 --retry-delay 2 -o $(1) $(2); \
+	rm -f $(1); \
+	if command -v curl >/dev/null 2>&1; then \
+		curl -fL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 20 -o $(1) $(2); \
+	elif command -v wget >/dev/null 2>&1; then \
+		wget -q --tries=5 --retry-connrefused --timeout=30 -O $(1) $(2); \
 	else \
 		echo "error: need wget or curl to fetch $(2)" >&2; exit 1; \
-	fi
+	fi; \
+	gzip -t $(1)
 endef
 
 # Windows helper utilities (make, etc.) — not the compiler
@@ -72,9 +76,13 @@ endif
 arm_sdk_install:
 	@echo Installing macos tools \(gcc $(XPACK_GCC_VER)\)
 	@if [ ! -x tools/macos/$(XPACK_GCC_DIR)/bin/arm-none-eabi-gcc ]; then \
-		echo "downloading $(MAC_XPACK_ASSET)"; \
 		mkdir -p tools/macos downloads; \
-		$(call xpack_download,downloads/$(MAC_XPACK_ASSET),$(XPACK_GCC_REL)/$(MAC_XPACK_ASSET)); \
+		if [ ! -s downloads/$(MAC_XPACK_ASSET) ] || ! gzip -t downloads/$(MAC_XPACK_ASSET) >/dev/null 2>&1; then \
+			echo "downloading $(MAC_XPACK_ASSET)"; \
+			$(call xpack_download,downloads/$(MAC_XPACK_ASSET),$(XPACK_GCC_REL)/$(MAC_XPACK_ASSET)); \
+		else \
+			echo "using existing downloads/$(MAC_XPACK_ASSET)"; \
+		fi; \
 		tar -xzf downloads/$(MAC_XPACK_ASSET) -C tools/macos; \
 	else \
 		echo "already installed: tools/macos/$(XPACK_GCC_DIR)"; \
@@ -95,9 +103,13 @@ endif
 arm_sdk_install:
 	@echo Installing linux tools \(gcc $(XPACK_GCC_VER)\)
 	@if [ ! -x tools/linux/$(XPACK_GCC_DIR)/bin/arm-none-eabi-gcc ]; then \
-		echo "downloading $(LINUX_XPACK_ASSET)"; \
 		mkdir -p tools/linux downloads; \
-		$(call xpack_download,downloads/$(LINUX_XPACK_ASSET),$(XPACK_GCC_REL)/$(LINUX_XPACK_ASSET)); \
+		if [ ! -s downloads/$(LINUX_XPACK_ASSET) ] || ! gzip -t downloads/$(LINUX_XPACK_ASSET) >/dev/null 2>&1; then \
+			echo "downloading $(LINUX_XPACK_ASSET)"; \
+			$(call xpack_download,downloads/$(LINUX_XPACK_ASSET),$(XPACK_GCC_REL)/$(LINUX_XPACK_ASSET)); \
+		else \
+			echo "using existing downloads/$(LINUX_XPACK_ASSET)"; \
+		fi; \
 		tar -xzf downloads/$(LINUX_XPACK_ASSET) -C tools/linux; \
 	else \
 		echo "already installed: tools/linux/$(XPACK_GCC_DIR)"; \


### PR DESCRIPTION
## Summary

Cache the pinned xPack GCC 15 toolchain on GitHub-hosted jobs, and refuse a truncated or non-gzip download before `tar`.

## Problem

CI Build Linux failed on `make arm_sdk_install` with `gzip: stdin: unexpected end of file`. Every run fetched `xpack-arm-none-eabi-gcc-15.2.1-1.1-linux-x64.tar.gz` with wget and no retries, so a short GitHub transfer left a half-file that `tar` then tried to unpack.

## Solution

A composite action restores `tools/linux/xpack-arm-none-eabi-gcc-<pin>` from `actions/cache` (key includes OS, arch, and `XPACK_GCC_VER` from `make/tools.mk`) and only downloads on a miss. `arm_sdk_install` now prefers curl with retries, checks `gzip -t` before extract, and reuses a good local tarball. Self-hosted HWCI is unchanged; the toolchain already persists on that runner.