### PR TITLE
fix(dshot): bound and expire settings transactions

### DIFF
--- a/Inc/dshot.h
+++ b/Inc/dshot.h
@@ -96,6 +96,9 @@ enum {
 void computeDshotDMA(void);
 void make_dshot_package(uint16_t com_time);
 
+/* Decremented by the control tick; only the decoder starts a transaction. */
+extern volatile uint16_t dshot_programming_ticks;
+
 extern void playInputTune(void);
 extern void playInputTune2(void);
 extern void playBeaconTune3(void);

--- a/Mcu/SITL/tests/test_dshot_programming.py
+++ b/Mcu/SITL/tests/test_dshot_programming.py
@@ -1,0 +1,95 @@
+"""Exercise legacy PX4 programming frames through the real DShot decoder."""
+
+import time
+
+import pytest
+import sitl_dshot as sd
+from sitl_gui_backend import EepromClient
+from sitl_harness import Sender
+
+
+@pytest.fixture
+def programmer(sitl_factory):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    time.sleep(2.2)
+    tx.stop()
+    port = sd.InputPort('127.0.0.1', sitl.input_port)
+    ee = EepromClient(port=sitl.state_port)
+
+    def send(value, telem=None, corrupt=False):
+        port.send_dshot(value, ptype=sd.TYPE_DSHOT600,
+                        telem=(value != 0) if telem is None else telem,
+                        corrupt=corrupt)
+        time.sleep(0.004)
+
+    def enter():
+        for _ in range(6):
+            send(36)
+
+    try:
+        yield send, enter, ee
+    finally:
+        port.close()
+
+
+@pytest.mark.parametrize('address,value', [(0, 0), (30, 7), (191, 255)])
+def test_program_valid_boundaries(programmer, address, value):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    for word in (address, value, 37):
+        send(word)
+    after, _ = ee.fetch()
+    expected = bytearray(before)
+    expected[address] = value
+    assert after == bytes(expected)
+
+
+@pytest.mark.parametrize('words', [(192, 7, 37), (2047, 7, 37),
+                                  (30, 256, 37), (30, 2047, 37),
+                                  (30, 7, 0, 37)])
+def test_invalid_transaction_does_not_write(programmer, words):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    for word in words:
+        send(word)
+    after, _ = ee.fetch()
+    assert after == before
+
+
+@pytest.mark.parametrize('stage', [0, 1, 2])
+def test_expired_transaction_does_not_commit_and_can_restart(programmer, stage):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    for word in (30, 7)[:stage]:
+        send(word)
+    # Keep valid traffic present: signal timeout alone cannot end programming.
+    for _ in range(40):
+        send(0)
+    send(37)
+    after, _ = ee.fetch()
+    assert after == before
+    enter()
+    for word in (30, 7, 37):
+        send(word)
+    after, _ = ee.fetch()
+    assert after is not None and after[30] == 7
+
+
+@pytest.mark.parametrize('corrupt', [False, True])
+def test_unmarked_or_bad_crc_data_aborts(programmer, corrupt):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    send(30, telem=corrupt, corrupt=corrupt)
+    send(7)
+    send(37)
+    after, _ = ee.fetch()
+    assert after == before

--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -63,6 +63,7 @@ uint16_t halfpulsetime = 0;
 uint8_t programming_mode;
 uint16_t position;
 uint8_t new_byte;
+volatile uint16_t dshot_programming_ticks;
 
 void computeDshotDMA()
 {
@@ -117,22 +118,37 @@ void computeDshotDMA()
 				send_telemetry = 1;
 			}
 			if (programming_mode > DSHOT_PROG_IDLE) {
+				/* Expiry discards the late frame instead of interpreting it as throttle.
+				 * PX4 sets the telemetry bit on nonzero programming data, but sends
+				 * zero without it. Zero data and MOTOR_STOP are indistinguishable. */
+				if (!dshot_programming_ticks || !armed || running || (tocheck != 0 && !(frame & DSHOT_TELEMETRY_BIT))) {
+					programming_mode = DSHOT_PROG_IDLE;
+					return;
+				}
 				if (programming_mode == DSHOT_PROG_WAIT_ADDRESS) {
+					if (tocheck >= (int)sizeof(eepromBuffer.buffer)) {
+						programming_mode = DSHOT_PROG_IDLE;
+						return;
+					}
 					position = tocheck; /* eepromBuffer index */
 					programming_mode = DSHOT_PROG_WAIT_VALUE;
 					return;
 				}
 				if (programming_mode == DSHOT_PROG_WAIT_VALUE) {
+					if (tocheck > UINT8_MAX) {
+						programming_mode = DSHOT_PROG_IDLE;
+						return;
+					}
 					new_byte = tocheck;
 					programming_mode = DSHOT_PROG_WAIT_COMMIT;
 					return;
 				}
 				if (programming_mode == DSHOT_PROG_WAIT_COMMIT) {
 					/* RAM only; DSHOT_CMD_SAVE_SETTINGS makes it permanent. */
-					if (tocheck == DSHOT_CMD_EXIT_PROGRAMMING_MODE) {
+					if (tocheck == DSHOT_CMD_EXIT_PROGRAMMING_MODE && position < sizeof(eepromBuffer.buffer)) {
 						eepromBuffer.buffer[position] = new_byte;
-						programming_mode = DSHOT_PROG_IDLE;
 					}
+					programming_mode = DSHOT_PROG_IDLE;
 				}
 				return; /* ignore throttle / other commands while programming */
 			}
@@ -236,7 +252,11 @@ void computeDshotDMA()
 							forward = eepromBuffer.dir_reversed;
 							break;
 						case DSHOT_CMD_ENTER_PROGRAMMING_MODE:
-							programming_mode = DSHOT_PROG_WAIT_ADDRESS;
+							if (frame & DSHOT_TELEMETRY_BIT) {
+								dshot_programming_ticks =
+									LOOP_FREQUENCY_HZ / 10; /* 100 ms total, not renewed by traffic */
+								programming_mode = DSHOT_PROG_WAIT_ADDRESS;
+							}
 							break;
 					}
 					last_dshot_command = dshotcommand;

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -19,6 +19,7 @@
 #include "esc_state.h"
 #include "IO.h"
 #include "sounds.h"
+#include "dshot.h"
 
 #ifdef USE_RGB_LED
 extern void setIndividualRGBLed(uint8_t, uint8_t, uint8_t);
@@ -69,6 +70,9 @@ uint8_t faultHandleStuckRotorIfNeeded(void)
 /* RAM-resident: called from tenKhzRoutine every 50 us on F051. */
 RAM_FUNC void faultSignalTimeoutTick(void)
 {
+	if (dshot_programming_ticks) {
+		dshot_programming_ticks--;
+	}
 #if defined(FIXED_DUTY_MODE) || defined(FIXED_SPEED_MODE)
 	if (getInputPinState()) {
 		signaltimeout++;

--- a/doc/dshot-programming.md
+++ b/doc/dshot-programming.md
@@ -1,0 +1,18 @@
+# Legacy DShot settings writes
+
+While armed and stopped, send command 36 six times, then one address frame,
+one byte-value frame, and command 37 to commit the byte to RAM. Command 12
+saves settings to flash. Complete the transaction within 100 ms of entry.
+Addresses must be 0..191 and values 0..255; invalid stages abort without a
+write. A late frame is discarded, and a fresh command-36 sequence can retry.
+Bad CRC aborts the transaction. Nonzero programming frames require the
+telemetry bit, matching PX4's command sender; zero payloads may omit it.
+
+The legacy format has no transaction identifier or independent payload type.
+A zero data byte is identical to MOTOR_STOP, and a marked in-range throttle
+value is identical to programming data. Consequently the decoder cannot
+ignore every stop/throttle-looking frame while preserving existing clients.
+Bounds, a fixed deadline and a final commit limit malformed transactions;
+they do not authenticate a write or distinguish all interleaved payloads.
+Clients must stop their normal throttle stream while programming. A fully
+unambiguous protocol would require a coordinated client/firmware extension.


### PR DESCRIPTION
## Summary
fixes #95
fixes #96

Bound and expire DShot settings-programming transactions.

## Problem
`DSHOT_CMD_ENTER_PROGRAMMING_MODE` took the next frame's 11-bit value as an index into the 192-byte EEPROM buffer, so a stray frame was an out-of-bounds RAM write. Programming mode had no timeout: a stop frame became address 0, and an interrupted sequence left the ESC ignoring throttle until command 37 or a CRC error.

## Solution
Reject addresses outside the buffer and values above a byte, abort on any unexpected stage, and expire the whole transaction 100 ms after entry regardless of traffic. Nonzero programming frames require the telemetry bit, which is how PX4's sender (checked at PX4/PX4-Autopilot@fc5256cf, `src/drivers/dshot/DShot.cpp`) marks them; zero payloads stay accepted so the existing sender keeps working. The legacy framing still cannot tell zero data from MOTOR_STOP or a marked in-range throttle from programming data; `doc/dshot-programming.md` records that limit and the client requirement to pause throttle while programming.

Validation: 13 SITL protocol regressions, `make format`, `make size-check-ark` (instrumented 27,540/27,648 bytes) and `make codegen-check-ark`. No hardware bench run.
