### PR TITLE
ci(release): gate publication and package factory provenance

### DIFF
--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -33,8 +33,10 @@ on:
 permissions:
   contents: read
 
+# Serialize publication per ref. The event name keeps a queued nightly from
+# being replaced by a later ark-release push (one pending run per group).
 concurrency:
-  group: firmware-release-${{ github.ref }}
+  group: firmware-release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -139,8 +141,9 @@ jobs:
 
       - name: Package release provenance and checksums
         run: |
-          sdk=$(find tools/linux -path '*/bin/arm-none-eabi-gcc' -type f -print -quit)
-          test -n "$sdk"
+          ver=$(sed -n 's/^XPACK_GCC_VER := //p' make/tools.mk)
+          sdk="tools/linux/xpack-arm-none-eabi-gcc-${ver}/bin/arm-none-eabi-gcc"
+          test -x "$sdk"
           python3 scripts/release_manifest.py --compiler "$sdk"
 
       - name: Archive build

--- a/.github/workflows/CICD_build.yml
+++ b/.github/workflows/CICD_build.yml
@@ -1,6 +1,6 @@
 name: CI Build Linux
 
-# Build all MCU targets and publish .hex assets for the ARK32 configurator
+# Build supported products and publish validated release assets for the ARK32 configurator
 # and production line (see ARK-Electronics/ARK32#67).
 #
 # Ubuntu-only: release assets and size-gated firmware builds are produced with
@@ -8,7 +8,7 @@ name: CI Build Linux
 # FLASH; native SITL on Windows is covered by the SITL workflow.)
 #
 # - Push/PR on ark-release: build + artifact.
-# - Version tags (vMAJOR.MINOR[.PATCH][-suffix]): GitHub Release with obj/*.hex.
+# - Version tags: publish app/factory/EEPROM images after all validation jobs pass.
 # - schedule / optional dispatch: rolling `nightly` prerelease (assets replaced).
 
 on:
@@ -31,9 +31,34 @@ on:
         type: boolean
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: firmware-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  validate-static:
+    if: >
+      github.repository == 'ARK-Electronics/ARK32' &&
+      (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish_nightly))
+    uses: ./.github/workflows/static-analysis.yml
+
+  validate-sitl:
+    if: >
+      github.repository == 'ARK-Electronics/ARK32' &&
+      (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish_nightly))
+    uses: ./.github/workflows/SITL.yml
+
+  validate-calibration:
+    if: >
+      github.repository == 'ARK-Electronics/ARK32' &&
+      (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish_nightly))
+    uses: ./.github/workflows/SITL-calibration.yml
+
   build:
     runs-on: ubuntu-latest
 
@@ -106,14 +131,48 @@ jobs:
           fi
           echo "Asserted ${#hexes[@]} hex asset(s)"
 
+      - name: Build and verify factory images
+        run: make factory-image-check
+
+      - name: Test release packaging
+        run: python3 -m unittest discover -s scripts/tests -p 'test_release_manifest.py'
+
+      - name: Package release provenance and checksums
+        run: |
+          sdk=$(find tools/linux -path '*/bin/arm-none-eabi-gcc' -type f -print -quit)
+          test -n "$sdk"
+          python3 scripts/release_manifest.py --compiler "$sdk"
+
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
           name: ARK32-binaries
           path: |
             obj/*.hex
+            obj/*.bin
+            obj/release-manifest.json
+            obj/SHA256SUMS
           retention-days: 60
           if-no-files-found: error
+
+  publish:
+    needs: [build, validate-static, validate-sitl, validate-calibration]
+    if: >
+      github.repository == 'ARK-Electronics/ARK32' &&
+      (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish_nightly))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ARK32-binaries
+          path: obj
+
+      - name: Verify downloaded assets
+        working-directory: obj
+        run: sha256sum --check SHA256SUMS
 
       - name: Upload version-tag release assets
         if: >
@@ -122,7 +181,11 @@ jobs:
           github.repository == 'ARK-Electronics/ARK32'
         uses: softprops/action-gh-release@v2
         with:
-          files: obj/*.hex
+          files: |
+            obj/*.hex
+            obj/*.bin
+            obj/release-manifest.json
+            obj/SHA256SUMS
           fail_on_unmatched_files: true
           generate_release_notes: true
         env:
@@ -137,6 +200,7 @@ jobs:
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           # Rolling prerelease: replace assets and retarget the tag each run.
           gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
@@ -155,7 +219,11 @@ jobs:
           prerelease: true
           make_latest: false
           target_commitish: ${{ github.sha }}
-          files: obj/*.hex
+          files: |
+            obj/*.hex
+            obj/*.bin
+            obj/release-manifest.json
+            obj/SHA256SUMS
           fail_on_unmatched_files: true
           body: |
             Rolling nightly firmware build for the ARK32 configurator and production line.

--- a/.github/workflows/SITL-calibration.yml
+++ b/.github/workflows/SITL-calibration.yml
@@ -4,7 +4,8 @@ name: SITL Calibration Tests
 # steady sweep, square amplitude sweep and 120s chirp per calibrated
 # model, checked against Mcu/SITL/data/*/expected.json. Heavier than
 # the functional SITL tests (~25 min), so it runs only when the
