### PR TITLE
refactor: drop unused sounds, input mapper, and crawler_mode

### DIFF
--- a/Inc/signal.h
+++ b/Inc/signal.h
@@ -13,7 +13,6 @@ extern char dshot;
 extern volatile char servoPwm;
 extern volatile char send_telemetry;
 extern volatile int16_t degrees_celsius;
-extern char crawler_mode;
 
 extern uint16_t ADC_raw_volts;
 extern uint16_t servo_low_threshold;  // anything below this point considered 0

--- a/Inc/signal.h
+++ b/Inc/signal.h
@@ -19,8 +19,5 @@ extern uint16_t servo_low_threshold;  // anything below this point considered 0
 extern uint16_t servo_high_threshold; // anything above this point considered 2000 (max)
 extern uint16_t servo_neutral;
 extern uint8_t servo_dead_band;
-extern volatile char inputSet;
-extern char dshot;
-extern volatile char servoPwm;
 
 void detectInput();

--- a/Inc/sounds.h
+++ b/Inc/sounds.h
@@ -15,7 +15,6 @@ void playInputTune(void);
 void playBrushedStartupTune(void);
 void playInputTune2(void);
 void playBeaconTune3(void);
-void playDuskingTune(void);
 void playDefaultTone(void);
 void playChangedTone(void);
 void playSignalLostTone(void);

--- a/Mcu/f415/Inc/sounds.h
+++ b/Mcu/f415/Inc/sounds.h
@@ -15,7 +15,6 @@ void playInputTune(void);
 void playBrushedStartupTune(void);
 void playInputTune2(void);
 void playBeaconTune3(void);
-void playDuskingTune(void);
 void playDefaultTone(void);
 void playChangedTone(void);
 

--- a/README.md
+++ b/README.md
@@ -218,12 +218,6 @@ Other DShot commands (direction, bi-dir, EDT, programming mode, etc.) do **not**
 | Motor spinning / throttle up | Deferred tone flags wait until throttle is at idle; beeps are not mixed into normal drive. |
 | No throttle signal after boot | ESC may stay in bootloader or keep waiting for input — you may only hear the **startup** tune, not the arm tune, until a valid zero throttle is seen. |
 
-### Defined but unused
-
-| Function | Status |
-|----------|--------|
-| **`playDuskingTune`** | Implemented in `sounds.c` (ascending then peaking melody) but **not called** from current application code. Kept for compatibility / possible future use. |
-
 ### Source map
 
 | File | Role |

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -142,16 +142,10 @@ void faultUpdateBemfTimeoutPolicy(void)
 		bemf_timeout_happened = 0;
 	}
 
-	if (crawler_mode) {
-		if (adjusted_input < 400) {
-			bemf_timeout_happened = 0;
-		}
+	if (adjusted_input < 150) { // startup duty cycle should be low enough to not burn motor
+		bemf_timeout = 100;
 	} else {
-		if (adjusted_input < 150) { // startup duty cycle should be low enough to not burn motor
-			bemf_timeout = 100;
-		} else {
-			bemf_timeout = 10;
-		}
+		bemf_timeout = 10;
 	}
 #endif
 }

--- a/Src/motor_runtime.c
+++ b/Src/motor_runtime.c
@@ -129,7 +129,6 @@ volatile uint8_t desync_episode_bucket = 0;
 volatile uint16_t desync_restart_holdoff_ms = 0;
 char maximum_throttle_change_ramp = 1;
 
-char crawler_mode = 0; // no longer used //
 uint16_t velocity_count = 0;
 uint16_t velocity_count_threshold = 75;
 

--- a/Src/signal.c
+++ b/Src/signal.c
@@ -31,19 +31,6 @@ uint32_t average_packet_length;
 uint16_t dshot_frametime_high = 50000;
 uint16_t dshot_frametime_low = 0;
 
-void computeMSInput()
-{
-	int lastnumber = dma_buffer[0];
-	for (int j = 1; j < 2; j++) {
-		if (((dma_buffer[j] - lastnumber) < 1500) && ((dma_buffer[j] - lastnumber) > 0)) { // blank space
-
-			newinput = map((dma_buffer[j] - lastnumber), 243, 1200, 0, 2000);
-			break;
-		}
-		lastnumber = dma_buffer[j];
-	}
-}
-
 void computeServoInput()
 {
 	if (((dma_buffer[1] - dma_buffer[0]) > 800) && ((dma_buffer[1] - dma_buffer[0]) < 2200)) {

--- a/Src/sounds.c
+++ b/Src/sounds.c
@@ -276,32 +276,6 @@ void playBrushedStartupTune()
 	__enable_irq();
 }
 
-void playDuskingTune()
-{
-	setCaptureCompare();
-	SET_AUTO_RELOAD_PWM(TIM1_AUTORELOAD);
-	comStep(2);	       // activate a pwm channel
-	SET_PRESCALER_PWM(60); // frequency of beep
-	delayMillis(200);      // duration of beep
-	SET_PRESCALER_PWM(55); // next beep is higher frequency
-	delayMillis(150);
-	SET_PRESCALER_PWM(50); // higher again..
-	delayMillis(150);
-	SET_PRESCALER_PWM(45); // frequency of beep
-	delayMillis(100);      // duration of beep
-	SET_PRESCALER_PWM(50); // next beep is higher frequency
-	delayMillis(100);
-	SET_PRESCALER_PWM(55); // higher again..
-	delayMillis(100);
-	SET_PRESCALER_PWM(25); // higher again..
-	delayMillis(200);
-	SET_PRESCALER_PWM(55); // higher again..
-	delayMillis(150);
-	allOff();	      // turn all channels low again
-	SET_PRESCALER_PWM(0); // set prescaler back to 0.
-	SET_AUTO_RELOAD_PWM(TIMER1_MAX_ARR);
-}
-
 // dshot beacon 4 / deferred arm beep: same morse "R" as playInputTune but
 // one arpeggio step lower so the beacon is distinguishable by pitch
 void playInputTune2()


### PR DESCRIPTION
## Summary
Delete a few unused functions and a dead flag. One commit each.

## Problem
`playDuskingTune` and `computeMSInput` have no callers. `crawler_mode` is never written after init-to-zero, so its BEMF-timeout branch is dead. `signal.h` declared `inputSet` / `dshot` / `servoPwm` twice.

## Solution
Remove the dead code and the duplicate externs. LTO already dropped the unused functions from the binary; this just deletes the source. No behavior change.