### PR TITLE
fix(dshot): refresh signal timeout only after valid CRC

### DIFF
--- a/Mcu/SITL/tests/test_dshot_failsafe.py
+++ b/Mcu/SITL/tests/test_dshot_failsafe.py
@@ -1,0 +1,33 @@
+"""A corrupt signal must not keep a previously running motor alive."""
+
+import time
+
+import sitl_dshot as sd
+from sitl_harness import Sender, rpm_from_state, wait_for_state
+
+
+def test_bad_crc_after_running_triggers_signal_timeout(sitl_factory, state_stream):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    sim = state_stream(sitl)
+    assert wait_for_state(sim), sitl.log_tail()
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    try:
+        time.sleep(2.2)
+        tx.value = 700
+        time.sleep(3.5)
+        assert rpm_from_state(sim) > 3000, sitl.log_tail()
+    finally:
+        tx.stop()
+
+    port = sd.InputPort('127.0.0.1', sitl.input_port)
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            port.send_dshot(700, ptype=sd.TYPE_DSHOT600, corrupt=True)
+            time.sleep(0.002)
+        assert sitl.proc.poll() is None, sitl.log_tail()
+        assert sim.samples, 'state stream missing'
+        rpm = rpm_from_state(sim, 0.5)
+        assert 0 <= rpm < 800, 'bad CRC retained drive: rpm=%.0f\n%s' % (rpm, sitl.log_tail())
+    finally:
+        port.close()

--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -69,7 +69,7 @@ void computeDshotDMA()
 	dshot_frametime = dma_buffer[31] - dma_buffer[0];
 	halfpulsetime = dshot_frametime >> 5;
 	if ((dshot_frametime > dshot_frametime_low) && (dshot_frametime < dshot_frametime_high)) {
-		signaltimeout = 0;
+		/* Only a CRC-valid frame below may refresh the signal-loss timer. */
 		// Shift the 16 decoded pulses straight into one register-resident word,
 		// msb first: bit (15 - i) is pulse i. The frame layout is then
 		// [11 bit value][telem req][4 bit crc], so every field below is a


### PR DESCRIPTION
Correctly timed DShot frames with bad CRCs refreshed the signal-loss timer before validation, allowing stale throttle to persist. Refresh the timer only after CRC validation.

Adds a SITL regression that arms and spins the motor before replacing input with corrupt frames. The regression fails on the base branch (motor still at approximately 3,400 RPM after five seconds) and passes with the fix; the existing DShot tests also pass (5 tests total).

Validation: make format with clang-format 22.1.5; make size-check-ark (instrumented and release); make codegen-check-ark. Instrumented flash usage is 27,380/27,648 bytes. No hardware bench run has been performed.