-# physics, models or measurement tools change, plus nightly.
+# physics, models or measurement tools change, plus the nightly release
+# validation call from CICD_build.yml.
 #
 # All measurements are paced against SITL simulation time, so a slow
 # runner simply takes longer in wall time and measures the same
@@ -32,8 +33,6 @@ on:
       - "Src/motor_runtime.c"
       - "Src/runtime_loop.c"
       - "Src/settings.c"
-  schedule:
-    - cron: "17 2 * * *"
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/SITL-calibration.yml
+++ b/.github/workflows/SITL-calibration.yml
@@ -34,6 +34,7 @@ on:
       - "Src/settings.c"
   schedule:
     - cron: "17 2 * * *"
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main", "ark-release"]
   pull_request:
     branches: ["main", "ark-release"]
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, ark-release]
   pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/factory/README.md
+++ b/factory/README.md
@@ -86,3 +86,17 @@ make factory-image-check   # build + scripts/check-factory-image-ark.sh
 ```
 
 The job fails if the 32 KiB layout is wrong or the EEPROM page drifts from `ARK_4IN1_F051_eeprom_defaults.json`. Artifacts (`*.factory.bin` / `.hex` / `.eeprom.bin`) are uploaded as `ark-4in1-factory-image`.
+
+## Release validation and provenance
+
+Tag and nightly publishing waits for static analysis (including size, codegen,
+and factory layout checks), SITL, and calibration on the same workflow commit.
+The publishing job verifies the downloaded build artifact with SHA256SUMS.
+Only that job receives contents-write permission.
+
+Every release includes application HEX/BIN, factory HEX/BIN, the EEPROM page,
+release-manifest.json, and SHA256SUMS. The manifest records the source commit,
+compiler version, bootloader hash, defaults hash, EEPROM layout, addresses,
+and each binary hash. The packager rejects missing, empty, or stale binaries.
+It currently supports the shipped ARK_4IN1_F051 product; adding a product must
+extend the manifest and its checks alongside the factory-image build.

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Package the supported ARK 4IN1 release with source/toolchain provenance."""
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def package(root, compiler, obj):
+    defines = dict(re.findall(r'^\s*#\s*define\s+(VERSION_MAJOR|VERSION_MINOR|VERSION_PATCH|EEPROM_VERSION)\s+(\d+)',
+                              (root / 'Inc/version.h').read_text(), re.MULTILINE))
+    version = '.'.join(defines[k] for k in ('VERSION_MAJOR', 'VERSION_MINOR', 'VERSION_PATCH') if k in defines)
+    tag = re.search(r'^\s*#\s*define\s+VERSION_TAG\s+"([^"\n]+)"',
+                    (root / 'Inc/version.h').read_text(), re.MULTILINE)
+    if tag:
+        version += '-' + tag.group(1)
+    target = 'ARK_4IN1_F051'
+    prefix = 'ARK32_' + target + '_' + version
+    assets = [obj / (prefix + suffix) for suffix in
+              ('.hex', '.bin', '.factory.hex', '.factory.bin', '.eeprom.bin')]
+    for asset in assets:
+        if not asset.is_file() or asset.stat().st_size == 0:
+            raise ValueError('missing or empty release asset: ' + str(asset))
+    if (obj / (prefix + '.factory.bin')).stat().st_size != 32768:
+        raise ValueError('factory image must cover exactly 32 KiB')
+    if (obj / (prefix + '.eeprom.bin')).stat().st_size != 1024:
+        raise ValueError('EEPROM image must cover exactly 1 KiB')
+    # Reject stale binaries instead of silently publishing an unrecorded file.
+    actual = set(obj.glob('*.hex')) | set(obj.glob('*.bin'))
+    if actual != set(assets):
+        raise ValueError('unexpected binary assets: ' + ', '.join(sorted(str(p) for p in actual - set(assets))))
+    commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=root, text=True).strip()
+    compiler_version = subprocess.check_output([str(compiler), '--version'], text=True).splitlines()[0]
+    bootloader = root / 'Bootloaders/AM32_F051_BOOTLOADER_ARK4IN1_V18.bin'
+    manifest = {
+        'manifest_version': 1, 'commit': commit, 'target': target, 'firmware_version': version,
+        'compiler': compiler_version, 'eeprom_layout': int(defines['EEPROM_VERSION']),
+        'bootloader': {'path': str(bootloader.relative_to(root)), 'sha256': sha256(bootloader)},
+        'factory_defaults_sha256': sha256(root / 'factory/ARK_4IN1_F051_eeprom_defaults.json'),
+        'flash_addresses': {'factory': '0x08000000', 'application': '0x08001000', 'eeprom': '0x08007C00'},
+        'assets': [{'name': p.name, 'size': p.stat().st_size, 'sha256': sha256(p)} for p in assets],
+    }
+    manifest_path = obj / 'release-manifest.json'
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + '\n')
+    checksummed = sorted(assets + [manifest_path])
+    (obj / 'SHA256SUMS').write_text(''.join(sha256(p) + '  ' + p.name + '\n' for p in checksummed))
+    return manifest
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--compiler', required=True)
+    parser.add_argument('--obj', default='obj')
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    package(root, Path(args.compiler).resolve(), (root / args.obj).resolve())
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_release_manifest.py
+++ b/scripts/tests/test_release_manifest.py
@@ -1,0 +1,59 @@
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location('release_manifest', Path(__file__).resolve().parents[1] / 'release_manifest.py')
+release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release)
+
+
+class ReleaseManifestTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        for name in ('Inc', 'Bootloaders', 'factory', 'obj'):
+            (self.root / name).mkdir()
+        (self.root / 'Inc/version.h').write_text('#define VERSION_MAJOR 3\n#define VERSION_MINOR 0\n#define VERSION_PATCH 3\n#define EEPROM_VERSION 3\n')
+        (self.root / 'Bootloaders/AM32_F051_BOOTLOADER_ARK4IN1_V18.bin').write_bytes(b'bootloader')
+        (self.root / 'factory/ARK_4IN1_F051_eeprom_defaults.json').write_text('{}')
+        self.obj = self.root / 'obj'
+        self.prefix = 'ARK32_ARK_4IN1_F051_3.0.3'
+        for suffix, size in (('.hex', 10), ('.bin', 20), ('.factory.hex', 30), ('.factory.bin', 32768), ('.eeprom.bin', 1024)):
+            (self.obj / (self.prefix + suffix)).write_bytes(bytes(size))
+
+    def package(self):
+        with patch.object(release.subprocess, 'check_output', side_effect=['a' * 40 + '\n', 'arm gcc 15.2.1\n']):
+            return release.package(self.root, Path('/compiler'), self.obj)
+
+    def test_complete_release_hashes_and_provenance(self):
+        manifest = self.package()
+        self.assertEqual(manifest['commit'], 'a' * 40)
+        self.assertEqual(manifest['eeprom_layout'], 3)
+        self.assertEqual(len(manifest['assets']), 5)
+        for line in (self.obj / 'SHA256SUMS').read_text().splitlines():
+            digest, name = line.split('  ')
+            self.assertEqual(digest, release.sha256(self.obj / name))
+        self.assertEqual(json.loads((self.obj / 'release-manifest.json').read_text()), manifest)
+
+    def test_missing_factory_image_rejected(self):
+        (self.obj / (self.prefix + '.factory.bin')).unlink()
+        with self.assertRaisesRegex(ValueError, 'missing or empty'):
+            self.package()
+
+    def test_truncated_factory_image_rejected(self):
+        (self.obj / (self.prefix + '.factory.bin')).write_bytes(b'bad')
+        with self.assertRaisesRegex(ValueError, '32 KiB'):
+            self.package()
+
+    def test_stale_asset_rejected(self):
+        (self.obj / 'ARK32_ARK_4IN1_F051_2.0.hex').write_bytes(b'old')
+        with self.assertRaisesRegex(ValueError, 'unexpected binary'):
+            self.package()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Release publication previously ran after a firmware build without depending on SITL, calibration or static-analysis results, and automated uploads omitted factory/EEPROM binaries.

Use reusable workflows to validate the same commit before tag/nightly publication. Build and verify the factory image, package all five application/factory/EEPROM assets with SHA256SUMS and release-manifest.json, and verify the downloaded artifact before publishing. Only the separate publishing job has contents-write permission. Serialize publishing for each ref.

The manifest records source commit, compiler version, bootloader/defaults hashes, EEPROM layout and flash addresses. Packaging rejects missing, empty, incorrectly sized or stale binary assets. It explicitly supports the currently shipped ARK_4IN1_F051 target; #79 must extend packaging when adding G431 production artifacts.

Validation: four packaging unit tests; all workflow YAML parses and reusable dependency graph checks pass; make factory-image-check; real release packaging and sha256sum verification of all five binaries plus the manifest. No tag was pushed and no release was published during validation.

Land alongside #111 so the reused SITL job also enforces CAN availability.