### PR TITLE
ci: require CAN coverage and calibrate control-path changes

### DIFF
--- a/.github/workflows/SITL-calibration.yml
+++ b/.github/workflows/SITL-calibration.yml
@@ -16,22 +16,24 @@ on:
     branches: ["main", "ark-release"]
     paths:
       - "Mcu/SITL/**"
-      - "scripts/esc_*.py"
-      - "Src/main.c"
-      - "Src/DroneCAN/**"
-      - "Src/motor_runtime.c"
-      - "Src/runtime_loop.c"
-      - "Src/settings.c"
+      - "scripts/**"
+      - "Src/**"
+      - "Inc/**"
+      - "Makefile"
+      - "*makefile.mk"
+      - "make/**"
+      - ".github/workflows/SITL-calibration.yml"
   pull_request:
     branches: ["main", "ark-release"]
     paths:
       - "Mcu/SITL/**"
-      - "scripts/esc_*.py"
-      - "Src/main.c"
-      - "Src/DroneCAN/**"
-      - "Src/motor_runtime.c"
-      - "Src/runtime_loop.c"
-      - "Src/settings.c"
+      - "scripts/**"
+      - "Src/**"
+      - "Inc/**"
+      - "Makefile"
+      - "*makefile.mk"
+      - "make/**"
+      - ".github/workflows/SITL-calibration.yml"
   schedule:
     - cron: "17 2 * * *"
   workflow_dispatch:

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -24,6 +24,8 @@ jobs:
           sitl-venv/bin/pip install -r Mcu/SITL/requirements-ci.txt
 
       - name: Run SITL pytest suite
+        env:
+          SITL_REQUIRE_CAN: "1"
         run: |
           mkdir sitl_test_run && cd sitl_test_run
           ../sitl-venv/bin/python ../Mcu/SITL/run_ci_tests.py \

--- a/Mcu/SITL/README.md
+++ b/Mcu/SITL/README.md
@@ -299,3 +299,15 @@ current, and battery voltage sag from internal resistance. The
 comparator compares the floating phase against the virtual neutral with
 configurable noise and hysteresis, so the firmware's blanking and
 filtering logic is genuinely exercised at PWM switching level.
+
+### Required CAN tests in CI
+
+The Linux pytest job sets `SITL_REQUIRE_CAN=1`. Missing DroneCAN dependencies,
+failed multicast startup, absent state streams, and undiscovered ESC nodes
+fail that job instead of silently skipping protocol and safety coverage.
+Local hosts without multicast can omit the variable to retain optional skips.
+Run the strict suite locally with:
+
+```sh
+SITL_REQUIRE_CAN=1 python3 Mcu/SITL/run_ci_tests.py --sitl obj/ARK32_AM32_SITL_CAN_*.elf
+```

--- a/Mcu/SITL/sitl_test_requirements.py
+++ b/Mcu/SITL/sitl_test_requirements.py
@@ -1,0 +1,20 @@
+"""Explicit CAN availability policy for local runs versus dedicated CI."""
+
+import importlib
+import os
+import pytest
+
+
+def unavailable_can(reason):
+    if os.environ.get('SITL_REQUIRE_CAN') == '1':
+        pytest.fail(reason, pytrace=False)
+    pytest.skip(reason, allow_module_level=True)
+
+
+def require_dronecan():
+    try:
+        return importlib.import_module('dronecan')
+    except ModuleNotFoundError as exc:
+        if exc.name != 'dronecan':
+            raise
+        unavailable_can('dronecan is required for CAN protocol tests')

--- a/Mcu/SITL/tests/conftest.py
+++ b/Mcu/SITL/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 HERE = os.path.dirname(os.path.abspath(__file__))
 SITL_DIR = os.path.normpath(os.path.join(HERE, '..'))
 sys.path.insert(0, SITL_DIR)
