### PR TITLE
test(sitl): unflake steady-duty ramp-fixed desync contract

### DIFF
--- a/Mcu/SITL/tests/test_ramp_settings_fixed.py
+++ b/Mcu/SITL/tests/test_ramp_settings_fixed.py
@@ -233,6 +233,14 @@ def test_steady_duty_desync_leaves_ramp_fixed(sitl_factory, state_stream):
     the configured ramp. This is the episode that crashed the vehicle. The
     bucket must still charge - removing the learned halve must not weaken
     the always-on escalation path.
+
+    Do not condition on desync_happened: after #87 a mode-1 blackout is
+    bridged by blind steps and, once it outlasts BEMF_STALL_TICKS, hands
+    off through the stall rail. That path charges desync_episode_bucket
+    and does not increment desync_happened (see the slew-case test and
+    the error_count comment in faults.h). The inject must also outlast
+    that budget: 60 * ci_us has been 12.6 ms on the unloaded plant, and
+    12.6 ms is a clean ride-through with no episode at all.
     '''
     sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
     sim = state_stream(sitl)
@@ -253,18 +261,51 @@ def test_steady_duty_desync_leaves_ramp_fixed(sitl_factory, state_stream):
         assert steady['running'], (steady, sitl.log_tail())
         base = _ramp(steady)
 
-        ci_us = max(steady['commutation_interval'] // 2, 100)
-        _zc_fault(ctl, mode=1, duration_us=60 * ci_us)
         first = None
-        probe_end = time.time() + 3.0
-        while time.time() < probe_end:
-            s = _zc_stats(ctl)
-            _assert_ramp_fixed(base, s, 'steady-duty desync', sitl)
-            if s['desync_happened'] > steady['desync_happened']:
-                first = s
+        saw_desync = False
+        for _ in range(6):
+            s0 = _zc_stats(ctl)
+            if not (s0['running'] and not s0['old_routine']
+                    and s0['zero_crosses'] > 100):
+                try:
+                    s0 = _spool_established(sitl, sim, ctl, tx, value=900,
+                                            budget=8.0)
+                except AssertionError:
+                    continue
+            ci_us = max(s0['commutation_interval'] // 2, 100)
+            # Longer blackouts: after #87 a dropout shorter than
+            # BEMF_STALL_TICKS (22.5 ms) is ridden out with blind steps
+            # and charges nothing. Floor at 80 ms like
+            # test_ceiling_hold_engages_on_desync.
+            fault_us = max(80 * ci_us, 80_000)
+            bucket0 = int(s0['desync_episode_bucket'])
+            d0 = int(s0['desync_happened'])
+            _zc_fault(ctl, mode=1, duration_us=fault_us)
+            probe_end = time.time() + 3.0
+            while time.time() < probe_end:
+                s = _zc_stats(ctl)
+                _assert_ramp_fixed(base, s, 'steady-duty desync', sitl)
+                if s['desync_happened'] > d0:
+                    saw_desync = True
+                if s['desync_episode_bucket'] > bucket0:
+                    first = s
+                    break
+            if first is not None:
                 break
+            # Recover for another attempt; keep the stick at 900 so duty
+            # is still steady when the next inject lands.
+            _zc_fault(ctl, mode=0, duration_us=0)
+            tx.value = 900
+            try:
+                _spool_established(sitl, sim, ctl, tx, value=900, budget=8.0)
+            except AssertionError:
+                continue
+
         assert first is not None, (
-            'fault injection never produced a desync\n' + sitl.log_tail())
+            'fault injection never charged desync_episode_bucket, so this '
+            'test proved nothing - a re-introduced halve would not have '
+            'been given a chance to fire (saw_desync=%s)\n%s'
+            % (saw_desync, sitl.log_tail()))
         assert first['desync_episode_bucket'] > steady[
             'desync_episode_bucket'], (
             'episode bucket did not charge on an established-run desync - '


### PR DESCRIPTION
## Why

SITL CI flakes on `test_steady_duty_desync_leaves_ramp_fixed`:

```
AssertionError: fault injection never produced a desync
SITL: zc fault mode 1 for 12660 us
```

The grass-case test injected a 12.6 ms mode-1 ZC blackout (`60 * ci_us` on the unloaded plant) and required `desync_happened` to increment. After #87 that is the wrong contract:

- Dead-reckoning budget is `BEMF_STALL_TICKS` = 22.5 ms. A 12.6 ms dropout is ridden out with blind steps and charges **no** episode.
- If the blackout *does* last long enough, the stall-rail handoff charges `desync_episode_bucket` and does **not** increment `desync_happened` (see `faults.h` error_count and the sibling slew test).

Same flake has already shown up on `ark-release` after #87 (`#88`, the 3.0.2 bump, `#91`, `#92`) and then gone green on a later push. Firmware is doing what #87 asked; the test is still asking for a jump-desync.

## Change

Align the grass case with the tests that already survive this plant:

- Floor the inject at 80 ms (`max(80 * ci_us, 80_000)`), same as `test_ceiling_hold_engages_on_desync`.
- Gate on `desync_episode_bucket` motion, not `desync_happened`.
- Retry up to 6 times, re-spooling at DShot 900 so duty stays steady.
- Keep the ramp-fixed assertion on every sample.

No firmware change.

## Test plan

- [ ] SITL CI `sitl-tests` green, including `test_steady_duty_desync_leaves_ramp_fixed`.
- [ ] Sibling `test_slew_desync_leaves_ramp_fixed` still passes (unchanged).
- [ ] Local SITL in the dev container is **not** authority for this file (motor does not spin there).