### PR TITLE
fix(settings): validate motor poles before runtime use

### DIFF
--- a/Inc/dshot.h
+++ b/Inc/dshot.h
@@ -96,6 +96,9 @@ enum {
 void computeDshotDMA(void);
 void make_dshot_package(uint16_t com_time);
 
+/* Decremented by the control tick; only the decoder starts a transaction. */
+extern volatile uint16_t dshot_programming_ticks;
+
 extern void playInputTune(void);
 extern void playInputTune2(void);
 extern void playBeaconTune3(void);

--- a/Inc/eeprom.h
+++ b/Inc/eeprom.h
@@ -19,6 +19,12 @@
 #	define MOTOR_POLES_MIN 2
 #	define MOTOR_POLES_MAX 128
 
+/* Validate before publishing a settings byte to IRQ/main-loop consumers. */
+static inline uint8_t sanitizeMotorPoles(uint8_t poles)
+{
+	return poles >= MOTOR_POLES_MIN && poles <= MOTOR_POLES_MAX ? poles : 14;
+}
+
 typedef union EEprom_u {
 	struct {
 		uint8_t reserved_0;	//0

--- a/Mcu/SITL/tests/test_dshot_programming.py
+++ b/Mcu/SITL/tests/test_dshot_programming.py
@@ -1,0 +1,95 @@
+"""Exercise legacy PX4 programming frames through the real DShot decoder."""
+
+import time
+
+import pytest
+import sitl_dshot as sd
+from sitl_gui_backend import EepromClient
+from sitl_harness import Sender
+
+
+@pytest.fixture
+def programmer(sitl_factory):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    time.sleep(2.2)
+    tx.stop()
+    port = sd.InputPort('127.0.0.1', sitl.input_port)
+    ee = EepromClient(port=sitl.state_port)
+
+    def send(value, telem=None, corrupt=False):
+        port.send_dshot(value, ptype=sd.TYPE_DSHOT600,
+                        telem=(value != 0) if telem is None else telem,
+                        corrupt=corrupt)
+        time.sleep(0.004)
+
+    def enter():
+        for _ in range(6):
+            send(36)
+
+    try:
+        yield send, enter, ee
+    finally:
+        port.close()
+
+
+@pytest.mark.parametrize('address,value', [(0, 0), (30, 7), (191, 255)])
+def test_program_valid_boundaries(programmer, address, value):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    for word in (address, value, 37):
+        send(word)
+    after, _ = ee.fetch()
+    expected = bytearray(before)
+    expected[address] = value
+    assert after == bytes(expected)
+
+
+@pytest.mark.parametrize('words', [(192, 7, 37), (2047, 7, 37),
+                                  (30, 256, 37), (30, 2047, 37),
+                                  (30, 7, 0, 37)])
+def test_invalid_transaction_does_not_write(programmer, words):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    for word in words:
+        send(word)
+    after, _ = ee.fetch()
+    assert after == before
+
+
+@pytest.mark.parametrize('stage', [0, 1, 2])
+def test_expired_transaction_does_not_commit_and_can_restart(programmer, stage):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    for word in (30, 7)[:stage]:
+        send(word)
+    # Keep valid traffic present: signal timeout alone cannot end programming.
+    for _ in range(40):
+        send(0)
+    send(37)
+    after, _ = ee.fetch()
+    assert after == before
+    enter()
+    for word in (30, 7, 37):
+        send(word)
+    after, _ = ee.fetch()
+    assert after is not None and after[30] == 7
+
+
+@pytest.mark.parametrize('corrupt', [False, True])
+def test_unmarked_or_bad_crc_data_aborts(programmer, corrupt):
+    send, enter, ee = programmer
+    before, _ = ee.fetch()
+    assert before is not None
+    enter()
+    send(30, telem=corrupt, corrupt=corrupt)
+    send(7)
+    send(37)
+    after, _ = ee.fetch()
+    assert after == before

--- a/Mcu/SITL/tests/test_eeprom_poles.py
+++ b/Mcu/SITL/tests/test_eeprom_poles.py
@@ -1,0 +1,64 @@
+"""Pole-count invariants at flash load and live protocol boundaries."""
+
+import time
+
+import pytest
+import sitl_dshot as sd
+import sitl_params
+from sitl_gui_backend import EepromClient
+from sitl_harness import Sender
+
+
+@pytest.mark.parametrize('poles', [0, 1, 2, 14, 46, 128, 129, 255])
+def test_flash_pole_count_is_sanitized(sitl_factory, workdir, poles):
+    from pathlib import Path
+    image = bytearray([255] * 192)
+    for offset, _name, _lo, _hi, default, _help in sitl_params.PARAMS:
+        image[offset] = default
+    image[27] = poles
+    path = Path(workdir) / 'pole-settings.bin'
+    path.write_bytes(image)
+    sitl = sitl_factory(extra_args=['--input-type', '1', '--eeprom', str(path)], can_uri='none')
+    result, _ = EepromClient(port=sitl.state_port).fetch()
+    assert result is not None, sitl.log_tail()
+    assert result[27] == (poles if 2 <= poles <= 128 else 14)
+    assert sitl.proc.poll() is None, sitl.log_tail()
+
+
+@pytest.mark.parametrize('poles', [0, 1, 128, 255])
+def test_dshot_cannot_publish_invalid_poles(sitl_factory, poles):
+    sitl = sitl_factory(extra_args=['--input-type', '1'], can_uri='none')
+    tx = Sender('127.0.0.1', sitl.input_port, sd.TYPE_DSHOT600)
+    time.sleep(2.2)
+    tx.stop()
+    port = sd.InputPort('127.0.0.1', sitl.input_port)
+    try:
+        for word in [36] * 6 + [27, poles, 37]:
+            port.send_dshot(word, ptype=sd.TYPE_DSHOT600, telem=word != 0)
+            time.sleep(0.004)
+        result, _ = EepromClient(port=sitl.state_port).fetch()
+        assert result is not None, sitl.log_tail()
+        assert result[27] == (poles if 2 <= poles <= 128 else 14)
+    finally:
+        port.close()
+
+
+@pytest.mark.parametrize('poles', [-1, 0, 1, 128, 129, 256, 65536])
+def test_can_checks_poles_before_narrowing(sitl_can_factory, mcast_uri, poles):
+    import dronecan
+    from test_params import _request_wait
+    sitl = sitl_can_factory(extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
+    node = dronecan.make_node(mcast_uri, node_id=115, bitrate=1000000)
+    try:
+        req = dronecan.uavcan.protocol.param.GetSet.Request()
+        req.name = 'MOTOR_POLES'
+        req.value = dronecan.uavcan.protocol.param.Value(integer_value=poles)
+        rsp = None
+        for _ in range(5):
+            rsp = _request_wait(node, 10, req)
+            if rsp is not None:
+                break
+        assert rsp is not None, sitl.log_tail()
+        assert int(rsp.value.integer_value) == (poles if 2 <= poles <= 128 else 14)
+    finally:
+        node.close()

--- a/Mcu/SITL/tests/test_eeprom_poles.py
+++ b/Mcu/SITL/tests/test_eeprom_poles.py
@@ -50,15 +50,18 @@ def test_can_checks_poles_before_narrowing(sitl_can_factory, mcast_uri, poles):
     sitl = sitl_can_factory(extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
     node = dronecan.make_node(mcast_uri, node_id=115, bitrate=1000000)
     try:
-        req = dronecan.uavcan.protocol.param.GetSet.Request()
-        req.name = 'MOTOR_POLES'
-        req.value = dronecan.uavcan.protocol.param.Value(integer_value=poles)
-        rsp = None
-        for _ in range(5):
-            rsp = _request_wait(node, 10, req)
-            if rsp is not None:
-                break
-        assert rsp is not None, sitl.log_tail()
-        assert int(rsp.value.integer_value) == (poles if 2 <= poles <= 128 else 14)
+        def set_poles(value):
+            req = dronecan.uavcan.protocol.param.GetSet.Request()
+            req.name = 'MOTOR_POLES'
+            req.value = dronecan.uavcan.protocol.param.Value(integer_value=value)
+            for _ in range(5):
+                rsp = _request_wait(node, 10, req)
+                if rsp is not None:
+                    return int(rsp.value.integer_value)
+            assert False, sitl.log_tail()
+
+        # A distinct valid value first, so a rejected write is told apart from a reset to the default.
+        assert set_poles(22) == 22
+        assert set_poles(poles) == (poles if 2 <= poles <= 128 else 22)
     finally:
         node.close()

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -381,7 +381,16 @@ static void handle_param_GetSet(CanardInstance *ins, CanardRxTransfer *transfer)
 		switch (p->vtype) {
 			case T_UINT8: {
 				uint8_t *ptr8 = (uint8_t *)p->ptr;
-				if (ptr8 == &eepromBuffer.limits.current) {
+				if (ptr8 == &eepromBuffer.motor_poles) {
+					/* Validate the wire integer before narrowing to a byte; 256
+					 * must not wrap to zero between IRQ consumers. */
+					if (req.value.union_tag != UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE) {
+						break;
+					}
+					*ptr8 = req.value.integer_value >= MOTOR_POLES_MIN && req.value.integer_value <= MOTOR_POLES_MAX
+							? sanitizeMotorPoles((uint8_t)req.value.integer_value)
+							: sanitizeMotorPoles(0);
+				} else if (ptr8 == &eepromBuffer.limits.current) {
 					*ptr8 = req.value.integer_value / 2;
 				} else {
 					*ptr8 = req.value.integer_value;

--- a/Src/DroneCAN/DroneCAN.c
+++ b/Src/DroneCAN/DroneCAN.c
@@ -382,14 +382,13 @@ static void handle_param_GetSet(CanardInstance *ins, CanardRxTransfer *transfer)
 			case T_UINT8: {
 				uint8_t *ptr8 = (uint8_t *)p->ptr;
 				if (ptr8 == &eepromBuffer.motor_poles) {
-					/* Validate the wire integer before narrowing to a byte; 256
-					 * must not wrap to zero between IRQ consumers. */
-					if (req.value.union_tag != UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE) {
+					/* Range-check the wire integer before narrowing: 256 would
+					 * wrap to zero. A rejected write leaves the stored value. */
+					if (req.value.union_tag != UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE ||
+					    req.value.integer_value < MOTOR_POLES_MIN || req.value.integer_value > MOTOR_POLES_MAX) {
 						break;
 					}
-					*ptr8 = req.value.integer_value >= MOTOR_POLES_MIN && req.value.integer_value <= MOTOR_POLES_MAX
-							? sanitizeMotorPoles((uint8_t)req.value.integer_value)
-							: sanitizeMotorPoles(0);
+					*ptr8 = (uint8_t)req.value.integer_value;
 				} else if (ptr8 == &eepromBuffer.limits.current) {
 					*ptr8 = req.value.integer_value / 2;
 				} else {

--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -63,6 +63,7 @@ uint16_t halfpulsetime = 0;
 uint8_t programming_mode;
 uint16_t position;
 uint8_t new_byte;
+volatile uint16_t dshot_programming_ticks;
 
 void computeDshotDMA()
 {
@@ -117,22 +118,37 @@ void computeDshotDMA()
 				send_telemetry = 1;
 			}
 			if (programming_mode > DSHOT_PROG_IDLE) {
+				/* Expiry discards the late frame instead of interpreting it as throttle.
+				 * PX4 sets the telemetry bit on nonzero programming data, but sends
+				 * zero without it. Zero data and MOTOR_STOP are indistinguishable. */
+				if (!dshot_programming_ticks || !armed || running || (tocheck != 0 && !(frame & DSHOT_TELEMETRY_BIT))) {
+					programming_mode = DSHOT_PROG_IDLE;
+					return;
+				}
 				if (programming_mode == DSHOT_PROG_WAIT_ADDRESS) {
+					if (tocheck >= (int)sizeof(eepromBuffer.buffer)) {
+						programming_mode = DSHOT_PROG_IDLE;
+						return;
+					}
 					position = tocheck; /* eepromBuffer index */
 					programming_mode = DSHOT_PROG_WAIT_VALUE;
 					return;
 				}
 				if (programming_mode == DSHOT_PROG_WAIT_VALUE) {
+					if (tocheck > UINT8_MAX) {
+						programming_mode = DSHOT_PROG_IDLE;
+						return;
+					}
 					new_byte = tocheck;
 					programming_mode = DSHOT_PROG_WAIT_COMMIT;
 					return;
 				}
 				if (programming_mode == DSHOT_PROG_WAIT_COMMIT) {
 					/* RAM only; DSHOT_CMD_SAVE_SETTINGS makes it permanent. */
-					if (tocheck == DSHOT_CMD_EXIT_PROGRAMMING_MODE) {
+					if (tocheck == DSHOT_CMD_EXIT_PROGRAMMING_MODE && position < sizeof(eepromBuffer.buffer)) {
 						eepromBuffer.buffer[position] = new_byte;
-						programming_mode = DSHOT_PROG_IDLE;
 					}
+					programming_mode = DSHOT_PROG_IDLE;
 				}
 				return; /* ignore throttle / other commands while programming */
 			}
@@ -236,7 +252,11 @@ void computeDshotDMA()
 							forward = eepromBuffer.dir_reversed;
 							break;
 						case DSHOT_CMD_ENTER_PROGRAMMING_MODE:
-							programming_mode = DSHOT_PROG_WAIT_ADDRESS;
+							if (frame & DSHOT_TELEMETRY_BIT) {
+								dshot_programming_ticks =
+									LOOP_FREQUENCY_HZ / 10; /* 100 ms total, not renewed by traffic */
+								programming_mode = DSHOT_PROG_WAIT_ADDRESS;
+							}
 							break;
 					}
 					last_dshot_command = dshotcommand;

--- a/Src/dshot.c
+++ b/Src/dshot.c
@@ -12,6 +12,7 @@
 #include "sounds.h"
 #include "targets.h"
 #include "hwci_perf.h"
+#include <stddef.h>
 #if DRONECAN_SUPPORT
 #	include "DroneCAN/DroneCAN.h"
 #endif
@@ -130,6 +131,9 @@ void computeDshotDMA()
 				if (programming_mode == DSHOT_PROG_WAIT_COMMIT) {
 					/* RAM only; DSHOT_CMD_SAVE_SETTINGS makes it permanent. */
 					if (tocheck == DSHOT_CMD_EXIT_PROGRAMMING_MODE) {
+						if (position == offsetof(EEprom_t, motor_poles)) {
+							new_byte = sanitizeMotorPoles(new_byte);
+						}
 						eepromBuffer.buffer[position] = new_byte;
 						programming_mode = DSHOT_PROG_IDLE;
 					}

--- a/Src/faults.c
+++ b/Src/faults.c
@@ -19,6 +19,7 @@
 #include "esc_state.h"
 #include "IO.h"
 #include "sounds.h"
+#include "dshot.h"
 
 #ifdef USE_RGB_LED
 extern void setIndividualRGBLed(uint8_t, uint8_t, uint8_t);
@@ -69,6 +70,9 @@ uint8_t faultHandleStuckRotorIfNeeded(void)
 /* RAM-resident: called from tenKhzRoutine every 50 us on F051. */
 RAM_FUNC void faultSignalTimeoutTick(void)
 {
+	if (dshot_programming_ticks) {
+		dshot_programming_ticks--;
+	}
 #if defined(FIXED_DUTY_MODE) || defined(FIXED_SPEED_MODE)
 	if (getInputPinState()) {
 		signaltimeout++;

--- a/Src/settings.c
+++ b/Src/settings.c
@@ -216,20 +216,11 @@ void loadEEpromSettings(void)
 		 * (am32-firmware/AM32#405 - the community workaround of entering
 		 * 50-60% of the real kv cancels exactly this factor).
 		 *
-		 * Out-of-range pole counts (an erased eeprom reads 0 or 0xff)
-		 * leave the envelope at zero, which map() treats as "always at
-		 * the high-rpm limit" - i.e. unrestricted, as before.
-		 * MOTOR_POLES_MIN..MOTOR_POLES_MAX is the range the DroneCAN
-		 * MOTOR_POLES parameter accepts (see eeprom.h). Worst case
-		 * 10220 kv * 128 poles / 544 = 2405 kerpm, well inside the
-		 * uint16 the levels are stored in. */
-		if (eepromBuffer.motor_poles >= MOTOR_POLES_MIN && eepromBuffer.motor_poles <= MOTOR_POLES_MAX) {
-			low_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (100U * 32U);
-			high_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (17U * 32U);
-		} else {
-			low_rpm_level = 0;
-			high_rpm_level = 0;
-		}
+		 * motor_poles is already within MOTOR_POLES_MIN..MOTOR_POLES_MAX
+		 * (sanitized at load). Worst case 10220 kv * 128 poles / 544 =
+		 * 2405 kerpm, well inside the uint16 the levels are stored in. */
+		low_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (100U * 32U);
+		high_rpm_level = ((uint32_t)motor_kv * eepromBuffer.motor_poles) / (17U * 32U);
 	}
 	/*
 	 * Advance-schedule normalization (see motor_runtime.h and the advance block
@@ -247,9 +238,7 @@ void loadEEpromSettings(void)
 	 * above it to 23, so a motor that truly hits ideal stays at the top.
 	 * Computed after motor_kv has taken its final value (the cell-count
 	 * reductions above). Left at 0 - meaning "use the duty proxy" - for a kV
-	 * below the range the throttle limiter already treats as unusable, or a
-	 * pole count outside the MOTOR_POLES_MIN..MOTOR_POLES_MAX the DroneCAN
-	 * MOTOR_POLES parameter accepts (an erased eeprom reads 0 or 0xff).
+	 * below the range the throttle limiter already treats as unusable.
 	 *
 	 * The reduced 256/12500 form above is the one evaluated below rather than
 	 * the equivalent 4096/200000: both are the same rational number (divided
@@ -261,7 +250,7 @@ void loadEEpromSettings(void)
 	 * path's (scale * centivolts) >> 12 on a 12S pack.
 	 */
 	advance_erpm_scale_q12 = 0;
-	if (motor_kv >= 300 && eepromBuffer.motor_poles >= MOTOR_POLES_MIN && eepromBuffer.motor_poles <= MOTOR_POLES_MAX) {
+	if (motor_kv >= 300) {
 		uint16_t scale = (uint16_t)(((uint32_t)motor_kv * eepromBuffer.motor_poles * 256u) / 12500u);
 		advance_erpm_scale_q12 = (uint16_t)(scale - (scale >> 4)); /* * 15/16 */
 	}

--- a/Src/settings.c
+++ b/Src/settings.c
@@ -20,6 +20,9 @@
 void loadEEpromSettings(void)
 {
 	read_flash_bin(eepromBuffer.buffer, eeprom_address, sizeof(eepromBuffer.buffer));
+	/* All consumers, including sine startup and RPM control, need nonzero
+	 * poles and pole pairs. Do not merely guard the derived schedules. */
+	eepromBuffer.motor_poles = sanitizeMotorPoles(eepromBuffer.motor_poles);
 	if (eepromBuffer.eeprom_version < EEPROM_VERSION) {
 		eepromBuffer.max_ramp = TARGET_DEFAULT_MAX_RAMP; // 0.1% per ms steps (see targets.h)
 		eepromBuffer.minimum_duty_cycle = 1;		 // 0.2% to 51 percent
@@ -273,6 +276,7 @@ void loadEEpromSettings(void)
 
 void saveEEpromSettings(void)
 {
+	eepromBuffer.motor_poles = sanitizeMotorPoles(eepromBuffer.motor_poles);
 	save_flash_nolib(eepromBuffer.buffer, sizeof(eepromBuffer.buffer), eeprom_address);
 }
 

--- a/doc/dshot-programming.md
+++ b/doc/dshot-programming.md
@@ -1,0 +1,18 @@
+# Legacy DShot settings writes
+
+While armed and stopped, send command 36 six times, then one address frame,
+one byte-value frame, and command 37 to commit the byte to RAM. Command 12
+saves settings to flash. Complete the transaction within 100 ms of entry.
+Addresses must be 0..191 and values 0..255; invalid stages abort without a
+write. A late frame is discarded, and a fresh command-36 sequence can retry.
+Bad CRC aborts the transaction. Nonzero programming frames require the
+telemetry bit, matching PX4's command sender; zero payloads may omit it.
+
+The legacy format has no transaction identifier or independent payload type.
+A zero data byte is identical to MOTOR_STOP, and a marked in-range throttle
+value is identical to programming data. Consequently the decoder cannot
+ignore every stop/throttle-looking frame while preserving existing clients.
+Bounds, a fixed deadline and a final commit limit malformed transactions;
+they do not authenticate a write or distinguish all interleaved payloads.
+Clients must stop their normal throttle stream while programming. A fully
+unambiguous protocol would require a coordinated client/firmware extension.


### PR DESCRIPTION
## Summary
Validate the EEPROM motor pole count before anything divides by it.

## Problem
`motor_poles` could load from flash as 0, 1 or 255, and sine startup, RPM control and DroneCAN telemetry divide by the pole count or pole-pair count. A DroneCAN GetSet narrowed the wire integer to a byte first, so 256 wrapped to zero.

## Solution
Normalize out-of-range values to the 14-pole default when loading and saving settings and before a DShot programming write publishes the byte. Range-check the full DroneCAN wire integer before narrowing; an out-of-range or wrongly typed set is rejected and the stored value is echoed back unchanged. Valid values 2..128 pass through, and the derived RPM levels no longer carry their own range guards. No EEPROM layout or firmware-version change. #107 must preserve this invariant when it integrates generated load policies.

Stacked on #109; merge that first. Validation: 32 SITL tests covering flash-loaded 0/1/2/14/46/128/129/255, DShot writes, negative and oversized DroneCAN integers, plus the programming regressions; `make format`, `make size-check-ark` (release 26,672/27,648) and `make codegen-check-ark`. No hardware bench run.