+from sitl_test_requirements import unavailable_can
 
 from sitl_harness import (  # noqa: E402
     Sitl,
@@ -89,7 +90,7 @@ def sitl_can_factory(sitl_factory):
             return sitl_factory(extra_args=extra_args, can_uri=can_uri, **kw)
         except SitlStartError as e:
             if e.looks_like_mcast_failure:
-                pytest.skip('SITL multicast CAN unavailable on this host:\n%s'
+                unavailable_can('SITL multicast CAN unavailable on this host:\n%s'
                             % e)
             raise
 

--- a/Mcu/SITL/tests/test_can_requirements.py
+++ b/Mcu/SITL/tests/test_can_requirements.py
@@ -1,0 +1,23 @@
+"""CI must fail rather than skip when its CAN prerequisite disappears."""
+
+import pytest
+import sitl_test_requirements as policy
+
+
+@pytest.mark.parametrize('strict', [False, True])
+def test_unavailable_can_policy(monkeypatch, strict):
+    monkeypatch.setenv('SITL_REQUIRE_CAN', '1' if strict else '0')
+    outcome = pytest.fail.Exception if strict else pytest.skip.Exception
+    with pytest.raises(outcome, match='missing multicast'):
+        policy.unavailable_can('missing multicast')
+
+
+@pytest.mark.parametrize('strict', [False, True])
+def test_missing_dronecan_policy(monkeypatch, strict):
+    monkeypatch.setenv('SITL_REQUIRE_CAN', '1' if strict else '0')
+    def missing(name):
+        raise ModuleNotFoundError(name=name)
+    monkeypatch.setattr(policy.importlib, 'import_module', missing)
+    outcome = pytest.fail.Exception if strict else pytest.skip.Exception
+    with pytest.raises(outcome, match='dronecan is required'):
+        policy.require_dronecan()

--- a/Mcu/SITL/tests/test_dronecan.py
+++ b/Mcu/SITL/tests/test_dronecan.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import time
 
 import pytest
+from sitl_test_requirements import unavailable_can, require_dronecan
 
 from sitl_harness import rpm_from_state, wait_for_state
 
-dronecan = pytest.importorskip('dronecan')
+dronecan = require_dronecan()
 
 
 def _multicast_usable(sitl, sim, timeout=5.0):
@@ -16,7 +17,7 @@ def _multicast_usable(sitl, sim, timeout=5.0):
     Skip rather than fail when the SITL never starts streaming with CAN on.'''
     if wait_for_state(sim, timeout=timeout):
         return True
-    pytest.skip(
+    unavailable_can(
         'SITL state stream never started with CAN enabled; '
         'multicast is probably unavailable.\n' + sitl.log_tail())
 

--- a/Mcu/SITL/tests/test_params.py
+++ b/Mcu/SITL/tests/test_params.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import time
 
 import pytest
+from sitl_test_requirements import unavailable_can, require_dronecan
 
 from sitl_harness import wait_for_state
 
-dronecan = pytest.importorskip('dronecan')
+dronecan = require_dronecan()
 
 
 def _wait_for_node(uri, timeout=8.0, our_id=110):
@@ -68,11 +69,11 @@ def _set_param(node, target, name, value, attempts=5):
 
 def _require_mcast_node(sitl, sim, mcast_uri, our_id=110):
     if not wait_for_state(sim, timeout=5.0):
-        pytest.skip('multicast/state unavailable\n' + sitl.log_tail())
+        unavailable_can('multicast/state unavailable\n' + sitl.log_tail())
     node, found = _wait_for_node(mcast_uri, our_id=our_id)
     if 10 not in found:
         node.close()
-        pytest.skip('ESC node 10 not seen on %s (mcast likely broken)\n%s'
+        unavailable_can('ESC node 10 not seen on %s (mcast likely broken)\n%s'
                     % (mcast_uri, sitl.log_tail()))
     return node, found
 

--- a/Mcu/SITL/tests/test_safety.py
+++ b/Mcu/SITL/tests/test_safety.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 import time
 
 import pytest
+from sitl_test_requirements import unavailable_can, require_dronecan
 
 import sitl_dshot as sd
 from sitl_harness import Sender, rpm_from_state, wait_for_state
 
 
 def _need_dronecan():
-    return pytest.importorskip('dronecan')
+    return require_dronecan()
 
 
 def _assert_stopped(sim, label, window=0.5, limit=200.0):
@@ -161,7 +162,7 @@ def test_dronecan_high_throttle_from_boot_does_not_spin(
         extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
     sim = state_stream(sitl)
     if not wait_for_state(sim, timeout=5.0):
-        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+        unavailable_can('multicast unavailable\n' + sitl.log_tail())
 
     node = dronecan.make_node(mcast_uri, node_id=120, bitrate=1000000)
     try:
@@ -180,7 +181,7 @@ def test_dronecan_arms_after_zero_then_spins(
         extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
     sim = state_stream(sitl)
     if not wait_for_state(sim, timeout=5.0):
-        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+        unavailable_can('multicast unavailable\n' + sitl.log_tail())
 
     node = dronecan.make_node(mcast_uri, node_id=121, bitrate=1000000)
     try:
@@ -212,7 +213,7 @@ def test_dronecan_disarm_zeros_input(
         extra_args=['--node-id', '10'], can_uri=mcast_uri, wait_s=1.0)
     sim = state_stream(sitl)
     if not wait_for_state(sim, timeout=5.0):
-        pytest.skip('multicast unavailable\n' + sitl.log_tail())
+        unavailable_can('multicast unavailable\n' + sitl.log_tail())
 
     node = dronecan.make_node(mcast_uri, node_id=122, bitrate=1000000)
     try:


### PR DESCRIPTION
Control-path and target-header changes could bypass PR calibration, while missing CAN connectivity could silently skip protocol/safety tests in the Linux CI job.

Expand calibration filters to firmware sources, headers, simulator, scripts and build configuration. Set SITL_REQUIRE_CAN=1 in the Linux pytest job: missing DroneCAN, failed multicast startup, absent state streams and undiscovered ESC nodes now fail. Local hosts can omit the variable to retain optional CAN skips.

Validation: 17 targeted tests pass with CAN required, including four tests of strict/local prerequisite handling and the existing CAN parameter, protocol and safety tests. The new helper is shared by fixtures and tests so they apply the same availability policy.